### PR TITLE
feat: add --remote flag for public relay connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@anthropic/vibe-mcp",
+  "name": "@vibebrowser/mcp",
   "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@anthropic/vibe-mcp",
+      "name": "@vibebrowser/mcp",
       "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,10 @@
  * Vibe MCP Server - CLI Entry Point
  * 
  * Command-line interface for starting the MCP server.
+ * 
+ * Modes:
+ *   Local (default): connects to local relay daemon on localhost
+ *   Remote (--remote <uuid>): connects to public relay at relay.api.vibebrowser.app
  */
 
 import { program } from 'commander';
@@ -13,8 +17,10 @@ program
   .name('vibe-mcp')
   .description('MCP server for Vibe AI Browser - allows AI agents to control your browser')
   .version('0.1.0')
-  .option('-p, --port <number>', 'WebSocket port for extension connection', String(DEFAULT_WS_PORT))
+  .option('-p, --port <number>', 'WebSocket port for local extension connection', String(DEFAULT_WS_PORT))
   .option('-d, --debug', 'Enable debug logging', false)
+  .option('-r, --remote <uuid>', 'Connect to a remote extension via public relay (provide the extension UUID)')
+  .option('--relay-url <url>', 'Custom relay server URL (default: wss://relay.api.vibebrowser.app)')
   .action(async (options) => {
     const port = parseInt(options.port, 10);
     
@@ -27,6 +33,8 @@ program
       await createServer({
         port,
         debug: options.debug,
+        remoteUuid: options.remote,
+        remoteRelayUrl: options.relayUrl,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2,7 +2,9 @@
  * Vibe MCP Server - Relay Connection
  * 
  * Connects to the relay server as a WebSocket client.
- * The relay handles the actual extension connection.
+ * Supports two modes:
+ *   - Local: connects to local relay daemon at ws://127.0.0.1:19888
+ *   - Remote: connects to public relay at wss://relay.api.vibebrowser.app/<uuid>
  */
 
 import WebSocket from 'ws';
@@ -24,8 +26,24 @@ const NO_CONNECTION_MESSAGE = `No connection to Vibe extension. Please:
 2. Click the Vibe extension icon in Chrome
 3. Enable "MCP External Control" in Settings`;
 
+const NO_CONNECTION_REMOTE_MESSAGE = `No connection to Vibe extension via remote relay. Please:
+1. Install the Vibe AI Browser extension from https://vibebrowser.app
+2. Open extension Settings > MCP External
+3. Select "Remote" mode and note your Extension UUID
+4. Make sure the extension is connected to the relay`;
+
 const RELAY_CONNECT_TIMEOUT = 10000;
 const RELAY_RECONNECT_DELAY = 2000;
+
+const DEFAULT_RELAY_URL = 'wss://relay.api.vibebrowser.app';
+
+/**
+ * Remote relay configuration
+ */
+export interface RemoteConfig {
+  uuid: string;
+  relayUrl?: string; // defaults to DEFAULT_RELAY_URL
+}
 
 /**
  * Pending request waiting for response
@@ -39,7 +57,7 @@ interface PendingRequest {
 /**
  * Relay connection manager
  * 
- * Connects to the relay server instead of directly to the extension.
+ * Connects to a relay server (local or remote) to reach the extension.
  */
 export class ExtensionConnection extends EventEmitter {
   private ws: WebSocket | null = null;
@@ -51,19 +69,28 @@ export class ExtensionConnection extends EventEmitter {
   private tools: ToolDefinition[] = [];
   private reconnectTimer: NodeJS.Timeout | null = null;
   private extensionConnected: boolean = false;
+  private remoteConfig: RemoteConfig | null = null;
 
-  constructor(port: number = AGENT_PORT, debug: boolean = false) {
+  constructor(port: number = AGENT_PORT, debug: boolean = false, remote?: RemoteConfig) {
     super();
     this.port = port;
     this.debug = debug;
+    this.remoteConfig = remote || null;
   }
 
   /**
-   * Start connection to relay server
-   * Spawns relay daemon if not already running
+   * Start connection to relay server.
+   * In local mode: spawns relay daemon if needed, then connects.
+   * In remote mode: connects directly to public relay.
    */
   async start(): Promise<void> {
-    // Check if relay is already running
+    if (this.remoteConfig) {
+      this.log(`Remote mode: connecting to relay for UUID ${this.remoteConfig.uuid}`);
+      await this.connectToRelay();
+      return;
+    }
+
+    // Local mode: check if relay is already running
     if (!isRelayRunning()) {
       this.log('Starting relay daemon...');
       await this.spawnRelay();
@@ -76,7 +103,7 @@ export class ExtensionConnection extends EventEmitter {
   }
 
   /**
-   * Spawn relay daemon as detached process
+   * Spawn relay daemon as detached process (local mode only)
    */
   private async spawnRelay(): Promise<void> {
     // Use __dirname equivalent for ESM
@@ -92,7 +119,7 @@ export class ExtensionConnection extends EventEmitter {
   }
 
   /**
-   * Wait for relay to become available
+   * Wait for local relay to become available
    */
   private async waitForRelay(): Promise<void> {
     const startTime = Date.now();
@@ -131,11 +158,24 @@ export class ExtensionConnection extends EventEmitter {
   }
 
   /**
-   * Connect to the relay server
+   * Get the WebSocket URL for connection.
+   * Local mode: ws://127.0.0.1:<port>
+   * Remote mode: wss://relay.api.vibebrowser.app/<uuid>
+   */
+  private getRelayUrl(): string {
+    if (this.remoteConfig) {
+      const base = this.remoteConfig.relayUrl || DEFAULT_RELAY_URL;
+      return `${base}/${this.remoteConfig.uuid}`;
+    }
+    return `ws://127.0.0.1:${this.port}`;
+  }
+
+  /**
+   * Connect to the relay server (local or remote)
    */
   private async connectToRelay(): Promise<void> {
     return new Promise((resolve, reject) => {
-      const url = `ws://127.0.0.1:${AGENT_PORT}`;
+      const url = this.getRelayUrl();
       this.log(`Connecting to relay at ${url}...`);
 
       try {
@@ -288,7 +328,7 @@ export class ExtensionConnection extends EventEmitter {
     }
 
     if (!this.extensionConnected) {
-      throw new Error(NO_CONNECTION_MESSAGE);
+      throw new Error(this.remoteConfig ? NO_CONNECTION_REMOTE_MESSAGE : NO_CONNECTION_MESSAGE);
     }
 
     const requestId = `req_${++this.requestIdCounter}`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import {
   ListToolsRequestSchema,
   ToolSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { ExtensionConnection } from './connection.js';
+import { ExtensionConnection, RemoteConfig } from './connection.js';
 import { MCP_PROTOCOL_VERSION, ServerConfig, ToolDefinition } from './types.js';
 
 const SERVER_NAME = 'vibe-mcp';
@@ -32,9 +32,15 @@ export class VibeMcpServer {
       port: config.port ?? 19989,
       host: config.host ?? '127.0.0.1',
       debug: config.debug ?? false,
+      remoteUuid: config.remoteUuid,
+      remoteRelayUrl: config.remoteRelayUrl,
     };
 
-    this.connection = new ExtensionConnection(this.config.port, this.config.debug);
+    const remoteConfig: RemoteConfig | undefined = this.config.remoteUuid
+      ? { uuid: this.config.remoteUuid, relayUrl: this.config.remoteRelayUrl }
+      : undefined;
+
+    this.connection = new ExtensionConnection(this.config.port, this.config.debug, remoteConfig);
 
     this.server = new Server(
       {
@@ -111,9 +117,13 @@ export class VibeMcpServer {
    * Start the MCP server
    */
   async start(): Promise<void> {
-    // Start WebSocket server for extension connection
+    // Start connection to extension (local relay or remote)
     await this.connection.start();
-    this.log(`Waiting for Vibe extension connection on port ${this.config.port}...`);
+    if (this.config.remoteUuid) {
+      this.log(`Connected to remote relay for UUID ${this.config.remoteUuid}`);
+    } else {
+      this.log(`Waiting for Vibe extension connection on port ${this.config.port}...`);
+    }
 
     // Connect MCP server to stdio transport
     const transport = new StdioServerTransport();

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,4 +100,8 @@ export interface ServerConfig {
   port: number;
   host: string;
   debug: boolean;
+  /** Remote relay UUID — when set, connects to public relay instead of local */
+  remoteUuid?: string;
+  /** Remote relay URL — defaults to wss://relay.api.vibebrowser.app */
+  remoteRelayUrl?: string;
 }


### PR DESCRIPTION
## Summary

Adds support for connecting `vibe-mcp` to a remote Vibe extension via the public relay server, enabling AI agents (Claude, Cursor, OpenCode) to control a browser over the internet.

## Changes

- **`src/cli.ts`** — Added `-r, --remote <uuid>` and `--relay-url <url>` CLI flags
- **`src/connection.ts`** — Added `RemoteConfig` interface, `getRelayUrl()` method, remote mode skips local relay daemon and connects directly to `wss://relay.api.vibebrowser.app/<uuid>`
- **`src/server.ts`** — Passes remote config to `ExtensionConnection`, mode-aware log messages
- **`src/types.ts`** — Added `remoteUuid` and `remoteRelayUrl` to `ServerConfig`

## Usage

```bash
# Local mode (unchanged)
vibe-mcp

# Remote mode — connect to extension by UUID
vibe-mcp --remote <extension-uuid>

# Remote mode with custom relay
vibe-mcp --remote <extension-uuid> --relay-url wss://relay.api-dev.vibebrowser.app
```

## Testing

E2E tested with real extension connected to dev relay. Test spawns `vibe-mcp --remote <uuid>`, uses `@modelcontextprotocol/sdk` Client over stdio, successfully calls `listTools()` (24 tools) and `callTool(create_new_tab)`.