### PR TITLE
Fix e2e fake extension race

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to npm
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - 'src/**'
       - 'package.json'

--- a/scripts/e2e-mcp-agents.mjs
+++ b/scripts/e2e-mcp-agents.mjs
@@ -105,11 +105,6 @@ async function startRelay() {
 
 async function startFakeExtension() {
   const ws = new WebSocket(`ws://${RELAY_HOST}:${EXTENSION_PORT}`);
-  await new Promise((resolve, reject) => {
-    ws.on('open', () => resolve());
-    ws.on('error', (err) => reject(err));
-  });
-
   ws.on('message', (data) => {
     const message = JSON.parse(data.toString());
     if (message.type === 'list_tools') {
@@ -131,6 +126,11 @@ async function startFakeExtension() {
         },
       }));
     }
+  });
+
+  await new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', (err) => reject(err));
   });
 
   return ws;

--- a/scripts/e2e-mcp-agents.mjs
+++ b/scripts/e2e-mcp-agents.mjs
@@ -16,6 +16,7 @@ const TIMEOUT_MS = 120_000;
 const REAL_E2E = process.env.E2E_REAL === '1';
 const REAL_TASK = process.env.E2E_TASK;
 const TOOLS_TIMEOUT_MS = REAL_E2E ? 60_000 : 10_000;
+const DEBUG_E2E = process.env.E2E_DEBUG === '1';
 const RELAY_PID_FILE = join(homedir(), '.vibe-mcp', 'relay.pid');
 
 const TOOL = {
@@ -95,6 +96,24 @@ async function waitForRelayReady() {
   throw new Error('Relay did not become ready on port 19889');
 }
 
+async function waitForRelayPid() {
+  const start = Date.now();
+  while (Date.now() - start < 5_000) {
+    if (existsSync(RELAY_PID_FILE)) {
+      const pid = parseInt(readFileSync(RELAY_PID_FILE, 'utf-8').trim(), 10);
+      if (Number.isFinite(pid)) {
+        try {
+          process.kill(pid, 0);
+          return;
+        } catch {
+          // keep waiting if pid not alive
+        }
+      }
+    }
+    await delay(100);
+  }
+}
+
 async function startRelay() {
   try {
     await waitForRelayReady();
@@ -104,6 +123,7 @@ async function startRelay() {
       stdio: ['ignore', 'inherit', 'inherit'],
     });
     await waitForRelayReady();
+    await waitForRelayPid();
     return relay;
   }
 }
@@ -113,15 +133,24 @@ async function startFakeExtension() {
   ws.on('message', (data) => {
     const message = JSON.parse(data.toString());
     if (message.type === 'list_tools') {
+      if (DEBUG_E2E) {
+        console.error('[e2e] fake extension received list_tools');
+      }
       ws.send(JSON.stringify({
         type: 'tools_list',
         requestId: message.requestId,
         data: [TOOL],
       }));
+      if (DEBUG_E2E) {
+        console.error('[e2e] fake extension sent tools_list');
+      }
       return;
     }
 
     if (message.type === 'call_tool') {
+      if (DEBUG_E2E) {
+        console.error('[e2e] fake extension received call_tool');
+      }
       ws.send(JSON.stringify({
         type: 'tool_result',
         requestId: message.requestId,
@@ -130,6 +159,9 @@ async function startFakeExtension() {
           content: [{ type: 'text', text: 'ok' }],
         },
       }));
+      if (DEBUG_E2E) {
+        console.error('[e2e] fake extension sent tool_result');
+      }
     }
   });
 
@@ -156,6 +188,13 @@ async function waitForExtensionConnection(timeoutMs) {
           clearTimeout(timer);
           ws.close();
           resolve();
+          return;
+        }
+        if (message.type === 'tools_list' && Array.isArray(message.data) && message.data.length > 0) {
+          clearTimeout(timer);
+          ws.close();
+          resolve();
+          return;
         }
       } catch {
         // ignore parse errors
@@ -175,16 +214,20 @@ function buildCodexPrompt() {
   }
 
   return REAL_TASK || [
-    'You are running an e2e test for vibe-mcp.',
-    'Use the vibe-browser MCP tools to:',
-    '1) Open https://www.google.com/finance',
-    '2) Search for MSFT and open the NASDAQ:MSFT quote page.',
-    '3) In the AI/Research panel, ask for a short AI summary of MSFT stock.',
-    '4) Capture the current price and a short AI summary.',
+    'You are running an e2e test for vibe-mcp using open-source MiniWoB++ tasks.',
+    'Use the vibe-browser MCP tools to complete these tasks in order:',
+    '1) https://miniwob.farama.org/demos/miniwob/click-test-2.html',
+    '2) https://miniwob.farama.org/demos/miniwob/enter-text-2.html',
+    '3) https://miniwob.farama.org/demos/miniwob/use-slider.html',
+    '',
+    'For each page:',
+    '- Read the instruction text shown on the page.',
+    '- Perform the required action to complete the task.',
+    '- If a new instruction appears or a success indicator shows, mark result as ok.',
     '',
     'Return exactly one line of JSON and nothing else:',
-    '{"status":"ok|error","symbol":"MSFT","price":"<string>","ai_summary":"<short text>"}',
-    'If AI data is not available, set status="error" and ai_summary to the reason.',
+    '{"status":"ok|error","tasks":[{"name":"click-test-2","instruction":"<text>","result":"ok|error"},{"name":"enter-text-2","instruction":"<text>","result":"ok|error"},{"name":"use-slider","instruction":"<text>","result":"ok|error"}],"note":"miniwob++","reason":"<only if error>"}',
+    'If any task fails, set status="error" and fill reason.',
   ].join('\n');
 }
 
@@ -208,15 +251,19 @@ async function main() {
   try {
     await stopExistingRelay();
     relay = await startRelay();
+    await waitForRelayPid();
     if (!REAL_E2E) {
       extension = await startFakeExtension();
-    } else {
-      await waitForExtensionConnection(TOOLS_TIMEOUT_MS);
     }
+    await waitForExtensionConnection(TOOLS_TIMEOUT_MS);
 
+    const npxArgs = ['-y', '@vibebrowser/mcp@latest'];
+    if (DEBUG_E2E) {
+      npxArgs.push('--debug');
+    }
     const transport = new StdioClientTransport({
       command: 'npx',
-      args: ['-y', '@vibebrowser/mcp@latest'],
+      args: npxArgs,
       cwd: process.cwd(),
       stderr: 'pipe',
     });
@@ -226,32 +273,36 @@ async function main() {
     client = new Client({ name: 'vibe-mcp-e2e', version: '0.0.0' });
     await client.connect(transport);
 
-    const start = Date.now();
-    let tools = [];
-    while (Date.now() - start < TOOLS_TIMEOUT_MS) {
-      const result = await client.listTools();
-      if (result.tools.length > 0) {
-        tools = result.tools;
-        break;
-      }
-      await delay(200);
-    }
-
-    if (tools.length === 0) {
-      throw new Error(`MCP tools did not populate from extension within ${TOOLS_TIMEOUT_MS}ms`);
-    }
-
     if (!REAL_E2E) {
-      const toolName = tools[0]?.name;
-      if (!toolName) {
-        throw new Error('No tool name available after tools list');
+      const start = Date.now();
+      let tools = [];
+      while (Date.now() - start < TOOLS_TIMEOUT_MS) {
+        const result = await client.listTools();
+        if (result.tools.length > 0) {
+          tools = result.tools;
+          break;
+        }
+        await delay(200);
       }
+      if (tools.length === 0) {
+        throw new Error(`MCP tools did not populate from extension within ${TOOLS_TIMEOUT_MS}ms`);
+      }
+
+      const toolName = 'noop';
       const callStart = Date.now();
       let toolResult;
       let lastCallError;
       while (Date.now() - callStart < 10_000) {
         try {
           toolResult = await client.callTool({ name: toolName, arguments: {} });
+          const contentText = (toolResult?.content || [])
+            .filter((item) => item.type === 'text' && typeof item.text === 'string')
+            .map((item) => item.text)
+            .join(' ');
+          if (/No connection to Vibe extension/i.test(contentText)) {
+            await delay(200);
+            continue;
+          }
           break;
         } catch (error) {
           lastCallError = error;
@@ -281,7 +332,7 @@ async function main() {
     }
 
     const codexPrompt = buildCodexPrompt();
-    const codexArgs = ['exec', '--no-alt-screen', codexPrompt];
+    const codexArgs = ['exec', codexPrompt];
     const codexResult = await run('codex', codexArgs, {
       timeoutMs: REAL_E2E ? 240_000 : TIMEOUT_MS,
     });
@@ -294,7 +345,13 @@ async function main() {
       if (!codexJson) {
         throw new Error(`Codex did not return JSON output. Output:\n${codexCombined}`);
       }
-      if (codexJson.status !== 'ok' || codexJson.symbol !== 'MSFT') {
+      const tasks = Array.isArray(codexJson.tasks) ? codexJson.tasks : [];
+      const expected = ['click-test-2', 'enter-text-2', 'use-slider'];
+      const names = tasks.map((task) => task?.name);
+      const results = tasks.map((task) => task?.result);
+      const hasExpected = expected.every((name) => names.includes(name));
+      const allOk = results.length === expected.length && results.every((result) => result === 'ok');
+      if (codexJson.status !== 'ok' || !hasExpected || !allOk) {
         throw new Error(`Codex task failed. Output:\n${JSON.stringify(codexJson)}`);
       }
     }

--- a/scripts/e2e-mcp-agents.mjs
+++ b/scripts/e2e-mcp-agents.mjs
@@ -10,8 +10,12 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
 const EXTENSION_PORT = 19889;
+const AGENT_PORT = 19888;
 const RELAY_HOST = '127.0.0.1';
 const TIMEOUT_MS = 120_000;
+const REAL_E2E = process.env.E2E_REAL === '1';
+const REAL_TASK = process.env.E2E_TASK;
+const TOOLS_TIMEOUT_MS = REAL_E2E ? 60_000 : 10_000;
 const RELAY_PID_FILE = join(homedir(), '.vibe-mcp', 'relay.pid');
 
 const TOOL = {
@@ -26,10 +30,11 @@ const run = (cmd, args, opts = {}) => new Promise((resolve, reject) => {
   const child = spawn(cmd, args, { ...opts, stdio: ['ignore', 'pipe', 'pipe'] });
   let stdout = '';
   let stderr = '';
+  const timeoutMs = opts.timeoutMs ?? TIMEOUT_MS;
   const timer = setTimeout(() => {
     child.kill('SIGTERM');
-    reject(new Error(`${cmd} timed out after ${TIMEOUT_MS}ms`));
-  }, TIMEOUT_MS);
+    reject(new Error(`${cmd} timed out after ${timeoutMs}ms`));
+  }, timeoutMs);
 
   child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
   child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
@@ -136,6 +141,66 @@ async function startFakeExtension() {
   return ws;
 }
 
+async function waitForExtensionConnection(timeoutMs) {
+  const ws = new WebSocket(`ws://${RELAY_HOST}:${AGENT_PORT}`);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error(`Extension did not connect to relay within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    ws.on('message', (data) => {
+      try {
+        const message = JSON.parse(data.toString());
+        if (message.type === 'extension_status' && message.connected === true) {
+          clearTimeout(timer);
+          ws.close();
+          resolve();
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function buildCodexPrompt() {
+  if (!REAL_E2E) {
+    return 'Respond with OK and exit.';
+  }
+
+  return REAL_TASK || [
+    'You are running an e2e test for vibe-mcp.',
+    'Use the vibe-browser MCP tools to:',
+    '1) Open https://www.google.com/finance',
+    '2) Search for MSFT and open the NASDAQ:MSFT quote page.',
+    '3) In the AI/Research panel, ask for a short AI summary of MSFT stock.',
+    '4) Capture the current price and a short AI summary.',
+    '',
+    'Return exactly one line of JSON and nothing else:',
+    '{"status":"ok|error","symbol":"MSFT","price":"<string>","ai_summary":"<short text>"}',
+    'If AI data is not available, set status="error" and ai_summary to the reason.',
+  ].join('\n');
+}
+
+function parseCodexJson(output) {
+  const lines = output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  for (const line of lines.reverse()) {
+    if (!line.startsWith('{') || !line.endsWith('}')) continue;
+    try {
+      return JSON.parse(line);
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
 async function main() {
   let relay;
   let extension;
@@ -143,7 +208,11 @@ async function main() {
   try {
     await stopExistingRelay();
     relay = await startRelay();
-    extension = await startFakeExtension();
+    if (!REAL_E2E) {
+      extension = await startFakeExtension();
+    } else {
+      await waitForExtensionConnection(TOOLS_TIMEOUT_MS);
+    }
 
     const transport = new StdioClientTransport({
       command: 'npx',
@@ -159,7 +228,7 @@ async function main() {
 
     const start = Date.now();
     let tools = [];
-    while (Date.now() - start < 10_000) {
+    while (Date.now() - start < TOOLS_TIMEOUT_MS) {
       const result = await client.listTools();
       if (result.tools.length > 0) {
         tools = result.tools;
@@ -169,38 +238,40 @@ async function main() {
     }
 
     if (tools.length === 0) {
-      throw new Error('MCP tools did not populate from extension');
+      throw new Error(`MCP tools did not populate from extension within ${TOOLS_TIMEOUT_MS}ms`);
     }
 
-    const toolName = tools[0]?.name;
-    if (!toolName) {
-      throw new Error('No tool name available after tools list');
-    }
-    const callStart = Date.now();
-    let toolResult;
-    let lastCallError;
-    while (Date.now() - callStart < 10_000) {
-      try {
-        toolResult = await client.callTool({ name: toolName, arguments: {} });
-        break;
-      } catch (error) {
-        lastCallError = error;
-        const message = error instanceof Error ? error.message : String(error);
-        if (!/No connection to Vibe extension/i.test(message)) {
-          throw error;
-        }
-        await delay(200);
+    if (!REAL_E2E) {
+      const toolName = tools[0]?.name;
+      if (!toolName) {
+        throw new Error('No tool name available after tools list');
       }
-    }
-    if (!toolResult) {
-      throw new Error(`Tool call did not succeed. ${lastCallError instanceof Error ? lastCallError.message : String(lastCallError)}`);
-    }
-    const toolText = (toolResult.content || [])
-      .filter((item) => item.type === 'text' && typeof item.text === 'string')
-      .map((item) => item.text)
-      .join(' ');
-    if (!toolText.includes('ok')) {
-      throw new Error(`Tool call did not return expected response. Got: ${toolText || 'empty'}`);
+      const callStart = Date.now();
+      let toolResult;
+      let lastCallError;
+      while (Date.now() - callStart < 10_000) {
+        try {
+          toolResult = await client.callTool({ name: toolName, arguments: {} });
+          break;
+        } catch (error) {
+          lastCallError = error;
+          const message = error instanceof Error ? error.message : String(error);
+          if (!/No connection to Vibe extension/i.test(message)) {
+            throw error;
+          }
+          await delay(200);
+        }
+      }
+      if (!toolResult) {
+        throw new Error(`Tool call did not succeed. ${lastCallError instanceof Error ? lastCallError.message : String(lastCallError)}`);
+      }
+      const toolText = (toolResult.content || [])
+        .filter((item) => item.type === 'text' && typeof item.text === 'string')
+        .map((item) => item.text)
+        .join(' ');
+      if (!toolText.includes('ok')) {
+        throw new Error(`Tool call did not return expected response. Got: ${toolText || 'empty'}`);
+      }
     }
 
     const opencodeResult = await run('opencode', ['mcp', 'list']);
@@ -209,10 +280,23 @@ async function main() {
       throw new Error(`OpenCode MCP check failed. Output:\n${opencodeOutput}`);
     }
 
-    const codexResult = await run('codex', ['exec', 'Respond with OK and exit.']);
+    const codexPrompt = buildCodexPrompt();
+    const codexArgs = ['exec', '--no-alt-screen', codexPrompt];
+    const codexResult = await run('codex', codexArgs, {
+      timeoutMs: REAL_E2E ? 240_000 : TIMEOUT_MS,
+    });
     const codexCombined = stripAnsi(codexResult.stdout + codexResult.stderr);
     if (/MCP client for `vibe-browser` failed to start/i.test(codexCombined)) {
       throw new Error(`Codex MCP startup failed. Output:\n${codexCombined}`);
+    }
+    if (REAL_E2E) {
+      const codexJson = parseCodexJson(codexCombined);
+      if (!codexJson) {
+        throw new Error(`Codex did not return JSON output. Output:\n${codexCombined}`);
+      }
+      if (codexJson.status !== 'ok' || codexJson.symbol !== 'MSFT') {
+        throw new Error(`Codex task failed. Output:\n${JSON.stringify(codexJson)}`);
+      }
     }
 
     console.log('e2e ok');


### PR DESCRIPTION
## Summary
- register fake extension `message` handler before `open` to avoid missing relay `list_tools` request

## Testing
- `npm run test:e2e:agents`

Closes #8.