### PR TITLE
Add shared chrome-devtools fallback in relay and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Claude Desktop       Cursor          VS Code         OpenCode
 - **Fast & Local** - Automation happens on your machine, no cloud latency
 - **Private** - Your browsing data never leaves your device
 - **Stable** - Content script based, no flaky CDP connections
+- **Chrome DevTools Fallback** - Automatically adds `chrome-devtools-mcp` tools when installed; extension tools stay primary
 
 ## Quick Start
 
@@ -210,6 +211,12 @@ Add to your Codex configuration:
 3. Go to Settings and enable "MCP External Control"
 4. The status should show "Connected"
 
+If the extension is not connected, `vibebrowser-mcp` can optionally fall back to
+`chrome-devtools-mcp` (started in `--autoConnect` mode) when that package is installed.
+This fallback runs once in the shared local relay daemon (multi-agent safe), so
+both `vibebrowser-mcp` and `vibebrowser-cli` use the same backend instance.
+When both are available, tool listing is a union and calls prefer the extension implementation.
+
 ## Available Tools
 
 | Tool | Description |
@@ -336,6 +343,7 @@ For OpenClaw agents that need your real browser context (logged-in sessions, exi
 
 The skill is located at [`openclaw/vibebrowser/SKILL.md`](openclaw/vibebrowser/SKILL.md) and provides:
 - Full OpenClaw-compatible CLI commands (`status`, `tabs`, `snapshot`, `click`, `type`, etc.)
+- Fallback-safe commands for DevTools-backed flows (`resize`, `upload`, `dialog`)
 - `--json` output for machine parsing
 - Environment-based configuration
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ If the extension is not connected, `vibebrowser-mcp` can optionally fall back to
 `chrome-devtools-mcp` (started in `--autoConnect` mode) when that package is installed.
 This fallback runs once in the shared local relay daemon (multi-agent safe), so
 both `vibebrowser-mcp` and `vibebrowser-cli` use the same backend instance.
-When both are available, tool listing is a union and calls prefer the extension implementation.
+When extension is connected, extension tools are authoritative. Chrome DevTools
+fallback tools are exposed only when extension is unavailable/disconnected.
 
 ## Available Tools
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Claude Desktop       Cursor          VS Code         OpenCode
 - **Fast & Local** - Automation happens on your machine, no cloud latency
 - **Private** - Your browsing data never leaves your device
 - **Stable** - Content script based, no flaky CDP connections
-- **Chrome DevTools Fallback** - Automatically adds `chrome-devtools-mcp` tools when installed; extension tools stay primary
+- **Chrome DevTools Fallback** - Extension tools stay primary by default; use `--devtools` to force chrome-devtools-only mode
 
 ## Quick Start
 
@@ -217,6 +217,8 @@ This fallback runs once in the shared local relay daemon (multi-agent safe), so
 both `vibebrowser-mcp` and `vibebrowser-cli` use the same backend instance.
 When extension is connected, extension tools are authoritative. Chrome DevTools
 fallback tools are exposed only when extension is unavailable/disconnected.
+Pass `--devtools` to either CLI to bypass relay/extension routing and use only
+the chrome-devtools backend.
 
 ## Available Tools
 
@@ -294,6 +296,7 @@ npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> open
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> snapshot
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> click 12
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> type 23 "hello" --submit
+npx -y --package @vibebrowser/mcp vibebrowser-cli --devtools status
 ```
 
 The package now exposes two executables:
@@ -411,6 +414,7 @@ npx -y --package @vibebrowser/mcp vibebrowser-mcp [start] [options]
   --http-path <path>   Path for streamable HTTP MCP transport (default: /mcp)
   --allow-host <host>  Allowed host header for HTTP transport (repeatable)
   -r, --remote <uuid>  Connect to a remote extension via public relay
+  --devtools           Use only chrome-devtools backend (bypasses extension relay)
   --relay-url <url>    Custom relay server URL
 
 # OpenClaw helper
@@ -422,6 +426,7 @@ npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> tabs
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> snapshot --json
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> click 12
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> type 23 "hello" --submit
+npx -y --package @vibebrowser/mcp vibebrowser-cli --devtools tabs
 
 # Local LLM server
 npx -y --package @vibebrowser/mcp vibebrowser-mcp serve <model> [options]

--- a/dist/server.js
+++ b/dist/server.js
@@ -163,7 +163,7 @@ export class VibeMcpServer {
             },
         });
         server.setRequestHandler(ListToolsRequestSchema, async () => {
-            if (this.connection.getTools().length === 0 && this.connection.isExtensionConnected()) {
+            if (this.connection.getTools().length === 0) {
                 try {
                     await this.connection.refreshTools(STARTUP_TOOLS_REFRESH_TIMEOUT_MS);
                 }
@@ -172,7 +172,7 @@ export class VibeMcpServer {
                     this.log(`tools/list refresh failed: ${message}`);
                 }
             }
-            if (this.connection.getTools().length === 0 && this.connection.isExtensionConnected()) {
+            if (this.connection.getTools().length === 0) {
                 await this.connection.waitForToolsUpdate(STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS);
             }
             return {
@@ -248,7 +248,7 @@ export class VibeMcpServer {
         };
     }
     async takeMarkdownSnapshot(pageId) {
-        if (this.connection.getTools().length === 0 && this.connection.isExtensionConnected()) {
+        if (this.connection.getTools().length === 0) {
             try {
                 await this.connection.refreshTools(STARTUP_TOOLS_REFRESH_TIMEOUT_MS);
             }

--- a/dist/server.js
+++ b/dist/server.js
@@ -10,6 +10,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { CallToolRequestSchema, isInitializeRequest, ListToolsRequestSchema, } from '@modelcontextprotocol/sdk/types.js';
 import { ExtensionConnection } from './connection.js';
+import { DevtoolsFallbackConnection } from './devtools-fallback.js';
 import { DEFAULT_HTTP_PATH, DEFAULT_HTTP_PORT, DEFAULT_WS_PORT, } from './types.js';
 import { getPackageVersion } from './version.js';
 const SERVER_NAME = 'vibebrowser-mcp';
@@ -34,6 +35,7 @@ export class VibeMcpServer {
             port: config.port ?? DEFAULT_WS_PORT,
             host: config.host ?? '127.0.0.1',
             debug: config.debug ?? false,
+            devtools: config.devtools ?? false,
             transport: config.transport ?? 'stdio',
             httpPort: config.httpPort ?? DEFAULT_HTTP_PORT,
             httpPath: normalizeHttpPath(config.httpPath ?? DEFAULT_HTTP_PATH),
@@ -42,10 +44,15 @@ export class VibeMcpServer {
             sessionId: config.sessionId,
             remoteRelayUrl: config.remoteRelayUrl,
         };
-        const remoteConfig = this.config.remoteUuid
-            ? { uuid: this.config.remoteUuid, relayUrl: this.config.remoteRelayUrl }
-            : undefined;
-        this.connection = new ExtensionConnection(this.config.port, this.config.debug, remoteConfig, this.config.remoteUuid ? undefined : { sessionId: this.config.sessionId });
+        if (this.config.devtools) {
+            this.connection = new DevtoolsFallbackConnection(this.config.debug);
+        }
+        else {
+            const remoteConfig = this.config.remoteUuid
+                ? { uuid: this.config.remoteUuid, relayUrl: this.config.remoteRelayUrl }
+                : undefined;
+            this.connection = new ExtensionConnection(this.config.port, this.config.debug, remoteConfig, this.config.remoteUuid ? undefined : { sessionId: this.config.sessionId });
+        }
         this.setupConnectionEvents();
     }
     /**
@@ -53,7 +60,15 @@ export class VibeMcpServer {
      */
     async start() {
         await this.connection.start();
-        if (this.config.remoteUuid) {
+        if (this.config.devtools) {
+            if (this.connection instanceof DevtoolsFallbackConnection && this.connection.isAvailable()) {
+                this.log('Connected to chrome-devtools backend');
+            }
+            else {
+                this.log('chrome-devtools backend unavailable; server started without tools');
+            }
+        }
+        else if (this.config.remoteUuid) {
             this.log(`Connected to remote relay for UUID ${this.config.remoteUuid}`);
         }
         else {
@@ -132,6 +147,20 @@ export class VibeMcpServer {
      * Set up extension connection events
      */
     setupConnectionEvents() {
+        if (this.connection instanceof DevtoolsFallbackConnection) {
+            this.connection.on('connected', () => {
+                this.log('chrome-devtools backend connected');
+            });
+            this.connection.on('unavailable', (reason) => {
+                this.log(reason);
+                this.notifyToolListChanged();
+            });
+            this.connection.on('tools_updated', (tools) => {
+                this.log(`Received ${tools.length} tools from chrome-devtools backend`);
+                this.notifyToolListChanged();
+            });
+            return;
+        }
         this.connection.on('connected', () => {
             this.log('Extension connected');
         });
@@ -173,7 +202,9 @@ export class VibeMcpServer {
                 }
             }
             if (this.connection.getTools().length === 0) {
-                await this.connection.waitForToolsUpdate(STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS);
+                if (this.connection instanceof ExtensionConnection) {
+                    await this.connection.waitForToolsUpdate(STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS);
+                }
             }
             return {
                 tools: this.connection.getTools().map((tool) => ({
@@ -315,7 +346,9 @@ export class VibeMcpServer {
                 version: SERVER_VERSION,
                 transport: 'http',
                 mcpPath: this.config.httpPath,
-                extensionConnected: this.connection.isExtensionConnected(),
+                extensionConnected: this.connection instanceof DevtoolsFallbackConnection
+                    ? this.connection.isAvailable()
+                    : this.connection.isExtensionConnected(),
                 cachedTools: this.connection.getTools().length,
             }));
         };

--- a/docs/chrome-devtools-relay.md
+++ b/docs/chrome-devtools-relay.md
@@ -14,6 +14,12 @@ in a cloud Kubernetes pod. There is no direct path.
 
 A **secure relay** that bridges the gap:
 
+> Current `vibebrowser-mcp` behavior: relay+extension remains the primary backend.
+> If `chrome-devtools-mcp` is available locally, the server also starts it in
+> `--autoConnect` mode as a fallback inside the shared relay daemon (single
+> instance for all local agents/CLIs), exposes a union of tools (without
+> duplicates), and routes calls deterministically (extension first, then fallback).
+
 ```
 ┌──────────────────────────────────────────────────────────────────┐
 │                         CLOUD                                    │

--- a/docs/chrome-devtools-relay.md
+++ b/docs/chrome-devtools-relay.md
@@ -17,8 +17,9 @@ A **secure relay** that bridges the gap:
 > Current `vibebrowser-mcp` behavior: relay+extension remains the primary backend.
 > If `chrome-devtools-mcp` is available locally, the server also starts it in
 > `--autoConnect` mode as a fallback inside the shared relay daemon (single
-> instance for all local agents/CLIs), exposes a union of tools (without
-> duplicates), and routes calls deterministically (extension first, then fallback).
+> instance for all local agents/CLIs). When extension is connected, extension
+> tools remain authoritative. Fallback tools are exposed and used only when the
+> extension is unavailable/disconnected.
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "chrome-devtools-mcp": "^0.21.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -204,6 +207,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chrome-devtools-mcp": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-0.21.0.tgz",
+      "integrity": "sha512-d+iqrRmcwpRFV3Q4DRCF2LCoq+WCRU3GhISKQ9v8g+1C2Uh8upj3urkjxNO4QIjhBMIYei/VQ1OQLFceby80Og==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "chrome-devtools": "build/src/bin/chrome-devtools.js",
+        "chrome-devtools-mcp": "build/src/bin/chrome-devtools-mcp.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:e2e:browser-cli": "node scripts/e2e-browser-cli.mjs",
     "test:e2e:cli-relay": "node scripts/e2e-cli-relay.mjs",
     "test:e2e:http": "node scripts/e2e-http-streamable.mjs",
+    "test:e2e:devtools-flag": "node scripts/e2e-devtools-flag.mjs",
     "test:e2e:browser-cli-live": "node scripts/e2e-browser-cli-live.mjs",
     "test:e2e:relay-race": "node scripts/e2e-relay-fake-extension-race.mjs",
     "test:e2e:relay-roundtrip": "node scripts/e2e-relay-roundtrip.mjs",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "commander": "^12.0.0",
     "ws": "^8.18.0"
   },
+  "optionalDependencies": {
+    "chrome-devtools-mcp": "^0.21.0"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/ws": "^8.5.0",

--- a/scripts/e2e-cli-relay.mjs
+++ b/scripts/e2e-cli-relay.mjs
@@ -19,7 +19,7 @@
  *   - tool list caching / refresh hangs that the fake-relay test masks
  */
 import { spawn } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import net from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
@@ -95,7 +95,10 @@ function assert(condition, message) {
 // Fake extension tool handler
 // ---------------------------------------------------------------------------
 
-const FAKE_TOOLS = [
+const SESSION_A = 'browser-alpha';
+const SESSION_B = 'browser-beta';
+
+const COMMON_TOOLS = [
   tool('list_pages', {}),
   tool('navigate_page', { pageId: { type: 'number' }, url: { type: 'string' }, type: { type: 'string' } }),
   tool('new_page', { url: { type: 'string' } }),
@@ -106,15 +109,31 @@ const FAKE_TOOLS = [
   tool('press_key', { keys: { type: 'string' } }),
   tool('evaluate_script', { function: { type: 'string' } }),
   tool('resize_page', { width: { type: 'number' }, height: { type: 'number' } }),
-  tool('upload_file', { uid: { type: 'string' }, filePath: { type: 'string' } }),
   tool('handle_dialog', { action: { type: 'string' }, promptText: { type: 'string' } }),
   tool('scroll_page', { direction: { type: 'string' }, numPages: { type: 'number' } }),
   tool('wait_for', { text: { type: 'array' }, timeout: { type: 'number' } }),
   tool('hover', { ref: { type: 'string' } }),
 ];
 
-const SESSION_A = 'browser-alpha';
-const SESSION_B = 'browser-beta';
+const SESSION_A_TOOLS = [
+  ...COMMON_TOOLS,
+  tool('file_upload', {
+    uid: { type: 'string' },
+    file: {
+      type: 'object',
+      properties: {
+        filename: { type: 'string' },
+        mimeType: { type: 'string' },
+        contentBase64: { type: 'string' },
+      },
+    },
+  }),
+];
+
+const SESSION_B_TOOLS = [
+  ...COMMON_TOOLS,
+  tool('upload_file', { uid: { type: 'string' }, filePath: { type: 'string' } }),
+];
 
 function tool(name, properties) {
   return { name, description: `Fake ${name}`, inputSchema: { type: 'object', properties } };
@@ -267,13 +286,14 @@ async function main() {
 
     // ------ Connect fake extensions (two local browser sessions) ------
     const attachFakeExtension = async (sessionId) => {
+      const sessionTools = sessionId === SESSION_B ? SESSION_B_TOOLS : SESSION_A_TOOLS;
       const extension = await connectWebSocket(`ws://${HOST}:${EXTENSION_PORT}`);
       extension.send(JSON.stringify({ type: 'connected', sessionId }));
       extension.send(JSON.stringify({
         type: 'sessions_list',
         connected: true,
         sessionId,
-        sessions: [{ sessionId, connected: true, connectedAt: Date.now(), toolCount: FAKE_TOOLS.length }],
+        sessions: [{ sessionId, connected: true, connectedAt: Date.now(), toolCount: sessionTools.length }],
       }));
 
       extension.on('message', (raw) => {
@@ -285,7 +305,7 @@ async function main() {
             type: 'tools_list',
             requestId: msg.requestId,
             sessionId,
-            data: FAKE_TOOLS,
+            data: sessionTools,
           }));
         }
 
@@ -327,7 +347,7 @@ async function main() {
       const { data, elapsed } = await runCli(['status']);
       assert(data.ok === true, `status not ok: ${JSON.stringify(data)}`);
       assert(data.extensionConnected === true, `extension not connected: ${JSON.stringify(data)}`);
-      assert(Number(data.toolCount) === FAKE_TOOLS.length, `toolCount mismatch (${data.toolCount} != ${FAKE_TOOLS.length}): ${JSON.stringify(data)}`);
+      assert(Number(data.toolCount) === SESSION_A_TOOLS.length, `toolCount mismatch (${data.toolCount} != ${SESSION_A_TOOLS.length}): ${JSON.stringify(data)}`);
       assert(data.sessionId === SESSION_A, `status should select ${SESSION_A} by default: ${JSON.stringify(data)}`);
       console.log(`  status:  ${elapsed}ms (budget: ${MAX_CLI_MS}ms) — ${data.toolCount} tools ✓`);
     }
@@ -409,17 +429,34 @@ async function main() {
     }
 
     // =================================================================
-    // TEST 9: `vibebrowser-cli upload <ref> <path>` calls upload_file
+    // TEST 9: `vibebrowser-cli upload <ref> <path>` maps extension payload schema
     // =================================================================
     {
       const { data, elapsed } = await runCli(['upload', 'A7', 'docs/chrome-devtools-relay.md']);
       assert(data.ok === true, `upload not ok: ${JSON.stringify(data)}`);
-      assert(data.tool === 'upload_file', `upload used wrong tool: ${JSON.stringify(data)}`);
-      console.log(`  upload:  ${elapsed}ms (budget: ${MAX_CLI_MS}ms) ✓`);
+      const expectedBase64 = readFileSync(resolve(PACKAGE_ROOT, 'docs/chrome-devtools-relay.md')).toString('base64');
+      assert(data.tool === 'file_upload', `upload used wrong tool: ${JSON.stringify(data)}`);
+      const echoed = JSON.parse(data.raw?.content?.[0]?.text ?? '{}');
+      assert(echoed.args?.file?.filename === 'chrome-devtools-relay.md', `upload filename mismatch: ${JSON.stringify(data)}`);
+      assert(echoed.args?.file?.mimeType === 'text/markdown', `upload mimeType mismatch: ${JSON.stringify(data)}`);
+      assert(echoed.args?.file?.contentBase64 === expectedBase64, `upload content payload mismatch: ${JSON.stringify(data)}`);
+      console.log(`  upload-e:${elapsed}ms (budget: ${MAX_CLI_MS}ms) — extension payload ✓`);
     }
 
     // =================================================================
-    // TEST 10: `vibebrowser-cli dialog --dismiss` calls handle_dialog
+    // TEST 10: `vibebrowser-cli upload <ref> <path>` maps devtools path schema
+    // =================================================================
+    {
+      const { data, elapsed } = await runCli(['--session', SESSION_B, 'upload', 'A7', 'docs/chrome-devtools-relay.md']);
+      assert(data.ok === true, `upload not ok: ${JSON.stringify(data)}`);
+      assert(data.tool === 'upload_file', `upload used wrong tool: ${JSON.stringify(data)}`);
+      const echoed = JSON.parse(data.raw?.content?.[0]?.text ?? '{}');
+      assert(echoed.args?.filePath === 'docs/chrome-devtools-relay.md', `upload filePath mismatch: ${JSON.stringify(data)}`);
+      console.log(`  upload-d:${elapsed}ms (budget: ${MAX_CLI_MS}ms) — devtools path ✓`);
+    }
+
+    // =================================================================
+    // TEST 11: `vibebrowser-cli dialog --dismiss` calls handle_dialog
     // =================================================================
     {
       const { data, elapsed } = await runCli(['dialog', '--dismiss']);

--- a/scripts/e2e-cli-relay.mjs
+++ b/scripts/e2e-cli-relay.mjs
@@ -327,7 +327,7 @@ async function main() {
       const { data, elapsed } = await runCli(['status']);
       assert(data.ok === true, `status not ok: ${JSON.stringify(data)}`);
       assert(data.extensionConnected === true, `extension not connected: ${JSON.stringify(data)}`);
-      assert(Number(data.toolCount) >= 10, `toolCount too low (${data.toolCount}): ${JSON.stringify(data)}`);
+      assert(Number(data.toolCount) === FAKE_TOOLS.length, `toolCount mismatch (${data.toolCount} != ${FAKE_TOOLS.length}): ${JSON.stringify(data)}`);
       assert(data.sessionId === SESSION_A, `status should select ${SESSION_A} by default: ${JSON.stringify(data)}`);
       console.log(`  status:  ${elapsed}ms (budget: ${MAX_CLI_MS}ms) — ${data.toolCount} tools ✓`);
     }

--- a/scripts/e2e-cli-relay.mjs
+++ b/scripts/e2e-cli-relay.mjs
@@ -105,6 +105,9 @@ const FAKE_TOOLS = [
   tool('take_screenshot', { detail: { type: 'string' } }),
   tool('press_key', { keys: { type: 'string' } }),
   tool('evaluate_script', { function: { type: 'string' } }),
+  tool('resize_page', { width: { type: 'number' }, height: { type: 'number' } }),
+  tool('upload_file', { uid: { type: 'string' }, filePath: { type: 'string' } }),
+  tool('handle_dialog', { action: { type: 'string' }, promptText: { type: 'string' } }),
   tool('scroll_page', { direction: { type: 'string' }, numPages: { type: 'number' } }),
   tool('wait_for', { text: { type: 'array' }, timeout: { type: 'number' } }),
   tool('hover', { ref: { type: 'string' } }),
@@ -393,6 +396,36 @@ async function main() {
       assert(data.ok === true, `click not ok: ${JSON.stringify(data)}`);
       assert(data.tool === 'click', `click used wrong tool: ${JSON.stringify(data)}`);
       console.log(`  click:   ${elapsed}ms (budget: ${MAX_CLI_MS}ms) ✓`);
+    }
+
+    // =================================================================
+    // TEST 8: `vibebrowser-cli resize <w> <h>` calls resize_page
+    // =================================================================
+    {
+      const { data, elapsed } = await runCli(['resize', '1280', '720']);
+      assert(data.ok === true, `resize not ok: ${JSON.stringify(data)}`);
+      assert(data.tool === 'resize_page', `resize used wrong tool: ${JSON.stringify(data)}`);
+      console.log(`  resize:  ${elapsed}ms (budget: ${MAX_CLI_MS}ms) ✓`);
+    }
+
+    // =================================================================
+    // TEST 9: `vibebrowser-cli upload <ref> <path>` calls upload_file
+    // =================================================================
+    {
+      const { data, elapsed } = await runCli(['upload', 'A7', 'docs/chrome-devtools-relay.md']);
+      assert(data.ok === true, `upload not ok: ${JSON.stringify(data)}`);
+      assert(data.tool === 'upload_file', `upload used wrong tool: ${JSON.stringify(data)}`);
+      console.log(`  upload:  ${elapsed}ms (budget: ${MAX_CLI_MS}ms) ✓`);
+    }
+
+    // =================================================================
+    // TEST 10: `vibebrowser-cli dialog --dismiss` calls handle_dialog
+    // =================================================================
+    {
+      const { data, elapsed } = await runCli(['dialog', '--dismiss']);
+      assert(data.ok === true, `dialog not ok: ${JSON.stringify(data)}`);
+      assert(data.tool === 'handle_dialog', `dialog used wrong tool: ${JSON.stringify(data)}`);
+      console.log(`  dialog:  ${elapsed}ms (budget: ${MAX_CLI_MS}ms) ✓`);
     }
 
     console.log('cli relay e2e ok');

--- a/scripts/e2e-devtools-flag.mjs
+++ b/scripts/e2e-devtools-flag.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import process from 'node:process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+import { WebSocketServer } from 'ws';
+import { DevtoolsFallbackConnection } from '../dist/devtools-fallback.js';
+
+const HOST = '127.0.0.1';
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(SCRIPT_DIR, '..');
+const BROWSER_CLI = resolve(PACKAGE_ROOT, 'dist', 'browser-main.js');
+const MCP_CLI = resolve(PACKAGE_ROOT, 'dist', 'cli.js');
+const REMOTE_UUID = 'devtools-mode-test-uuid';
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function findFreePort() {
+  return new Promise((resolvePort, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, HOST, () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolvePort(port);
+      });
+    });
+  });
+}
+
+function probePort(port) {
+  return new Promise((resolveConnected) => {
+    const socket = net.connect({ host: HOST, port });
+    socket.on('connect', () => {
+      socket.destroy();
+      resolveConnected(true);
+    });
+    socket.on('error', () => resolveConnected(false));
+  });
+}
+
+async function waitForPort(port, timeoutMs = 10_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await probePort(port)) return;
+    await delay(100);
+  }
+  throw new Error(`Timed out waiting for port ${port}`);
+}
+
+function runJsonCli(scriptPath, args, timeoutMs = 10_000) {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, [scriptPath, '--json', ...args], {
+      cwd: PACKAGE_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`CLI timed out: ${args.join(' ')}\nstdout=${stdout}\nstderr=${stderr}`));
+    }, timeoutMs);
+
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('exit', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(`CLI exited ${code}: ${args.join(' ')}\nstdout=${stdout}\nstderr=${stderr}`));
+        return;
+      }
+      try {
+        resolveResult(JSON.parse(stdout));
+      } catch (error) {
+        reject(new Error(`CLI did not emit JSON: ${args.join(' ')}\nstdout=${stdout}\nstderr=${stderr}\n${error}`));
+      }
+    });
+  });
+}
+
+function runCliText(scriptPath, args, timeoutMs = 10_000) {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: PACKAGE_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`CLI timed out: ${args.join(' ')}\nstdout=${stdout}\nstderr=${stderr}`));
+    }, timeoutMs);
+
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('exit', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(`CLI exited ${code}: ${args.join(' ')}\nstdout=${stdout}\nstderr=${stderr}`));
+        return;
+      }
+      resolveResult(`${stdout}\n${stderr}`);
+    });
+  });
+}
+
+async function main() {
+  const relayPort = await findFreePort();
+  const httpPort = await findFreePort();
+  const relayUrl = `ws://${HOST}:${relayPort}`;
+
+  let relayConnections = 0;
+  let relayMessages = 0;
+  const wss = new WebSocketServer({ host: HOST, port: relayPort });
+  wss.on('connection', (ws) => {
+    relayConnections += 1;
+    ws.on('message', () => {
+      relayMessages += 1;
+    });
+  });
+
+  let serverProcess;
+  try {
+    const mcpHelp = await runCliText(MCP_CLI, ['start', '--help']);
+    assert(mcpHelp.includes('--devtools'), 'vibebrowser-mcp start --help must include --devtools');
+    const browserHelp = await runCliText(BROWSER_CLI, ['--help']);
+    assert(browserHelp.includes('--devtools'), 'vibebrowser-cli --help must include --devtools');
+
+    const browserStatus = await runJsonCli(BROWSER_CLI, [
+      '--devtools',
+      '--remote',
+      REMOTE_UUID,
+      '--relay-url',
+      relayUrl,
+      'status',
+    ]);
+    assert(browserStatus.command === 'status', `Unexpected browser status payload: ${JSON.stringify(browserStatus)}`);
+    assert(browserStatus.mode === 'devtools', `Expected mode=devtools, got ${browserStatus.mode}`);
+    assert(relayConnections === 0 && relayMessages === 0, 'vibebrowser-cli --devtools should not touch relay');
+
+    serverProcess = spawn(
+      process.execPath,
+      [
+        MCP_CLI,
+        'start',
+        '--transport',
+        'http',
+        '--host',
+        HOST,
+        '--http-port',
+        String(httpPort),
+        '--devtools',
+        '--remote',
+        REMOTE_UUID,
+        '--relay-url',
+        relayUrl,
+      ],
+      {
+        cwd: PACKAGE_ROOT,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+
+    let serverStderr = '';
+    serverProcess.stderr.on('data', (chunk) => {
+      serverStderr += chunk.toString();
+    });
+
+    await waitForPort(httpPort);
+    assert(relayConnections === 0 && relayMessages === 0, 'vibebrowser-mcp start --devtools should not touch relay');
+
+    const health = await fetch(`http://${HOST}:${httpPort}/health`);
+    assert(health.ok, `health endpoint failed: ${health.status}`);
+    const payload = await health.json();
+    assert(payload.transport === 'http', `Unexpected health payload: ${JSON.stringify(payload)}`);
+    assert(typeof payload.cachedTools === 'number', `Expected cachedTools number: ${JSON.stringify(payload)}`);
+
+    const originalResolveBinaryPath = DevtoolsFallbackConnection.prototype.resolveBinaryPath;
+    // eslint-disable-next-line no-param-reassign
+    DevtoolsFallbackConnection.prototype.resolveBinaryPath = function () {
+      return undefined;
+    };
+    try {
+      const unavailable = new DevtoolsFallbackConnection(false);
+      await unavailable.start();
+      try {
+        await unavailable.callTool('list_pages', {});
+        throw new Error('Expected callTool to fail when backend is unavailable');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        assert(
+          message === 'chrome-devtools backend unavailable: chrome-devtools-mcp is not installed',
+          `Unexpected unavailable error message: ${message}`,
+        );
+      } finally {
+        await unavailable.stop();
+      }
+    } finally {
+      DevtoolsFallbackConnection.prototype.resolveBinaryPath = originalResolveBinaryPath;
+    }
+
+    console.log('devtools flag e2e ok');
+  } finally {
+    await new Promise((resolveClose) => wss.close(() => resolveClose()));
+    if (serverProcess) {
+      serverProcess.kill('SIGTERM');
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -295,7 +295,17 @@ function registerBrowserSubcommands(browser: Command): void {
       );
     });
 
-  // NOTE: resize command removed — no resize_page tool in the extension.
+  browser
+    .command('resize <width> <height>')
+    .description('Resize the current page viewport/window')
+    .action(async function (this: Command, width: string, height: string) {
+      await runBrowserCommand(this, 'resize', true, async (ctx) =>
+        ctx.resize(
+          parsePositiveInteger(width, '<width>'),
+          parsePositiveInteger(height, '<height>'),
+        )
+      );
+    });
 
   browser
     .command('click <ref>')
@@ -331,7 +341,14 @@ function registerBrowserSubcommands(browser: Command): void {
       await runBrowserCommand(this, 'hover', true, async (ctx) => ctx.hover(ref));
     });
 
-  // NOTE: scrollintoview, download, waitfordownload, upload commands removed — no matching tools.
+  browser
+    .command('upload <ref> <path>')
+    .description('Upload a local file via an input element reference')
+    .action(async function (this: Command, ref: string, path: string) {
+      await runBrowserCommand(this, 'upload', true, async (ctx) => ctx.upload(ref, path));
+    });
+
+  // NOTE: scrollintoview, download, waitfordownload commands removed — no matching tools.
 
   browser
     .command('drag <source> <target>')
@@ -357,7 +374,21 @@ function registerBrowserSubcommands(browser: Command): void {
       );
     });
 
-  // NOTE: dialog command removed — no handle_dialog tool in the extension.
+  browser
+    .command('dialog')
+    .description('Handle browser dialog (accept/dismiss prompt/confirm/alert)')
+    .option('--accept', 'Accept dialog', false)
+    .option('--dismiss', 'Dismiss dialog', false)
+    .option('--prompt <text>', 'Optional prompt text when accepting')
+    .action(async function (this: Command) {
+      await runBrowserCommand(this, 'dialog', true, async (ctx, options) =>
+        ctx.dialog({
+          accept: Boolean(options.accept),
+          dismiss: Boolean(options.dismiss),
+          promptText: options.prompt ? String(options.prompt) : undefined,
+        })
+      );
+    });
 
   browser
     .command('wait')
@@ -486,8 +517,9 @@ class BrowserCliContext {
       return;
     }
     this.sessions = await this.connection.listSessions(1_500).catch(() => this.connection.getSessions());
+    this.toolsLoaded = false;
     await this.ensureToolsLoaded();
-    if (!this.connection.isExtensionConnected()) {
+    if (!this.connection.isExtensionConnected() && this.tools.length === 0) {
       throw new Error(this.connection.getConnectionErrorMessage());
     }
   }
@@ -508,12 +540,7 @@ class BrowserCliContext {
 
   async status(): Promise<CommandOutput> {
     this.sessions = await this.connection.listSessions(STATUS_TOOLS_TIMEOUT_MS).catch(() => this.connection.getSessions());
-    if (this.connection.isExtensionConnected()) {
-      // Use a short timeout for status — this is a diagnostic command that
-      // should return quickly.  Fall back to cached tools if the extension
-      // is slow to respond.
-      await this.ensureToolsLoaded(STATUS_TOOLS_TIMEOUT_MS);
-    }
+    await this.ensureToolsLoaded(STATUS_TOOLS_TIMEOUT_MS);
 
     return {
       ok: true,
@@ -947,6 +974,56 @@ class BrowserCliContext {
     return this.outputFromInvocation('evaluate', invocation);
   }
 
+  async resize(width: number, height: number): Promise<CommandOutput> {
+    const invocation = await this.callTool(
+      'resize',
+      [
+        {
+          names: ['resize_page'],
+          buildArgs: (tool) => withResizeArgs(tool, width, height),
+        },
+      ],
+      {}
+    );
+    return this.outputFromInvocation('resize', invocation);
+  }
+
+  async upload(ref: string, path: string): Promise<CommandOutput> {
+    const invocation = await this.callTool(
+      'upload',
+      [
+        {
+          names: ['upload_file', 'file_upload'],
+          buildArgs: (tool) => withUploadArgs(tool, ref, path),
+        },
+      ],
+      {}
+    );
+    return this.outputFromInvocation('upload', invocation);
+  }
+
+  async dialog(options: {
+    accept: boolean;
+    dismiss: boolean;
+    promptText?: string;
+  }): Promise<CommandOutput> {
+    if (options.accept && options.dismiss) {
+      throw new Error('dialog supports either --accept or --dismiss, not both');
+    }
+    const accept = options.dismiss ? false : true;
+    const invocation = await this.callTool(
+      'dialog',
+      [
+        {
+          names: ['handle_dialog'],
+          buildArgs: (tool) => withDialogArgs(tool, accept, options.promptText),
+        },
+      ],
+      {}
+    );
+    return this.outputFromInvocation('dialog', invocation);
+  }
+
   private async callGenericCommand(
     commandName: string,
     candidates: ToolCandidate[],
@@ -1004,19 +1081,15 @@ class BrowserCliContext {
       return;
     }
     const effectiveTimeout = timeoutMs ?? this.timeoutMs;
-    if (this.connection.isExtensionConnected()) {
-      try {
-        this.tools = await this.connection.refreshTools(effectiveTimeout);
-      } catch {
-        // Refresh timed out or failed — fall back to cached tools or a short
-        // passive wait so the status command is not blocked.
-        this.tools = this.connection.getTools();
-        if (this.tools.length === 0) {
-          this.tools = await this.connection.waitForToolsUpdate(1_000);
-        }
-      }
-    } else {
+    try {
+      this.tools = await this.connection.refreshTools(effectiveTimeout);
+    } catch {
+      // Refresh timed out or failed — fall back to cached tools or a short
+      // passive wait so the status command is not blocked.
       this.tools = this.connection.getTools();
+      if (this.tools.length === 0) {
+        this.tools = await this.connection.waitForToolsUpdate(1_000);
+      }
     }
     this.toolsLoaded = true;
   }
@@ -1923,6 +1996,13 @@ function withRequestDetailsArgs(tool: ToolDefinition, requestId: string): Record
   return args;
 }
 
+function withResizeArgs(tool: ToolDefinition, width: number, height: number): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  maybeAssign(args, tool, 'width', width);
+  maybeAssign(args, tool, 'height', height);
+  return args;
+}
+
 function withRefArgs(
   tool: ToolDefinition,
   ref: string,
@@ -2002,6 +2082,34 @@ function withFillFormArgs(tool: ToolDefinition, fields: JsonValue[]): Record<str
   const args: Record<string, unknown> = {};
   maybeAssign(args, tool, 'fields', fields);
   maybeAssign(args, tool, 'elements', fields);
+  return args;
+}
+
+function withUploadArgs(tool: ToolDefinition, ref: string, path: string): Record<string, unknown> {
+  const args = withRefArgs(tool, ref);
+  maybeAssign(args, tool, 'filePath', path);
+  maybeAssign(args, tool, 'path', path);
+  if (hasProperty(tool, 'paths')) {
+    args.paths = [path];
+  }
+  return args;
+}
+
+function withDialogArgs(tool: ToolDefinition, accept: boolean, promptText?: string): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  if (hasProperty(tool, 'action')) {
+    args.action = accept ? 'accept' : 'dismiss';
+  }
+  if (hasProperty(tool, 'accept')) {
+    args.accept = accept;
+  }
+  if (promptText !== undefined) {
+    maybeAssign(args, tool, 'promptText', promptText);
+    maybeAssign(args, tool, 'prompt', promptText);
+    if (hasProperty(tool, 'prompt_text')) {
+      args.prompt_text = promptText;
+    }
+  }
   return args;
 }
 

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -1,13 +1,31 @@
-import { writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { basename, extname, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { Command } from 'commander';
 import { ExtensionConnection } from './connection.js';
+import { DevtoolsFallbackConnection } from './devtools-fallback.js';
 import { DEFAULT_WS_PORT, type RelaySessionSummary, type ToolDefinition, type ToolResult } from './types.js';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 /** Short timeout for the `status` command — it should never block for 30 s. */
 const STATUS_TOOLS_TIMEOUT_MS = 2_000;
+const MIME_TYPE_BY_EXTENSION: Record<string, string> = {
+  '.css': 'text/css',
+  '.csv': 'text/csv',
+  '.gif': 'image/gif',
+  '.html': 'text/html',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.md': 'text/markdown',
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain',
+  '.webp': 'image/webp',
+  '.xml': 'application/xml',
+};
 const DEFAULT_BROWSER_PROFILE = process.env.VIBE_BROWSER_PROFILE || 'user';
 const DEFAULT_REMOTE_UUID = process.env.VIBE_EXTENSION_UUID || process.env.VIBE_RELAY_UUID;
 const DEFAULT_REMOTE_RELAY_URL = process.env.VIBE_REMOTE_RELAY_URL || process.env.VIBE_RELAY_URL;
@@ -20,6 +38,7 @@ interface BrowserCommandOptions {
   target?: string;
   port: string;
   debug: boolean;
+  devtools: boolean;
   remote?: string;
   session?: string;
   relayUrl?: string;
@@ -48,7 +67,7 @@ interface CommandOutput {
   ok: boolean;
   command: string;
   profile: string;
-  mode: 'local' | 'remote';
+  mode: 'local' | 'remote' | 'devtools';
   sessionId?: string;
   requestedSessionId?: string;
   sessions?: RelaySessionSummary[];
@@ -65,6 +84,7 @@ interface InvocationResult {
 interface CommandContextInit {
   port: number;
   debug: boolean;
+  devtools: boolean;
   remoteUuid?: string;
   sessionId?: string;
   relayUrl?: string;
@@ -99,6 +119,7 @@ function buildBrowserCommand(command: Command): Command {
     .option('--target <target>', 'OpenClaw compatibility target selector (accepted, not used by the Vibe browser CLI)')
     .option('-p, --port <number>', 'WebSocket port for local relay (agent) connection', String(DEFAULT_WS_PORT))
     .option('-d, --debug', 'Enable debug logging', false)
+    .option('--devtools', 'Use only chrome-devtools backend (bypasses extension relay)', false)
     .option('-r, --remote <uuid>', 'Connect to a remote extension via public relay (provide the extension UUID)', DEFAULT_REMOTE_UUID)
     .option('-s, --session <id>', 'Target a specific local browser session ID; defaults to the first connected session')
     .option('--relay-url <url>', 'Custom relay server URL', DEFAULT_REMOTE_RELAY_URL)
@@ -441,6 +462,7 @@ async function runBrowserCommand(
   const ctx = new BrowserCliContext({
     port: parsePositiveInteger(globalOptions.port, '--port'),
     debug: Boolean(globalOptions.debug),
+    devtools: Boolean(globalOptions.devtools),
     remoteUuid: globalOptions.remote,
     sessionId: globalOptions.session,
     relayUrl: globalOptions.relayUrl,
@@ -468,10 +490,11 @@ async function runBrowserCommand(
 }
 
 class BrowserCliContext {
-  private readonly connection: ExtensionConnection;
+  private readonly connection: ExtensionConnection | DevtoolsFallbackConnection;
   private readonly profile: string;
   private readonly json: boolean;
   private readonly timeoutMs: number;
+  private readonly devtoolsOnly: boolean;
   private readonly remoteUuid?: string;
   private readonly requestedSessionId?: string;
   private readonly target?: string;
@@ -482,12 +505,15 @@ class BrowserCliContext {
   private readonly ignoredCompatibilityOptions: string[];
 
   constructor(init: CommandContextInit) {
-    this.connection = new ExtensionConnection(
-      init.port,
-      init.debug,
-      init.remoteUuid ? { uuid: init.remoteUuid, relayUrl: init.relayUrl } : undefined,
-      init.remoteUuid ? undefined : { sessionId: init.sessionId },
-    );
+    this.devtoolsOnly = init.devtools;
+    this.connection = init.devtools
+      ? new DevtoolsFallbackConnection(init.debug)
+      : new ExtensionConnection(
+        init.port,
+        init.debug,
+        init.remoteUuid ? { uuid: init.remoteUuid, relayUrl: init.relayUrl } : undefined,
+        init.remoteUuid ? undefined : { sessionId: init.sessionId },
+      );
     this.profile = init.profile;
     this.json = init.json;
     this.timeoutMs = init.timeoutMs;
@@ -503,9 +529,12 @@ class BrowserCliContext {
 
   async connect(): Promise<void> {
     await this.connection.start();
-    await delay(100);
-    this.sessions = await this.connection.listSessions(1_500).catch(() => this.connection.getSessions());
-    await this.connection.waitForToolsUpdate(500);
+    if (this.connection instanceof ExtensionConnection) {
+      const extension = this.connection;
+      await delay(100);
+      this.sessions = await extension.listSessions(1_500).catch(() => extension.getSessions());
+      await extension.waitForToolsUpdate(500);
+    }
   }
 
   async shutdown(): Promise<void> {
@@ -513,19 +542,26 @@ class BrowserCliContext {
   }
 
   async ensureExtensionConnected(): Promise<void> {
-    if (this.connection.isExtensionConnected()) {
+    if (this.isBackendConnected()) {
       return;
     }
-    this.sessions = await this.connection.listSessions(1_500).catch(() => this.connection.getSessions());
+    if (this.connection instanceof ExtensionConnection) {
+      const extension = this.connection;
+      this.sessions = await extension.listSessions(1_500).catch(() => extension.getSessions());
+    }
     this.toolsLoaded = false;
     await this.ensureToolsLoaded();
-    if (!this.connection.isExtensionConnected() && this.tools.length === 0) {
-      throw new Error(this.connection.getConnectionErrorMessage());
+    if (!this.isBackendConnected() && this.tools.length === 0) {
+      throw new Error(this.getConnectionErrorMessage());
     }
   }
 
   async listSessions(): Promise<CommandOutput> {
-    this.sessions = await this.connection.listSessions(this.timeoutMs);
+    if (this.connection instanceof ExtensionConnection) {
+      this.sessions = await this.connection.listSessions(this.timeoutMs);
+    } else {
+      this.sessions = [];
+    }
     return {
       ok: true,
       command: 'sessions',
@@ -539,20 +575,27 @@ class BrowserCliContext {
   }
 
   async status(): Promise<CommandOutput> {
-    this.sessions = await this.connection.listSessions(STATUS_TOOLS_TIMEOUT_MS).catch(() => this.connection.getSessions());
+    if (this.connection instanceof ExtensionConnection) {
+      const extension = this.connection;
+      this.sessions = await extension.listSessions(STATUS_TOOLS_TIMEOUT_MS).catch(() => extension.getSessions());
+    } else {
+      this.sessions = [];
+    }
     await this.ensureToolsLoaded(STATUS_TOOLS_TIMEOUT_MS);
 
     return {
       ok: true,
       command: 'status',
       profile: this.profile,
-      mode: this.remoteUuid ? 'remote' : 'local',
+      mode: this.mode(),
       sessionId: this.currentSessionId(),
       requestedSessionId: this.requestedSessionId,
       sessions: this.sessions,
       ignoredCompatibilityOptions: this.ignoredCompatibilityOptions,
-      relayConnected: this.connection.getStatus() === 'connected',
-      extensionConnected: this.connection.isExtensionConnected(),
+      relayConnected: this.connection instanceof ExtensionConnection
+        ? this.connection.getStatus() === 'connected'
+        : false,
+      extensionConnected: this.isBackendConnected(),
       managedLifecycle: false,
       transport: 'vibebrowser-mcp',
       toolCount: this.tools.length,
@@ -1088,7 +1131,9 @@ class BrowserCliContext {
       // passive wait so the status command is not blocked.
       this.tools = this.connection.getTools();
       if (this.tools.length === 0) {
-        this.tools = await this.connection.waitForToolsUpdate(1_000);
+        if (this.connection instanceof ExtensionConnection) {
+          this.tools = await this.connection.waitForToolsUpdate(1_000);
+        }
       }
     }
     this.toolsLoaded = true;
@@ -1273,11 +1318,17 @@ class BrowserCliContext {
     }
   }
 
-  private mode(): 'local' | 'remote' {
+  private mode(): 'local' | 'remote' | 'devtools' {
+    if (this.devtoolsOnly) {
+      return 'devtools';
+    }
     return this.remoteUuid ? 'remote' : 'local';
   }
 
   private currentSessionId(): string | undefined {
+    if (this.devtoolsOnly) {
+      return undefined;
+    }
     if (this.remoteUuid) {
       return this.remoteUuid;
     }
@@ -1293,6 +1344,24 @@ class BrowserCliContext {
     }
 
     return this.sessions.find((session) => session.connected)?.sessionId;
+  }
+
+  private isBackendConnected(): boolean {
+    if (this.connection instanceof ExtensionConnection) {
+      return this.connection.isExtensionConnected();
+    }
+    return this.connection.isAvailable();
+  }
+
+  private getConnectionErrorMessage(): string {
+    if (this.connection instanceof ExtensionConnection) {
+      return this.connection.getConnectionErrorMessage();
+    }
+    return this.connection.getUnavailableReason() || 'chrome-devtools backend unavailable';
+  }
+
+  outputMode(): 'local' | 'remote' | 'devtools' {
+    return this.mode();
   }
 }
 
@@ -1517,7 +1586,7 @@ function emitError(
       ok: false,
       command: commandName,
       profile: DEFAULT_BROWSER_PROFILE,
-      mode: 'local',
+      mode: ctx.outputMode(),
       error: message,
     }, null, 2));
     return;
@@ -2092,6 +2161,36 @@ function withUploadArgs(tool: ToolDefinition, ref: string, path: string): Record
   if (hasProperty(tool, 'paths')) {
     args.paths = [path];
   }
+
+  const filenameKey = hasProperty(tool, 'filename');
+  const mimeTypeKey = hasProperty(tool, 'mimeType');
+  const contentBase64Key = hasProperty(tool, 'contentBase64');
+  const hasTopLevelPayload = Boolean(filenameKey && mimeTypeKey && contentBase64Key);
+
+  const fileKey = hasProperty(tool, 'file');
+  const fileSchema = fileKey ? toolProperties(tool)[fileKey] : undefined;
+  const fileProperties = isRecord(fileSchema) && isRecord(fileSchema.properties) ? fileSchema.properties : undefined;
+  const hasNestedPayload = Boolean(
+    fileKey
+    && fileProperties
+    && Object.prototype.hasOwnProperty.call(fileProperties, 'filename')
+    && Object.prototype.hasOwnProperty.call(fileProperties, 'mimeType')
+    && Object.prototype.hasOwnProperty.call(fileProperties, 'contentBase64'),
+  );
+
+  if (!hasTopLevelPayload && !hasNestedPayload) {
+    return args;
+  }
+
+  const filePayload = buildUploadFilePayload(path);
+  if (hasTopLevelPayload && filenameKey && mimeTypeKey && contentBase64Key) {
+    args[filenameKey] = filePayload.filename;
+    args[mimeTypeKey] = filePayload.mimeType;
+    args[contentBase64Key] = filePayload.contentBase64;
+  }
+  if (hasNestedPayload && fileKey) {
+    args[fileKey] = filePayload;
+  }
   return args;
 }
 
@@ -2160,6 +2259,25 @@ function maybeAssign(target: Record<string, unknown>, tool: ToolDefinition, prop
 
 function stripUndefined(value: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function buildUploadFilePayload(path: string): { filename: string; mimeType: string; contentBase64: string } {
+  let contentBase64: string;
+  try {
+    contentBase64 = readFileSync(path).toString('base64');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read upload file at "${path}": ${message}`);
+  }
+  return {
+    filename: basename(path),
+    mimeType: MIME_TYPE_BY_EXTENSION[extname(path).toLowerCase()] ?? 'application/octet-stream',
+    contentBase64,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function parseRef(ref: string): RefTarget {

--- a/src/browser-main.ts
+++ b/src/browser-main.ts
@@ -6,6 +6,7 @@ import { getPackageVersion } from './version.js';
 
 program
   .name('vibebrowser-cli')
+  .description('OpenClaw-compatible browser CLI (relay mode by default, or chrome-devtools with --devtools)')
   .version(getPackageVersion());
 
 registerStandaloneBrowserCli(program);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ program
   .description('Start the MCP server (default)')
   .option('-p, --port <number>', 'WebSocket port for local relay (agent) connection', String(DEFAULT_WS_PORT))
   .option('-d, --debug', 'Enable debug logging', false)
+  .option('--devtools', 'Use only chrome-devtools backend (bypasses extension relay)', false)
   .option('-r, --remote <uuid>', 'Connect to a remote extension via public relay (provide the extension UUID)')
   .option('-s, --session <id>', 'Target a specific local browser session ID; defaults to the first connected session')
   .option('--relay-url <url>', 'Custom relay server URL (default: wss://relay.api.vibebrowser.app)')
@@ -49,6 +50,7 @@ program
         port,
         host: options.host,
         debug: options.debug,
+        devtools: options.devtools,
         transport,
         httpPort,
         httpPath: options.httpPath,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -409,10 +409,6 @@ export class ExtensionConnection extends EventEmitter {
       throw new Error('Not connected to relay');
     }
 
-    if (type !== 'list_sessions' && !this.extensionConnected) {
-      throw new Error(this.getConnectionErrorMessage());
-    }
-
     const requestId = `req_${++this.requestIdCounter}`;
     
     return new Promise<T>((resolve, reject) => {

--- a/src/devtools-fallback.ts
+++ b/src/devtools-fallback.ts
@@ -1,0 +1,206 @@
+import { EventEmitter } from 'node:events';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { ToolDefinition, ToolResult, ToolResultContent } from './types.js';
+
+const TOOLS_REFRESH_TIMEOUT_MS = 6_000;
+const TOOL_CALL_TIMEOUT_MS = 30_000;
+
+interface ChromeDevtoolsPackageMeta {
+  bin?: string | Record<string, string>;
+}
+
+function normalizeToolName(value: string): string {
+  return value.replace(/[-\s]/g, '_').toLowerCase();
+}
+
+function toToolDefinition(input: {
+  name: string;
+  description?: string;
+  inputSchema: {
+    type: 'object';
+    properties?: Record<string, object>;
+    required?: string[];
+  };
+}): ToolDefinition {
+  return {
+    name: input.name,
+    description: input.description ?? '',
+    inputSchema: {
+      type: 'object',
+      properties: input.inputSchema.properties as Record<string, never> | undefined,
+      required: input.inputSchema.required,
+    },
+  };
+}
+
+export class DevtoolsFallbackConnection extends EventEmitter {
+  private readonly debug: boolean;
+  private client: Client | null = null;
+  private transport: StdioClientTransport | null = null;
+  private tools: ToolDefinition[] = [];
+  private available = false;
+  private unavailableReason?: string;
+
+  constructor(debug: boolean) {
+    super();
+    this.debug = debug;
+  }
+
+  async start(): Promise<void> {
+    const binaryPath = this.resolveBinaryPath();
+    if (!binaryPath) {
+      this.unavailableReason = 'chrome-devtools-mcp is not installed';
+      this.log(this.unavailableReason);
+      return;
+    }
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [binaryPath, '--autoConnect'],
+      stderr: this.debug ? 'inherit' : 'pipe',
+    });
+    const client = new Client(
+      {
+        name: 'vibebrowser-mcp-devtools-fallback',
+        version: '1.0.0',
+      },
+      { capabilities: {} },
+    );
+
+    try {
+      await client.connect(transport, { timeout: TOOLS_REFRESH_TIMEOUT_MS });
+      this.client = client;
+      this.transport = transport;
+      this.available = true;
+      this.unavailableReason = undefined;
+      await this.refreshTools(TOOLS_REFRESH_TIMEOUT_MS);
+      this.emit('connected');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.unavailableReason = `chrome-devtools fallback unavailable: ${message}`;
+      this.log(this.unavailableReason);
+      this.available = false;
+      this.client = null;
+      this.transport = null;
+      this.tools = [];
+      this.emit('unavailable', this.unavailableReason);
+      try {
+        await transport.close();
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.available = false;
+    this.tools = [];
+
+    if (this.client) {
+      try {
+        await this.client.close();
+      } catch {
+        // ignore shutdown errors
+      }
+      this.client = null;
+    }
+
+    if (this.transport) {
+      try {
+        await this.transport.close();
+      } catch {
+        // ignore shutdown errors
+      }
+      this.transport = null;
+    }
+  }
+
+  async refreshTools(timeoutMs: number = TOOLS_REFRESH_TIMEOUT_MS): Promise<ToolDefinition[]> {
+    if (!this.client || !this.available) {
+      return this.tools;
+    }
+
+    try {
+      const listed = await this.client.listTools(undefined, { timeout: timeoutMs });
+      const nextTools = listed.tools.map(toToolDefinition);
+      const previousNames = this.tools.map((tool) => normalizeToolName(tool.name)).join(',');
+      const nextNames = nextTools.map((tool) => normalizeToolName(tool.name)).join(',');
+      this.tools = nextTools;
+      if (previousNames !== nextNames) {
+        this.emit('tools_updated', this.tools);
+      }
+      return this.tools;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.log(`Unable to refresh chrome-devtools tools: ${message}`);
+      return this.tools;
+    }
+  }
+
+  getTools(): ToolDefinition[] {
+    return this.tools;
+  }
+
+  hasTool(name: string): boolean {
+    const needle = normalizeToolName(name);
+    return this.tools.some((tool) => normalizeToolName(tool.name) === needle);
+  }
+
+  async callTool(name: string, args: Record<string, unknown>, timeoutMs: number = TOOL_CALL_TIMEOUT_MS): Promise<ToolResult> {
+    if (!this.client || !this.available) {
+      throw new Error(this.unavailableReason || 'chrome-devtools fallback is unavailable');
+    }
+
+    const result = await this.client.callTool(
+      { name, arguments: args },
+      undefined,
+      { timeout: timeoutMs },
+    );
+
+    const content = Array.isArray(result.content)
+      ? (result.content as ToolResultContent[])
+      : [{ type: 'text', text: JSON.stringify(result) } as ToolResultContent];
+    const isError = typeof result.isError === 'boolean' ? result.isError : false;
+
+    return {
+      success: !isError,
+      isError,
+      content,
+    };
+  }
+
+  isAvailable(): boolean {
+    return this.available;
+  }
+
+  getUnavailableReason(): string | undefined {
+    return this.unavailableReason;
+  }
+
+  private resolveBinaryPath(): string | undefined {
+    try {
+      const require = createRequire(import.meta.url);
+      const packageJsonPath = require.resolve('chrome-devtools-mcp/package.json');
+      const metadata = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as ChromeDevtoolsPackageMeta;
+      const bin = typeof metadata.bin === 'string'
+        ? metadata.bin
+        : metadata.bin?.['chrome-devtools-mcp'] ?? metadata.bin?.['chrome-devtools'];
+      if (!bin) {
+        return undefined;
+      }
+      return resolve(dirname(packageJsonPath), bin);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private log(message: string): void {
+    if (this.debug) {
+      console.error(`[vibebrowser-mcp] ${message}`);
+    }
+  }
+}

--- a/src/devtools-fallback.ts
+++ b/src/devtools-fallback.ts
@@ -8,6 +8,8 @@ import type { ToolDefinition, ToolResult, ToolResultContent } from './types.js';
 
 const TOOLS_REFRESH_TIMEOUT_MS = 6_000;
 const TOOL_CALL_TIMEOUT_MS = 30_000;
+const DEVTOOLS_UNAVAILABLE_PREFIX = 'chrome-devtools backend unavailable';
+const DEVTOOLS_NOT_INSTALLED_MESSAGE = `${DEVTOOLS_UNAVAILABLE_PREFIX}: chrome-devtools-mcp is not installed`;
 
 interface ChromeDevtoolsPackageMeta {
   bin?: string | Record<string, string>;
@@ -53,7 +55,7 @@ export class DevtoolsFallbackConnection extends EventEmitter {
   async start(): Promise<void> {
     const binaryPath = this.resolveBinaryPath();
     if (!binaryPath) {
-      this.unavailableReason = 'chrome-devtools-mcp is not installed';
+      this.unavailableReason = DEVTOOLS_NOT_INSTALLED_MESSAGE;
       this.log(this.unavailableReason);
       return;
     }
@@ -81,7 +83,7 @@ export class DevtoolsFallbackConnection extends EventEmitter {
       this.emit('connected');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      this.unavailableReason = `chrome-devtools fallback unavailable: ${message}`;
+      this.unavailableReason = `${DEVTOOLS_UNAVAILABLE_PREFIX}: ${message}`;
       this.log(this.unavailableReason);
       this.available = false;
       this.client = null;
@@ -152,7 +154,7 @@ export class DevtoolsFallbackConnection extends EventEmitter {
 
   async callTool(name: string, args: Record<string, unknown>, timeoutMs: number = TOOL_CALL_TIMEOUT_MS): Promise<ToolResult> {
     if (!this.client || !this.available) {
-      throw new Error(this.unavailableReason || 'chrome-devtools fallback is unavailable');
+      throw new Error(this.unavailableReason || DEVTOOLS_UNAVAILABLE_PREFIX);
     }
 
     const result = await this.client.callTool(

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -468,7 +468,7 @@ export class RelayServer extends EventEmitter {
         return;
       }
 
-      if (this.findFallbackTool(requestedToolName)) {
+      if (!this.hasConnectedExtensionSession() && this.findFallbackTool(requestedToolName)) {
         try {
           const args = message.data?.arguments && typeof message.data.arguments === 'object'
             ? message.data.arguments
@@ -800,22 +800,15 @@ export class RelayServer extends EventEmitter {
   }
 
   private getToolsForSession(session: ExtensionSession | null): ToolDefinition[] {
-    const byName = new Map<string, ToolDefinition>();
-
     if (session) {
-      for (const tool of session.tools) {
-        byName.set(normalizeToolName(tool.name), tool);
-      }
+      return [...session.tools];
     }
 
-    for (const tool of this.devtoolsFallback.getTools()) {
-      const key = normalizeToolName(tool.name);
-      if (!byName.has(key)) {
-        byName.set(key, tool);
-      }
+    if (this.hasConnectedExtensionSession()) {
+      return [];
     }
 
-    return [...byName.values()];
+    return [...this.devtoolsFallback.getTools()];
   }
 
   private findExtensionTool(session: ExtensionSession | null, toolName: string): ToolDefinition | undefined {
@@ -839,6 +832,10 @@ export class RelayServer extends EventEmitter {
       data: tools,
       sessionId: defaultSession?.sessionId,
     }, excludeAgentId);
+  }
+
+  private hasConnectedExtensionSession(): boolean {
+    return this.getDefaultSession() !== null;
   }
 
   private sendSessionStateToAgent(ws: WebSocket): void {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -14,6 +14,8 @@ import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync } from '
 import { join } from 'path';
 import { homedir } from 'os';
 import { EventEmitter } from 'events';
+import { DevtoolsFallbackConnection } from './devtools-fallback.js';
+import type { ToolDefinition } from './types.js';
 
 function parseEnvPort(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -26,6 +28,10 @@ function parseEnvPort(name: string, fallback: number): number {
     throw new Error(`Invalid ${name} value: ${raw}`);
   }
   return port;
+}
+
+function normalizeToolName(value: string): string {
+  return value.replace(/[-\s]/g, '_').toLowerCase();
 }
 
 // Ports (19888/19889 to avoid conflict with Playwriter MCP which uses 19988/19989)
@@ -72,7 +78,7 @@ interface ExtensionSession {
   ws: WebSocket;
   sessionId: string;
   connectedAt: number;
-  tools: unknown[];
+  tools: ToolDefinition[];
   toolsSyncTimer: NodeJS.Timeout | null;
 }
 
@@ -98,6 +104,11 @@ interface PendingRequest {
 
 /**
  * Vibe MCP Relay Server
+ *
+ * Owns exactly one shared chrome-devtools fallback backend process per relay
+ * daemon instance. All connected MCP clients (vibebrowser-mcp and
+ * vibebrowser-cli) route through this relay, so fallback lifecycle and tool
+ * routing stay deterministic across concurrent agents.
  */
 export class RelayServer extends EventEmitter {
   private extensionWss: WebSocketServer | null = null;
@@ -109,10 +120,12 @@ export class RelayServer extends EventEmitter {
   private requestIdCounter = 0;
   private anonymousSessionCounter = 0;
   private debug: boolean;
+  private readonly devtoolsFallback: DevtoolsFallbackConnection;
 
   constructor(debug: boolean = false) {
     super();
     this.debug = debug;
+    this.devtoolsFallback = new DevtoolsFallbackConnection(debug);
   }
 
   /**
@@ -129,6 +142,20 @@ export class RelayServer extends EventEmitter {
     
     // Start agent WebSocket server
     await this.startAgentServer();
+    await this.devtoolsFallback.start();
+
+    this.devtoolsFallback.on('tools_updated', () => {
+      this.broadcastDefaultToolsToAgents();
+      this.broadcastSessionState();
+    });
+    this.devtoolsFallback.on('connected', () => {
+      this.broadcastDefaultToolsToAgents();
+      this.broadcastSessionState();
+    });
+    this.devtoolsFallback.on('unavailable', () => {
+      this.broadcastDefaultToolsToAgents();
+      this.broadcastSessionState();
+    });
 
     // Write PID file
     writeFileSync(PID_FILE, String(process.pid));
@@ -221,6 +248,7 @@ export class RelayServer extends EventEmitter {
       this.broadcastSessionState();
       if (this.extensionSessions.size === 0) {
         this.broadcastToAgents({ type: 'extension_disconnected' });
+        this.broadcastDefaultToolsToAgents();
       }
     });
 
@@ -248,14 +276,18 @@ export class RelayServer extends EventEmitter {
     this.sendSessionStateToAgent(ws);
 
     const defaultSession = this.getDefaultSession();
-    if (defaultSession && defaultSession.tools.length > 0) {
-      ws.send(JSON.stringify({ type: 'tools_list', data: defaultSession.tools, sessionId: defaultSession.sessionId }));
+    const tools = this.getToolsForSession(defaultSession);
+    if (tools.length > 0) {
+      ws.send(JSON.stringify({ type: 'tools_list', data: tools, sessionId: defaultSession?.sessionId }));
     }
 
     ws.on('message', (data) => {
       try {
         const message = JSON.parse(data.toString());
-        this.handleAgentMessage(agentId, message);
+        this.handleAgentMessage(agentId, message).catch((error) => {
+          const reason = error instanceof Error ? error.message : String(error);
+          this.log(`Unhandled agent message failure (${agentId}): ${reason}`);
+        });
       } catch (error) {
         this.log(`Failed to parse agent message: ${error}`);
       }
@@ -305,19 +337,28 @@ export class RelayServer extends EventEmitter {
         // Forward response to the requesting agent
         const agent = this.agents.get(pending.agentId);
         if (agent) {
-          agent.ws.send(JSON.stringify({
-            ...message,
-            sessionId: session.sessionId,
-            requestId: pending.originalRequestId,
-          }));
+          if (message.type === 'tools_list') {
+            agent.ws.send(JSON.stringify({
+              type: 'tools_list',
+              requestId: pending.originalRequestId,
+              data: this.getToolsForSession(this.extensionSessions.get(pending.sessionId) || null),
+              sessionId: pending.sessionId,
+            }));
+          } else {
+            agent.ws.send(JSON.stringify({
+              ...message,
+              sessionId: session.sessionId,
+              requestId: pending.originalRequestId,
+            }));
+          }
         }
 
         // For tools_list we still want to cache + broadcast to *other* agents
         // so they stay in sync, but the requesting agent already got its copy.
         if (message.type === 'tools_list') {
-          session.tools = message.data as unknown[];
+          session.tools = this.parseToolDefinitions(message.data);
           this.stopToolsSyncLoop(session);
-          this.broadcastToAgents({ type: 'tools_list', data: session.tools, sessionId: session.sessionId }, pending.agentId);
+          this.broadcastDefaultToolsToAgents(pending.agentId);
           this.broadcastSessionState();
         }
         return;
@@ -326,9 +367,9 @@ export class RelayServer extends EventEmitter {
 
     // Handle unsolicited tools list (e.g. extension announces on connect)
     if (message.type === 'tools_list') {
-      session.tools = message.data as unknown[];
+      session.tools = this.parseToolDefinitions(message.data);
       this.stopToolsSyncLoop(session);
-      this.broadcastToAgents({ type: 'tools_list', data: session.tools, sessionId: session.sessionId });
+      this.broadcastDefaultToolsToAgents();
       this.broadcastSessionState();
       return;
     }
@@ -340,8 +381,9 @@ export class RelayServer extends EventEmitter {
   /**
    * Handle message from an agent
    */
-  private handleAgentMessage(agentId: string, message: ServerMessage): void {
-    this.log(`Agent ${agentId} message: ${message.type}`);
+  private async handleAgentMessage(agentId: string, message: ServerMessage): Promise<void> {
+    try {
+      this.log(`Agent ${agentId} message: ${message.type}`);
 
     if (message.type === 'list_sessions') {
       const agent = this.agents.get(agentId);
@@ -357,11 +399,114 @@ export class RelayServer extends EventEmitter {
 
     const requestedSessionId = typeof message.data?.sessionId === 'string' ? message.data.sessionId : undefined;
     const targetSession = this.resolveTargetSession(requestedSessionId);
+    const agent = this.agents.get(agentId);
+    if (!agent || !message.requestId) {
+      return;
+    }
 
-    if (!targetSession) {
-      // No extension connected, send error back
-      const agent = this.agents.get(agentId);
-      if (agent && message.requestId) {
+    if (message.type === 'list_tools') {
+      if (requestedSessionId && !targetSession) {
+        agent.ws.send(JSON.stringify({
+          type: 'error',
+          requestId: message.requestId,
+          error: `No browser session connected for sessionId=${requestedSessionId}`,
+        }));
+        return;
+      }
+
+      agent.ws.send(JSON.stringify({
+        type: 'tools_list',
+        requestId: message.requestId,
+        data: this.getToolsForSession(targetSession),
+        sessionId: targetSession?.sessionId,
+      }));
+      return;
+    }
+
+    if (message.type === 'call_tool') {
+      const requestedToolName = message.data?.name;
+      if (typeof requestedToolName !== 'string' || requestedToolName.trim().length === 0) {
+        agent.ws.send(JSON.stringify({
+          type: 'error',
+          requestId: message.requestId,
+          error: 'Tool name is required',
+        }));
+        return;
+      }
+
+      if (requestedSessionId && !targetSession) {
+        agent.ws.send(JSON.stringify({
+          type: 'error',
+          requestId: message.requestId,
+          error: `No browser session connected for sessionId=${requestedSessionId}`,
+        }));
+        return;
+      }
+
+      const extensionTool = this.findExtensionTool(targetSession, requestedToolName);
+      if (extensionTool && targetSession) {
+        const relayRequestId = `relay_${++this.requestIdCounter}`;
+        const cleanData = message.data ? { ...message.data } : undefined;
+        if (cleanData && 'sessionId' in cleanData) {
+          delete cleanData.sessionId;
+        }
+        const forwardMessage: ServerMessage = {
+          ...message,
+          requestId: relayRequestId,
+          ...(cleanData ? { data: cleanData } : {}),
+        };
+
+        this.pendingRequests.set(relayRequestId, {
+          agentId,
+          originalRequestId: message.requestId,
+          lastSentAt: Date.now(),
+          forwardMessage,
+          sessionId: targetSession.sessionId,
+        });
+
+        targetSession.ws.send(JSON.stringify(forwardMessage));
+        return;
+      }
+
+      if (this.findFallbackTool(requestedToolName)) {
+        try {
+          const args = message.data?.arguments && typeof message.data.arguments === 'object'
+            ? message.data.arguments
+            : {};
+          const result = await this.devtoolsFallback.callTool(
+            requestedToolName,
+            args as Record<string, unknown>,
+          );
+          agent.ws.send(JSON.stringify({
+            type: 'tool_result',
+            requestId: message.requestId,
+            data: result,
+            sessionId: targetSession?.sessionId,
+          }));
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : String(error);
+          agent.ws.send(JSON.stringify({
+            type: 'error',
+            requestId: message.requestId,
+            error: reason,
+            sessionId: targetSession?.sessionId,
+          }));
+        }
+        return;
+      }
+
+      agent.ws.send(JSON.stringify({
+        type: 'error',
+        requestId: message.requestId,
+        error: targetSession
+          ? `Tool not found: ${requestedToolName}`
+          : 'No extension connected',
+      }));
+      return;
+    }
+
+      if (!targetSession) {
+        // No extension connected, send error back
         agent.ws.send(JSON.stringify({
           type: 'error',
           requestId: message.requestId,
@@ -369,9 +514,8 @@ export class RelayServer extends EventEmitter {
             ? `No browser session connected for sessionId=${requestedSessionId}`
             : 'No extension connected',
         }));
+        return;
       }
-      return;
-    }
 
     // Generate relay request ID
     const relayRequestId = `relay_${++this.requestIdCounter}`;
@@ -396,7 +540,20 @@ export class RelayServer extends EventEmitter {
     });
 
     // Forward to extension with relay request ID
-    targetSession.ws.send(JSON.stringify(forwardMessage));
+      targetSession.ws.send(JSON.stringify(forwardMessage));
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      this.log(`Failed to handle agent message (${agentId}, ${message.type}): ${reason}`);
+
+      const agent = this.agents.get(agentId);
+      if (agent && message.requestId && agent.ws.readyState === WebSocket.OPEN) {
+        agent.ws.send(JSON.stringify({
+          type: 'error',
+          requestId: message.requestId,
+          error: `Relay error: ${reason}`,
+        }));
+      }
+    }
   }
 
   /**
@@ -511,6 +668,7 @@ export class RelayServer extends EventEmitter {
     }
     this.extensionSessions.clear();
     this.socketToSessionId.clear();
+    await this.devtoolsFallback.stop();
 
     // Close servers
     if (this.agentWss) {
@@ -629,6 +787,58 @@ export class RelayServer extends EventEmitter {
       return null;
     }
     return this.getDefaultSession();
+  }
+
+  private parseToolDefinitions(data: unknown): ToolDefinition[] {
+    if (!Array.isArray(data)) {
+      return [];
+    }
+
+    return data
+      .filter((entry) => Boolean(entry) && typeof entry === 'object' && typeof (entry as { name?: unknown }).name === 'string')
+      .map((entry) => entry as ToolDefinition);
+  }
+
+  private getToolsForSession(session: ExtensionSession | null): ToolDefinition[] {
+    const byName = new Map<string, ToolDefinition>();
+
+    if (session) {
+      for (const tool of session.tools) {
+        byName.set(normalizeToolName(tool.name), tool);
+      }
+    }
+
+    for (const tool of this.devtoolsFallback.getTools()) {
+      const key = normalizeToolName(tool.name);
+      if (!byName.has(key)) {
+        byName.set(key, tool);
+      }
+    }
+
+    return [...byName.values()];
+  }
+
+  private findExtensionTool(session: ExtensionSession | null, toolName: string): ToolDefinition | undefined {
+    if (!session) {
+      return undefined;
+    }
+    const key = normalizeToolName(toolName);
+    return session.tools.find((tool) => normalizeToolName(tool.name) === key);
+  }
+
+  private findFallbackTool(toolName: string): ToolDefinition | undefined {
+    const key = normalizeToolName(toolName);
+    return this.devtoolsFallback.getTools().find((tool) => normalizeToolName(tool.name) === key);
+  }
+
+  private broadcastDefaultToolsToAgents(excludeAgentId?: string): void {
+    const defaultSession = this.getDefaultSession();
+    const tools = this.getToolsForSession(defaultSession);
+    this.broadcastToAgents({
+      type: 'tools_list',
+      data: tools,
+      sessionId: defaultSession?.sessionId,
+    }, excludeAgentId);
   }
 
   private sendSessionStateToAgent(ws: WebSocket): void {

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { ExtensionConnection, type RemoteConfig } from './connection.js';
+import { DevtoolsFallbackConnection } from './devtools-fallback.js';
 import {
   DEFAULT_HTTP_PATH,
   DEFAULT_HTTP_PORT,
@@ -46,7 +47,7 @@ interface SessionState {
  * Exposes Vibe browser tools to MCP clients via stdio or streamable HTTP transport.
  */
 export class VibeMcpServer {
-  private readonly connection: ExtensionConnection;
+  private readonly connection: ExtensionConnection | DevtoolsFallbackConnection;
   private readonly config: ServerConfig;
   private readonly sessions = new Map<string, SessionState>();
   private stdioServer: Server | null = null;
@@ -59,6 +60,7 @@ export class VibeMcpServer {
       port: config.port ?? DEFAULT_WS_PORT,
       host: config.host ?? '127.0.0.1',
       debug: config.debug ?? false,
+      devtools: config.devtools ?? false,
       transport: config.transport ?? 'stdio',
       httpPort: config.httpPort ?? DEFAULT_HTTP_PORT,
       httpPath: normalizeHttpPath(config.httpPath ?? DEFAULT_HTTP_PATH),
@@ -68,16 +70,20 @@ export class VibeMcpServer {
       remoteRelayUrl: config.remoteRelayUrl,
     };
 
-    const remoteConfig: RemoteConfig | undefined = this.config.remoteUuid
-      ? { uuid: this.config.remoteUuid, relayUrl: this.config.remoteRelayUrl }
-      : undefined;
+    if (this.config.devtools) {
+      this.connection = new DevtoolsFallbackConnection(this.config.debug);
+    } else {
+      const remoteConfig: RemoteConfig | undefined = this.config.remoteUuid
+        ? { uuid: this.config.remoteUuid, relayUrl: this.config.remoteRelayUrl }
+        : undefined;
 
-    this.connection = new ExtensionConnection(
-      this.config.port,
-      this.config.debug,
-      remoteConfig,
-      this.config.remoteUuid ? undefined : { sessionId: this.config.sessionId },
-    );
+      this.connection = new ExtensionConnection(
+        this.config.port,
+        this.config.debug,
+        remoteConfig,
+        this.config.remoteUuid ? undefined : { sessionId: this.config.sessionId },
+      );
+    }
     this.setupConnectionEvents();
   }
 
@@ -86,7 +92,13 @@ export class VibeMcpServer {
    */
   async start(): Promise<void> {
     await this.connection.start();
-    if (this.config.remoteUuid) {
+    if (this.config.devtools) {
+      if (this.connection instanceof DevtoolsFallbackConnection && this.connection.isAvailable()) {
+        this.log('Connected to chrome-devtools backend');
+      } else {
+        this.log('chrome-devtools backend unavailable; server started without tools');
+      }
+    } else if (this.config.remoteUuid) {
       this.log(`Connected to remote relay for UUID ${this.config.remoteUuid}`);
     } else {
       this.log(`Waiting for Vibe extension connection on port ${this.config.port}...`);
@@ -171,6 +183,21 @@ export class VibeMcpServer {
    * Set up extension connection events
    */
   private setupConnectionEvents(): void {
+    if (this.connection instanceof DevtoolsFallbackConnection) {
+      this.connection.on('connected', () => {
+        this.log('chrome-devtools backend connected');
+      });
+      this.connection.on('unavailable', (reason: string) => {
+        this.log(reason);
+        this.notifyToolListChanged();
+      });
+      this.connection.on('tools_updated', (tools: ToolDefinition[]) => {
+        this.log(`Received ${tools.length} tools from chrome-devtools backend`);
+        this.notifyToolListChanged();
+      });
+      return;
+    }
+
     this.connection.on('connected', () => {
       this.log('Extension connected');
     });
@@ -220,7 +247,9 @@ export class VibeMcpServer {
       }
 
       if (this.connection.getTools().length === 0) {
-        await this.connection.waitForToolsUpdate(STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS);
+        if (this.connection instanceof ExtensionConnection) {
+          await this.connection.waitForToolsUpdate(STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS);
+        }
       }
 
       return {
@@ -385,7 +414,9 @@ export class VibeMcpServer {
         version: SERVER_VERSION,
         transport: 'http',
         mcpPath: this.config.httpPath,
-        extensionConnected: this.connection.isExtensionConnected(),
+        extensionConnected: this.connection instanceof DevtoolsFallbackConnection
+          ? this.connection.isAvailable()
+          : this.connection.isExtensionConnected(),
         cachedTools: this.connection.getTools().length,
       }));
     };

--- a/src/server.ts
+++ b/src/server.ts
@@ -210,7 +210,7 @@ export class VibeMcpServer {
     );
 
     server.setRequestHandler(ListToolsRequestSchema, async () => {
-      if (this.connection.getTools().length === 0 && this.connection.isExtensionConnected()) {
+      if (this.connection.getTools().length === 0) {
         try {
           await this.connection.refreshTools(STARTUP_TOOLS_REFRESH_TIMEOUT_MS);
         } catch (error) {
@@ -219,7 +219,7 @@ export class VibeMcpServer {
         }
       }
 
-      if (this.connection.getTools().length === 0 && this.connection.isExtensionConnected()) {
+      if (this.connection.getTools().length === 0) {
         await this.connection.waitForToolsUpdate(STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS);
       }
 
@@ -313,7 +313,7 @@ export class VibeMcpServer {
   }
 
   private async takeMarkdownSnapshot(pageId?: number): Promise<string | undefined> {
-    if (this.connection.getTools().length === 0 && this.connection.isExtensionConnected()) {
+    if (this.connection.getTools().length === 0) {
       try {
         await this.connection.refreshTools(STARTUP_TOOLS_REFRESH_TIMEOUT_MS);
       } catch {

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,10 @@ export interface ToolResult {
  */
 export type ToolResultContent =
   | { type: 'text'; text: string }
-  | { type: 'image'; data: string; mimeType: string };
+  | { type: 'image'; data: string; mimeType: string }
+  | { type: 'audio'; data: string; mimeType: string }
+  | { type: 'resource'; resource: unknown }
+  | { type: 'resource_link'; uri: string; name?: string };
 
 /**
  * Server configuration

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,8 @@ export interface ServerConfig {
   port: number;
   host: string;
   debug: boolean;
+  /** Use chrome-devtools-mcp directly and bypass relay/extension routing. */
+  devtools?: boolean;
   transport: ServerTransportMode;
   httpPort: number;
   httpPath: string;


### PR DESCRIPTION
Summary:
- add optional chrome-devtools-mcp fallback backend launched with --autoConnect
- run one shared fallback instance inside relay (RelayServer) and expose union tools (extension-first, deduped)
- route call_tool deterministically: extension tool when present, otherwise fallback tool
- support extension-absent mode by serving fallback tool surface through relay
- add CLI support for fallback-backed commands: resize, upload, dialog
- harden relay/CLI behavior for disconnects and async message handling
- add/update docs and relay CLI e2e coverage for resize/upload/dialog

Validation:
- npm run build
- npm run test:e2e:relay-race
- npm run test:e2e:relay-roundtrip
- npm run test:e2e:http
- npm run test:e2e:cli-relay
- npm test

Closes #45