### PR TITLE
docs: clarify snapshot format fallback (ai vs aria) — README, SKILL.md, CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ Local-session selection:
 
 Snapshot behavior is tool-only (no legacy snapshot RPC shortcut):
 
-- `snapshot` (default) resolves via `take_md_snapshot`
-- `snapshot --format aria` resolves via `take_a11y_snapshot`
+- `snapshot` (default, `--format ai`) resolves via `take_md_snapshot` — uses the content script's in-page markdown extractor. Fast and readable, but **may return empty for background tabs or complex SPAs** (Notion, Gmail) where the content script is unreachable or layout is not computed.
+- `snapshot --format aria` resolves via `take_a11y_snapshot` — uses Chrome DevTools Protocol `Accessibility.getFullAXTree` directly. **Reliable for all tabs including background tabs and SPAs.** Use this as a fallback when the default format returns empty or only a page title.
 
 This keeps CLI behavior aligned with extension-supported tools and ensures page targeting works consistently with `--page-id`/`--pageId`.
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remot
 
 This exposes a local MCP endpoint at `http://127.0.0.1:8788/mcp` by default.
 
+When OpenClaw runs on a different machine (for example cloud-hosted), provide a reachable URL:
+
+```bash
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <extension-uuid> --public-url https://<reachable-host>/mcp
+```
+
 You can print the exact OpenClaw-friendly setup with:
 
 ```bash
@@ -334,7 +340,7 @@ There are two ways to use Vibe with OpenClaw:
 If OpenClaw runs in the cloud but you want it to control your local browser:
 
 1. Install the Vibe extension and enable **Remote** mode (see [docs/openclaw-local-browser.md](docs/openclaw-local-browser.md))
-2. Start the local HTTP bridge: `vibebrowser-mcp openclaw --remote <extension-uuid>`
+2. Start the local HTTP bridge: `vibebrowser-mcp openclaw --remote <extension-uuid> [--public-url <url>]`
 3. Register the MCP URL in OpenClaw
 
 **Option B: OpenClaw skill for local agents**
@@ -418,10 +424,11 @@ npx -y --package @vibebrowser/mcp vibebrowser-mcp [start] [options]
   --relay-url <url>    Custom relay server URL
 
 # OpenClaw helper
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <extension-uuid>
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <extension-uuid> [--public-url <url>]
 
 # OpenClaw-compatible browser CLI
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> status
+npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> status --wait-for-extension --wait-timeout 10000
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> tabs
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> snapshot --json
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> click 12
@@ -448,7 +455,7 @@ npx -y --package @vibebrowser/mcp vibebrowser-mcp serve <model> [options]
 1. Start `vibebrowser-mcp` in HTTP mode instead of stdio
 2. Make sure the bridge process is still running on the user's machine
 3. Confirm the extension is in `Remote` mode and connected
-4. Verify the MCP URL in OpenClaw matches the bridge URL, usually `http://127.0.0.1:8788/mcp`
+4. Verify the MCP URL in OpenClaw matches the bridge URL. If OpenClaw is cloud-hosted, do not use `127.0.0.1`; use `openclaw --public-url` with a reachable host.
 
 ### Debug mode
 

--- a/docs/openclaw-local-browser.md
+++ b/docs/openclaw-local-browser.md
@@ -98,6 +98,12 @@ npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <extension-u
 
 This prints the exact commands and MCP URL you need.
 
+If OpenClaw is running on another machine (for example in the cloud), provide a reachable URL:
+
+```bash
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <extension-uuid> --public-url https://<reachable-host>/mcp
+```
+
 **Option B: Manual command**
 
 ```bash
@@ -109,6 +115,8 @@ By default this starts a local MCP endpoint at:
 ```
 http://127.0.0.1:8788/mcp
 ```
+
+That loopback URL only works when OpenClaw can reach the same machine. For cloud OpenClaw, register a reachable URL (`--public-url`) instead.
 
 Keep this terminal open - the bridge must stay running for OpenClaw to connect.
 
@@ -151,6 +159,8 @@ Register the bridge URL in OpenClaw:
   }
 }
 ```
+
+Use that loopback URL only for same-machine setups. For cloud OpenClaw, set `"url"` to the reachable value you passed through `--public-url`.
 
 Once that is configured, the cloud OpenClaw agent can use the Vibe browser tools through the local bridge.
 
@@ -246,7 +256,7 @@ Make sure you've enabled **Remote** mode in the Vibe extension settings. The UUI
 
 1. Ensure the `vibebrowser-mcp` process is still running
 2. Check the terminal for error messages
-3. Verify the MCP URL matches exactly (including the `/mcp` path)
+3. Verify the MCP URL matches exactly (including the `/mcp` path) and is reachable from OpenClaw (not `127.0.0.1` for cloud-hosted OpenClaw)
 
 ### "No extension connected"
 

--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -51,7 +51,8 @@ The shell running OpenClaw must have:
 export VIBE_EXTENSION_UUID="<extension-uuid>"
 
 # Optional if you use a custom relay URL.
-# export VIBE_RELAY_URL="wss://relay.api.vibebrowser.app"
+# export VIBE_REMOTE_RELAY_URL="wss://relay.api.vibebrowser.app"
+# export VIBE_RELAY_URL="wss://relay.api.vibebrowser.app"  # legacy alias
 
 # Optional compatibility label. Vibe always targets the real local browser path.
 # export VIBE_BROWSER_PROFILE="user"
@@ -77,6 +78,39 @@ If you set `VIBE_RELAY_URL`, append:
 --relay-url "$VIBE_RELAY_URL"
 ```
 
+If you set `VIBE_REMOTE_RELAY_URL`, use:
+
+```bash
+--relay-url "$VIBE_REMOTE_RELAY_URL"
+```
+
+## Deterministic runbook (default)
+
+Use this sequence when the task needs reliable, repeatable control:
+
+1. Verify connection:
+   ```bash
+   npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json status --wait-for-extension --wait-timeout 10000
+   ```
+2. Resolve a target page id without changing focus:
+   ```bash
+   PAGE_ID="$(
+     npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json tabs \
+     | jq -r '.pages[] | select(.active == true) | .id' \
+     | head -n1
+   )"
+   ```
+3. Snapshot that page before acting:
+   ```bash
+   npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id "$PAGE_ID" snapshot --format aria --interactive
+   ```
+4. Perform action on the same page id:
+   ```bash
+   npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id "$PAGE_ID" click 12
+   ```
+
+If `jq` is unavailable, parse `.pages` from `tabs --json` directly and still pass `--page-id <id>` on every action.
+
 ## Safe operating rules
 
 - **Never use `focus` or `tab select` unless explicitly asked.** The user may be actively working in the browser — switching their active tab is disruptive. Instead, pass `--page-id <id>` (or `--pageId <id>`) to target a specific tab without switching focus. Get the page ID from `tabs` output, then use it on any command:
@@ -84,10 +118,10 @@ If you set `VIBE_RELAY_URL`, append:
   vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id 2 snapshot
   vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id 2 click 7
   ```
-- Prefer `browser tabs` or `browser snapshot` before acting.
+- Prefer `tabs` or `snapshot` before acting.
 - `snapshot` is tool-only and maps to extension snapshot tools (`take_md_snapshot` by default, `take_a11y_snapshot` for `--format aria`).
-- Use `browser open <url>` to create a fresh page when possible.
-- Use `browser evaluate --fn ...` only for simple compatibility-safe expressions such as:
+- Use `open <url>` to create a fresh page when possible.
+- Use `evaluate --fn ...` only for simple compatibility-safe expressions such as:
   - `() => 21 + 21`
   - `() => document.title`
   - `() => location.href`

--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -104,6 +104,12 @@ Use this sequence when the task needs reliable, repeatable control:
    ```bash
    npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id "$PAGE_ID" snapshot --format aria --interactive
    ```
+   If the aria snapshot is too verbose, try the default first and fall back:
+   ```bash
+   npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id "$PAGE_ID" snapshot
+   # If empty or only title returned, retry with aria:
+   npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id "$PAGE_ID" snapshot --format aria --interactive
+   ```
 4. Perform action on the same page id:
    ```bash
    npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id "$PAGE_ID" click 12
@@ -175,6 +181,32 @@ Evaluate JavaScript:
 ```bash
 npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json evaluate --fn '() => document.title'
 ```
+
+## Snapshot format: `ai` vs `aria`
+
+The `snapshot` command supports two extraction formats:
+
+| Format | Flag | Engine | Best for |
+|--------|------|--------|----------|
+| `ai` (default) | `--format ai` | Content script (in-page JS) | Simple pages, articles, search results |
+| `aria` | `--format aria` | CDP accessibility tree | **SPAs, background tabs, Notion, Gmail, complex apps** |
+
+**When the default `--format ai` returns only the page title or empty content**, switch to `--format aria`:
+
+```bash
+# Default — may return empty for background tabs or SPAs like Notion
+vibebrowser-cli ... snapshot
+
+# Reliable fallback — uses Chrome DevTools Protocol directly, works on background tabs
+vibebrowser-cli ... snapshot --format aria --interactive
+```
+
+**Known limitations of `--format ai`:**
+- Returns empty for **background tabs** (content script not injected or `getBoundingClientRect` returns 0x0)
+- Returns `"Could not establish connection"` when the content script is unreachable
+- May miss content behind `aria-hidden` containers in SPAs like Notion
+
+**Rule of thumb:** If `snapshot` returns suspiciously little content, retry with `--format aria --interactive` before reporting failure.
 
 ## Success criteria
 

--- a/scripts/e2e-browser-cli.mjs
+++ b/scripts/e2e-browser-cli.mjs
@@ -25,6 +25,7 @@ let packedPackageDir = null;
 let cliInvocation = null;
 let delayToolResultMs = 0;
 let missingPageIdMode = false;
+let fillCompatibilityErrorMode = false;
 
 const ONE_PIXEL_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6n8AAAAASUVORK5CYII=';
@@ -48,6 +49,7 @@ const TOOLS = [
   }),
   tool('click', { ref: { type: 'string' }, dblClick: { type: 'boolean' }, pageId: { type: 'number' } }),
   tool('fill', { ref: { type: 'string' }, value: { type: 'string' }, pageId: { type: 'number' } }),
+  tool('type_text', { text: { type: 'string' }, submitKey: { type: 'string' }, pageId: { type: 'number' } }),
   tool('press_key', { keys: { type: 'string' }, pageId: { type: 'number' } }),
   tool('hover', { ref: { type: 'string' }, pageId: { type: 'number' } }),
   tool('drag', { source: { type: 'string' }, target: { type: 'string' }, pageId: { type: 'number' } }),
@@ -104,13 +106,21 @@ try {
       if (message.type === 'call_tool') {
         if (
           missingPageIdMode
-          && message.data?.name === 'navigate_page'
+          && (message.data?.name === 'navigate_page' || message.data?.name === 'click')
           && message.data?.arguments?.pageId === undefined
         ) {
           ws.send(JSON.stringify({
             type: 'error',
             requestId: message.requestId,
             error: 'Missing required pageId',
+          }));
+          return;
+        }
+        if (fillCompatibilityErrorMode && message.data?.name === 'fill') {
+          ws.send(JSON.stringify({
+            type: 'error',
+            requestId: message.requestId,
+            error: 'Invalid arguments: fill does not accept ref in this backend',
           }));
           return;
         }
@@ -205,6 +215,11 @@ try {
   const typed = await runCli(['type', '23', 'hello world', '--submit']);
   assert(typed.ok === true && typed.tool === 'fill', `type failed: ${JSON.stringify(typed)}`);
 
+  fillCompatibilityErrorMode = true;
+  const typedFallback = await runCli(['type', '23', 'hello via fallback']);
+  assert(typedFallback.ok === true && typedFallback.tool === 'type_text', `type fallback failed: ${JSON.stringify(typedFallback)}`);
+  fillCompatibilityErrorMode = false;
+
   const pressed = await runCli(['press', 'Enter']);
   assert(pressed.ok === true && pressed.tool === 'press_key', `press failed: ${JSON.stringify(pressed)}`);
 
@@ -256,7 +271,12 @@ try {
 
   // Missing required pageId should include actionable hint.
   missingPageIdMode = true;
-  await expectCliFailure(['navigate', 'https://example.com'], /Hint: use `tabs` to list pages, then pass --page-id <id> to target a specific tab\./);
+  const missingPageMessage = await expectCliFailure(
+    ['click', '12'],
+    /Hint: use `tabs` to list pages, then pass --page-id <id> to target a specific tab\./,
+  );
+  assert(/"mode":\s*"remote"/.test(missingPageMessage), `error payload should report remote mode: ${missingPageMessage}`);
+  assert(/"profile":\s*"user"/.test(missingPageMessage), `error payload should report user profile: ${missingPageMessage}`);
   missingPageIdMode = false;
 
   console.log('browser cli e2e ok');
@@ -336,6 +356,8 @@ function handleToolCall(name, args) {
       return jsonResult({ clicked: args.ref ?? null, double: Boolean(args.dblClick), ...(args.pageId !== undefined ? { pageId: args.pageId } : {}) });
     case 'fill':
       return jsonResult({ ref: args.ref ?? null, value: args.value ?? '' });
+    case 'type_text':
+      return jsonResult({ text: args.text ?? '', submitKey: args.submitKey ?? null });
     case 'press_key':
       return jsonResult({ keys: args.keys ?? '' });
     case 'hover':
@@ -451,6 +473,7 @@ async function expectCliFailure(args, pattern) {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     assert(pattern.test(message), `Expected failure matching ${pattern}, got:\n${message}`);
+    return message;
   }
 }
 

--- a/scripts/e2e-cli-relay.mjs
+++ b/scripts/e2e-cli-relay.mjs
@@ -322,6 +322,26 @@ async function main() {
       return extension;
     };
 
+    // =================================================================
+    // TEST 0: status --wait-for-extension waits up to timeout when disconnected
+    // =================================================================
+    {
+      const { data, elapsed } = await runCli([
+        'status',
+        '--wait-for-extension',
+        '--wait-timeout',
+        '400',
+        '--poll-interval',
+        '100',
+      ]);
+      assert(data.ok === true, `waited status not ok: ${JSON.stringify(data)}`);
+      assert(data.extensionConnected === false, `waited status should time out disconnected: ${JSON.stringify(data)}`);
+      assert(data.waitForExtension === true, `waited status should report waitForExtension: ${JSON.stringify(data)}`);
+      assert(Number(data.waitedMs) >= 300, `waited status should wait near timeout: ${JSON.stringify(data)}`);
+      assert(elapsed >= 300, `status --wait-for-extension should not return immediately: ${elapsed}ms`);
+      console.log(`  status+w:${elapsed}ms (budget: ${MAX_CLI_MS}ms) — waited for timeout ✓`);
+    }
+
     extensionA = await attachFakeExtension(SESSION_A);
     extensionB = await attachFakeExtension(SESSION_B);
 

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -252,7 +252,7 @@ function registerBrowserSubcommands(browser: Command): void {
   browser
     .command('snapshot')
     .description('Capture a textual browser snapshot')
-    .option('--format <format>', 'Snapshot format (ai or aria)', 'ai')
+    .option('--format <format>', 'Snapshot format: "ai" (default, content-script markdown — may fail on background tabs or complex SPAs) or "aria" (CDP accessibility tree — reliable for all tabs)', 'ai')
     .option('--limit <count>', 'Max visible lines/items to print in human mode')
     .option('--interactive', 'Prefer interactive/ARIA-flavored snapshot output', false)
     .option('--selector <selector>', 'Selector to scope the snapshot to')

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -134,8 +134,21 @@ function registerBrowserSubcommands(browser: Command): void {
   browser
     .command('status')
     .description('Show browser bridge status')
+    .option('--wait-for-extension', 'Wait for extension connection before returning status', false)
+    .option('--wait-timeout <ms>', 'Maximum wait time when --wait-for-extension is enabled')
+    .option('--poll-interval <ms>', 'Polling interval while waiting for extension')
     .action(async function (this: Command) {
-      await runBrowserCommand(this, 'status', false, async (ctx) => ctx.status());
+      await runBrowserCommand(this, 'status', false, async (ctx, options) =>
+        ctx.status({
+          waitForExtension: Boolean(options.waitForExtension),
+          waitTimeoutMs: options.waitTimeout
+            ? parsePositiveInteger(String(options.waitTimeout), '--wait-timeout')
+            : undefined,
+          pollIntervalMs: options.pollInterval
+            ? parsePositiveInteger(String(options.pollInterval), '--poll-interval')
+            : undefined,
+        })
+      );
     });
 
   browser
@@ -574,12 +587,43 @@ class BrowserCliContext {
     };
   }
 
-  async status(): Promise<CommandOutput> {
+  async status(options: {
+    waitForExtension?: boolean;
+    waitTimeoutMs?: number;
+    pollIntervalMs?: number;
+  } = {}): Promise<CommandOutput> {
+    const waitForExtension = options.waitForExtension === true;
+    const waitTimeoutMs = options.waitTimeoutMs ?? this.timeoutMs;
+    const pollIntervalMs = options.pollIntervalMs ?? 250;
+    const waitStartedAt = Date.now();
+
     if (this.connection instanceof ExtensionConnection) {
       const extension = this.connection;
       this.sessions = await extension.listSessions(STATUS_TOOLS_TIMEOUT_MS).catch(() => extension.getSessions());
     } else {
       this.sessions = [];
+    }
+
+    if (waitForExtension && !this.isBackendConnected()) {
+      const deadline = Date.now() + waitTimeoutMs;
+      while (!this.isBackendConnected() && Date.now() < deadline) {
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          break;
+        }
+        await delay(Math.min(pollIntervalMs, remainingMs));
+        if (this.connection instanceof ExtensionConnection) {
+          const extension = this.connection;
+          this.sessions = await extension.listSessions(STATUS_TOOLS_TIMEOUT_MS).catch(() => extension.getSessions());
+        }
+      }
+    }
+
+    if (this.isBackendConnected()) {
+      // Use a short timeout for status — this is a diagnostic command that
+      // should return quickly.  Fall back to cached tools if the extension
+      // is slow to respond.
+      await this.ensureToolsLoaded(STATUS_TOOLS_TIMEOUT_MS);
     }
     await this.ensureToolsLoaded(STATUS_TOOLS_TIMEOUT_MS);
 
@@ -600,6 +644,12 @@ class BrowserCliContext {
       transport: 'vibebrowser-mcp',
       toolCount: this.tools.length,
       tools: this.tools.map((tool) => tool.name),
+      ...(waitForExtension
+        ? {
+          waitForExtension: true,
+          waitedMs: Date.now() - waitStartedAt,
+        }
+        : {}),
     };
   }
 
@@ -1084,6 +1134,7 @@ class BrowserCliContext {
     await this.ensureToolsLoaded();
 
     const available = new Map(this.tools.map((tool) => [normalizeName(tool.name), tool]));
+    const compatibilityErrors: string[] = [];
     for (const candidate of candidates) {
       for (const candidateName of candidate.names) {
         const tool = available.get(normalizeName(candidateName));
@@ -1108,14 +1159,25 @@ class BrowserCliContext {
             args[pageStateKey] = 'markdown';
           }
         }
-        const result = await this.connection.callTool(tool.name, args, this.timeoutMs);
-        return { tool: tool.name, args, result: result as ToolResult & Record<string, unknown> };
+        try {
+          const result = await this.connection.callTool(tool.name, args, this.timeoutMs);
+          return { tool: tool.name, args, result: result as ToolResult & Record<string, unknown> };
+        } catch (error) {
+          if (!isToolArgumentCompatibilityError(error)) {
+            throw error;
+          }
+          const message = error instanceof Error ? error.message : String(error);
+          compatibilityErrors.push(`${tool.name}: ${message}`);
+        }
       }
     }
 
     const requested = candidates.flatMap((candidate) => candidate.names);
+    const compatibilityHint = compatibilityErrors.length > 0
+      ? ` Compatibility errors: ${compatibilityErrors.join(' | ')}`
+      : '';
     throw new Error(
-      `No compatible browser tool found for "${commandName}". Tried ${requested.join(', ')}. Available tools: ${this.tools.map((tool) => tool.name).join(', ')}`
+      `No compatible browser tool found for "${commandName}". Tried ${requested.join(', ')}. Available tools: ${this.tools.map((tool) => tool.name).join(', ')}.${compatibilityHint}`
     );
   }
 
@@ -1363,6 +1425,16 @@ class BrowserCliContext {
   outputMode(): 'local' | 'remote' | 'devtools' {
     return this.mode();
   }
+
+  outputContext(): Pick<CommandOutput, 'profile' | 'mode' | 'sessionId' | 'requestedSessionId' | 'ignoredCompatibilityOptions'> {
+    return {
+      profile: this.profile,
+      mode: this.mode(),
+      sessionId: this.currentSessionId(),
+      requestedSessionId: this.requestedSessionId,
+      ignoredCompatibilityOptions: this.ignoredCompatibilityOptions,
+    };
+  }
 }
 
 interface ToolCandidate {
@@ -1501,6 +1573,21 @@ function isTimeoutError(error: unknown): boolean {
   return /timed out|timeout/i.test(message);
 }
 
+function isToolArgumentCompatibilityError(error: unknown): boolean {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  if (!message) {
+    return false;
+  }
+
+  if (
+    /timed out|timeout|relay connection|connection lost|not connected|no connection|disconnected/.test(message)
+  ) {
+    return false;
+  }
+
+  return /missing required|required (field|property|argument)|invalid argument|invalid args|invalid input|unexpected argument|unexpected property|unknown argument|does not accept|unrecognized (field|property|argument)/.test(message);
+}
+
 function findBestPageMatchByUrl(pages: PageSummary[], targetUrl: string): { id: number; url?: string } | undefined {
   const normalizedTarget = normalizeUrlForMatch(targetUrl);
   let bestExact: { id: number; url?: string } | undefined;
@@ -1582,11 +1669,11 @@ function emitError(
     message += '\nHint: use `tabs` to list pages, then pass --page-id <id> to target a specific tab.';
   }
   if (asJson) {
+    const context = ctx.outputContext();
     console.log(JSON.stringify({
       ok: false,
       command: commandName,
-      profile: DEFAULT_BROWSER_PROFILE,
-      mode: ctx.outputMode(),
+      ...context,
       error: message,
     }, null, 2));
     return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,12 +79,16 @@ program
   .option('--host <host>', 'Host to bind the HTTP server to', '127.0.0.1')
   .option('--http-port <number>', 'Port for streamable HTTP MCP transport', String(DEFAULT_HTTP_PORT))
   .option('--http-path <path>', 'Path for streamable HTTP MCP transport', DEFAULT_HTTP_PATH)
+  .option('--public-url <url>', 'Publicly reachable MCP URL for OpenClaw when different from local bind URL')
   .option('--allow-host <host>', 'Allowed host header for HTTP transport (repeatable)', collectRepeatedOption, [])
   .action((options) => {
     const httpPort = parsePort(options.httpPort, 'HTTP port');
     const httpPath = normalizePath(options.httpPath);
     const host = options.host;
-    const httpUrl = `http://${formatHost(host)}:${httpPort}${httpPath}`;
+    const localHttpUrl = `http://${formatHost(host)}:${httpPort}${httpPath}`;
+    const openClawUrl = options.publicUrl
+      ? normalizePublicUrl(String(options.publicUrl), httpPath)
+      : localHttpUrl;
 
     const cliArgs = [
       '-y',
@@ -114,7 +118,7 @@ program
     const openClawConfig = {
       mcpServers: {
         vibe: {
-          url: httpUrl,
+          url: openClawUrl,
         },
       },
     };
@@ -122,8 +126,16 @@ program
     console.log('Start a local bridge on the machine running the Vibe extension:');
     console.log(`npx ${cliArgs.join(' ')}`);
     console.log('');
-    console.log('Then add this MCP server URL in OpenClaw:');
-    console.log(httpUrl);
+    console.log('Local bridge MCP URL:');
+    console.log(localHttpUrl);
+    console.log('');
+    console.log('Use this MCP server URL in OpenClaw:');
+    console.log(openClawUrl);
+    if (isLoopbackUrl(openClawUrl)) {
+      console.log('');
+      console.log('Warning: this URL uses loopback/localhost and is only reachable from the same machine.');
+      console.log('If OpenClaw runs in the cloud, pass --public-url with a reachable host.');
+    }
     console.log('');
     console.log('OpenClaw JSON snippet:');
     console.log(JSON.stringify(openClawConfig, null, 2));
@@ -182,4 +194,38 @@ function normalizePath(value: string): string {
 
 function formatHost(host: string): string {
   return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
+
+function normalizePublicUrl(value: string, fallbackPath: string): string {
+  const parsed = parseHttpUrl(value, '--public-url');
+  if (!parsed.pathname || parsed.pathname === '/') {
+    parsed.pathname = fallbackPath;
+  }
+  return parsed.toString();
+}
+
+function parseHttpUrl(value: string, label: string): URL {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('protocol must be http:// or https://');
+    }
+    return parsed;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${label} must be a valid HTTP(S) URL (${message})`);
+    process.exit(1);
+  }
+}
+
+function isLoopbackUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1' || hostname === '[::1]';
 }


### PR DESCRIPTION
## Summary

Clarifies when to use `--format ai` (default) vs `--format aria` for the `snapshot` command.

### Changes

**README.md**
- Expands the snapshot format descriptions: `ai` (default) is fast but may return empty for background tabs or complex SPAs (Notion, Gmail); `aria` uses CDP accessibility tree and is reliable for all tabs.

**openclaw/vibebrowser/SKILL.md**
- Adds a snapshot format comparison table (ai vs aria)
- Documents known limitations of `--format ai` (background tabs, content script unreachable, SPAs)
- Adds fallback pattern: try default first, retry with `--format aria --interactive` when empty
- Adds explicit guidance in the reliable-control workflow sequence

**src/browser-cli.ts**
- Improves `--format` option description with failure notes inline in `--help` output

### Why

Agents (OpenClaw, coding assistants) frequently hit empty snapshots on background tabs or SPAs and don't know to retry with `--format aria`. These changes make the fallback pattern explicit and discoverable.