### PR TITLE
fix: remove __skipPageContent injection from connection layer

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -37,30 +37,6 @@ const RELAY_RECONNECT_DELAY = 2000;
 
 const DEFAULT_RELAY_URL = 'wss://relay.api.vibebrowser.app';
 
-function hasExplicitPageContext(args: Record<string, unknown>): boolean {
-  const candidates = [args.tabId, args.pageId, args.tab_id, args.page_id];
-  return candidates.some((candidate) => {
-    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
-      return true;
-    }
-    if (typeof candidate === 'string') {
-      return /^\d+$/.test(candidate.trim());
-    }
-    return false;
-  });
-}
-
-function withImplicitPageCaptureGuard(args: Record<string, unknown>): Record<string, unknown> {
-  if (args.__skipPageContent === true || hasExplicitPageContext(args)) {
-    return args;
-  }
-
-  return {
-    ...args,
-    __skipPageContent: true,
-  };
-}
-
 /**
  * Remote relay configuration
  */
@@ -555,7 +531,7 @@ export class ExtensionConnection extends EventEmitter {
   async callTool(name: string, args: Record<string, unknown>, timeoutMs?: number): Promise<ToolResult> {
     return this.sendRequest<ToolResult>(
       'call_tool',
-      { name, arguments: withImplicitPageCaptureGuard(args) },
+      { name, arguments: args },
       timeoutMs,
     );
   }


### PR DESCRIPTION
## Summary

Removes the `__skipPageContent` mechanism from the connection layer. This was a workaround that:
1. Suppressed page content from the extension for ALL tool calls without explicit page context
2. Then re-captured it via a separate `take_md_snapshot` call in `withFallbackPageContent` -- doubling relay round-trips

## Root Cause

The real issue (VibeTechnologies/VibeWebAgent#1218) was that the extension's `shouldAppendPageContent()` tried to capture page content after `new_page` with `waitForReady=false`, triggering DOM stabilization waits on a page that hadn't loaded yet. This is fixed in VibeTechnologies/VibeWebAgent#1222.

## Changes

- Remove `withImplicitPageCaptureGuard()` function
- Remove `hasExplicitPageContext()` helper (only used by the guard)
- `callTool()` now passes args directly without injecting `__skipPageContent`
- `withFallbackPageContent` in server.ts is kept as a harmless safety net

## Related

- VibeTechnologies/VibeWebAgent#1218 (CLI hang issue)
- VibeTechnologies/VibeWebAgent#1222 (extension-side fix)