### PR TITLE
feat: @vibebrowser/cli package + simplified --remote + set_remote MCP tool

### DIFF
--- a/.agents/knowledgebase/README.md
+++ b/.agents/knowledgebase/README.md
@@ -1,0 +1,17 @@
+# vibe-mcp Knowledgebase
+
+Concise reference for future agents working in this repository. Application code is TypeScript under `src/`; this knowledgebase only summarizes existing repo facts.
+
+## Files
+
+- `architecture.md` - components, relay paths, source layout, and remote relay concepts.
+- `operations.md` - common commands, tests/evals, publishing/docs locations, and debugging notes.
+
+## Canonical References
+
+- `README.md` - user-facing setup, supported MCP clients, tools, CLI modes, and HTTP transport examples.
+- `AGENTS.md` - production debugging memory, relay invariants, and minimum/full eval expectations.
+- `docs/eval.md` - canonical eval matrix, source selectors, pass criteria, and latest verification notes.
+- `docs/openclaw-local-browser.md` - OpenClaw/local browser bridge setup and CLI examples.
+- `docs/chrome-devtools-relay.md` - remote relay system design and security model.
+- `openclaw/vibebrowser/SKILL.md` - OpenClaw-compatible skill shipped in the npm package.

--- a/.agents/knowledgebase/architecture.md
+++ b/.agents/knowledgebase/architecture.md
@@ -1,0 +1,69 @@
+# Architecture
+
+## Purpose
+
+`@vibebrowser/mcp` is a Node/TypeScript MCP server package that lets AI agents control a user's Vibe-connected Chrome/Chromium browser. Direct browser CLI docs use the separate `@vibebrowser/cli` package. It supports multiple agents by routing through a shared relay instead of each agent owning a browser connection.
+
+## Main Entry Points
+
+- Package binaries from `package.json`: `vibebrowser-mcp`, legacy alias `vibe-mcp`, and standalone `vibebrowser-cli`.
+- `src/cli.ts`: MCP server CLI. Default command is `start`; supports stdio and streamable HTTP transports, local relay mode, remote relay mode, `--devtools`, and `openclaw` config printing.
+- `src/server.ts`: MCP protocol server. Exposes tool listing/calling over stdio or HTTP and delegates to an extension/relay connection or Chrome DevTools fallback.
+- `src/browser-main.ts` and `src/browser-cli.ts`: OpenClaw-compatible browser CLI surface for status, sessions, tabs, open/navigate, snapshots, clicks, typing, upload/drop, network, and evaluation helpers.
+- `src/relay-daemon.ts` starts the local relay daemon; `src/relay.ts` implements relay multiplexing.
+
+## Local Relay Model
+
+Default local flow:
+
+```text
+MCP client -> vibebrowser-mcp stdio -> local relay agent WS :19888 -> local relay extension WS :19889 -> Vibe extension -> user's browser
+```
+
+Key facts:
+
+- Agent WebSocket port defaults to `19888`; extension WebSocket port defaults to `19889`.
+- Ports can be overridden with `VIBE_MCP_AGENT_PORT` and `VIBE_MCP_EXTENSION_PORT`.
+- Relay state/log files live under `~/.vibe-mcp` by default, overridable with `VIBE_MCP_STATE_DIR`.
+- One local relay daemon can serve many agent connections.
+- The relay can track extension sessions and lets CLIs target a session with `--session <id>`.
+- The relay owns a single shared `chrome-devtools-mcp` fallback backend so concurrent clients do not spawn competing fallback processes.
+
+## Extension Socket Invariants
+
+- The relay has many agent sockets and extension sessions keyed by session id.
+- When an extension socket is replaced or disconnects, stale `close` events from old sockets must not clear the current active session.
+- Pending requests must be rejected for the disconnected session rather than allowed to hang or be attributed to a later reconnect.
+- If failures say `No extension connected`, inspect relay state transitions and logs before changing prompts or agent behavior.
+
+## Remote Relay Model
+
+Remote mode connects to the public relay instead of the local relay daemon:
+
+```text
+MCP client or @vibebrowser/cli -> wss://relay.api.vibebrowser.app/<extension-uuid> -> Vibe extension remote mode -> user's browser
+```
+
+Key facts:
+
+- `src/connection.ts` defaults remote relay URL base to `wss://relay.api.vibebrowser.app`.
+- `--remote <uuid>` uses the default public relay.
+- `--remote <full-ws-url>` targets an explicit relay endpoint.
+- `@vibebrowser/cli` also reads the remote value from `VIBE_REMOTE_URL`.
+- The extension UUID in the relay URL identifies a browser session; it is not a secret by itself.
+- Remote mode is for reaching the user's real local browser from a client or bridge that cannot use the local relay directly.
+
+## HTTP Bridge And OpenClaw
+
+`vibebrowser-mcp start --transport http` exposes streamable HTTP MCP on `http://127.0.0.1:8788/mcp` by default. `vibebrowser-mcp openclaw --remote <uuid>` and `vibebrowser-mcp openclaw --remote <full-ws-url>` print OpenClaw-friendly commands and MCP JSON snippets. The running MCP server also exposes a `set_remote { "url": "wss://relay.api.vibebrowser.app/<uuid>" }` tool for hot-reconnecting without restarting.
+
+Use this split from `docs/openclaw-local-browser.md`:
+
+- Tenant browser in cloud: use the tenant `/browser` stack.
+- User's real local browser: use Vibe extension + relay + `vibebrowser-mcp` HTTP bridge or `@vibebrowser/cli`.
+
+## Chrome DevTools Fallback
+
+- `chrome-devtools-mcp` is an optional dependency.
+- `--devtools` bypasses extension/relay routing and uses only the Chrome DevTools backend.
+- In normal local relay mode, fallback tools are used only when the extension is unavailable/disconnected; extension tools are authoritative when connected.

--- a/.agents/knowledgebase/operations.md
+++ b/.agents/knowledgebase/operations.md
@@ -1,0 +1,65 @@
+# Operations
+
+## Common Commands
+
+- Install dependencies: `npm install`
+- Build: `npm run build`
+- TypeScript watch: `npm run dev`
+- Start local stdio MCP server from built output: `npm start`
+- Start HTTP MCP endpoint: `npm run build && node dist/cli.js start --transport http`
+- Print OpenClaw bridge config: `npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <uuid>` or `npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <full-ws-url>`
+- Standalone CLI status: `npx @vibebrowser/cli --remote <uuid> --json status`
+- Standalone CLI tabs: `npx @vibebrowser/cli --remote <full-ws-url> --json tabs`
+- Prefer `--page-id <id>` for browser actions to avoid disrupting the user's active tab.
+
+## Test And Eval Commands
+
+- Full local test script: `npm test`
+- Relay race regression: `npm run test:e2e:relay-race`
+- Relay roundtrip: `npm run test:e2e:relay-roundtrip`
+- CLI relay: `npm run test:e2e:cli-relay`
+- Streamable HTTP MCP: `npm run test:e2e:http`
+- Browser CLI fake-extension harness: `npm run test:e2e:browser-cli`
+- Agent harness with real extension: `npm run test:e2e:agents`
+- Debug agent harness: `E2E_DEBUG=1 npm run test:e2e:agents`
+- Live browser CLI regression: `npm run test:e2e:browser-cli-live`
+- DevTools flag harness: `npm run test:e2e:devtools-flag`
+
+Pass signals from `docs/eval.md` and `AGENTS.md`:
+
+- `npm test` should exit `0` and include `e2e ok`, `http e2e ok`, and `browser cli e2e ok`.
+- Meaningful MCP e2e is not just `list_tools`; it must prove `call_tool` reaches extension/fallback and returns the expected payload.
+- Real-extension tests require an active Vibe extension session with MCP External enabled; failures waiting for extension connection can be environment-only.
+- Full behavioral eval lives in sibling repo `../vibe`, not here: `cd ../vibe && node tests/mcp-eval.test.js --skip-build --model github-copilot/gpt-4.1`.
+- Full scenario sweep in sibling repo: `cd ../vibe && node tests/eval.test.js --headless --model github-copilot/gpt-4.1`.
+
+## Source Selectors
+
+- Browser CLI harness supports `E2E_BROWSER_CLI_SOURCE=local|pack|npm` and optional `E2E_BROWSER_CLI_PACKAGE=<tgz>`.
+- MCP agent harness supports `E2E_MCP_SOURCE=local|pack|npm` and optional `E2E_MCP_PACKAGE=<tgz>`.
+- Cross-repo `../vibe/tests/mcp-eval.test.js` supports `--mcp-source auto|local|pack|npm` and `--mcp-package <tarball-or-package-spec>`.
+- Use `pack` mode for release candidates before publishing.
+
+## Publishing And Packaged Files
+
+- `prepublishOnly` runs `npm run build`.
+- Published npm package includes `dist`, `openclaw`, `docs`, `README.md`, and `LICENSE`.
+- Current MCP package binaries are `vibebrowser-mcp`, `vibe-mcp`, and `vibebrowser-cli`; normal direct browser CLI docs use the separate `@vibebrowser/cli` package.
+- Package smoke check pattern: create a tarball with `npm pack --json --pack-destination <tmp>` and verify `vibebrowser-mcp --help` plus browser CLI help via the relevant package under test.
+- `docs/eval.md` records npm/publish verification history and should be updated when evaluation scope or pass criteria changes.
+
+## Docs And Skill Locations
+
+- User docs: `README.md`.
+- Eval runbook: `docs/eval.md`.
+- Remote relay design: `docs/chrome-devtools-relay.md`.
+- OpenClaw/local browser article: `docs/openclaw-local-browser.md`.
+- Shipped OpenClaw skill: `openclaw/vibebrowser/SKILL.md`.
+- The OpenClaw skill is installed by copying `openclaw/vibebrowser/SKILL.md` to an OpenClaw skills directory, typically `~/.openclaw/skills/` or a project `openclaw/skills/` folder.
+
+## Debugging Notes
+
+- Use `E2E_DEBUG=1` to start relay daemon with debug logging in relevant harnesses.
+- Inspect relay logs around `call_tool` before changing agent prompts.
+- Fake extension harnesses should register message handlers before waiting on socket `open`, periodically announce `tools_list`, reconnect on socket close, and never treat stale `No connection` payloads as final success.
+- If default `vibebrowser-cli snapshot` returns little content, retry with `snapshot --format aria --interactive`.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,12 @@ on:
     paths:
       - 'src/**'
       - 'package.json'
+      - 'package-lock.json'
       - 'openclaw/**'
+      - 'docs/**'
+      - 'packages/cli/**'
+      - 'scripts/prepare-cli-package.mjs'
+      - '.github/workflows/publish.yml'
   release:
     types: [published]
   workflow_dispatch:
@@ -36,32 +41,78 @@ jobs:
       - name: Build
         run: npm run build
       
-      - name: Check if version changed
-        id: version
+      - name: Check package versions
+        id: versions
+        shell: bash
         run: |
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          NPM_VERSION=$(npm view @vibebrowser/mcp version 2>/dev/null || echo "0.0.0")
-          echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          echo "npm=$NPM_VERSION" >> $GITHUB_OUTPUT
-          if [ "$CURRENT_VERSION" != "$NPM_VERSION" ]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
+          set -euo pipefail
+
+          check_package() {
+            local key="$1"
+            local package_name="$2"
+            local package_dir="$3"
+            local current_version
+            local npm_version
+            local published
+            local out
+            local err
+
+            current_version=$(node -p "require('./${package_dir}/package.json').version")
+            out=$(mktemp)
+            err=$(mktemp)
+
+            if npm view "$package_name@$current_version" version >"$out" 2>"$err"; then
+              npm_version=$(tr -d '[:space:]' <"$out")
+              published=true
+            elif grep -qiE 'E404|404 Not Found|Not found' "$err"; then
+              npm_version="unpublished"
+              published=false
+            else
+              echo "Unable to determine whether $package_name@$current_version is published." >&2
+              cat "$err" >&2
+              echo "Check npm access/network for @vibebrowser/mcp and @vibebrowser/cli." >&2
+              rm -f "$out" "$err"
+              exit 1
+            fi
+
+            rm -f "$out" "$err"
+
+            echo "${key}_name=$package_name" >> "$GITHUB_OUTPUT"
+            echo "${key}_dir=$package_dir" >> "$GITHUB_OUTPUT"
+            echo "${key}_current=$current_version" >> "$GITHUB_OUTPUT"
+            echo "${key}_npm=$npm_version" >> "$GITHUB_OUTPUT"
+            echo "${key}_published=$published" >> "$GITHUB_OUTPUT"
+            if [ "$published" != "true" ]; then
+              echo "${key}_changed=true" >> "$GITHUB_OUTPUT"
+              echo "$package_name version $current_version needs publishing (exact version not found on npm)"
+            else
+              echo "${key}_changed=false" >> "$GITHUB_OUTPUT"
+              echo "$package_name version $current_version already published"
+            fi
+          }
+
+          check_package "root" "@vibebrowser/mcp" "."
+          check_package "cli" "@vibebrowser/cli" "packages/cli"
       
       - name: Publish to npm
         id: publish
-        if: steps.version.outputs.changed == 'true'
+        if: steps.versions.outputs.root_changed == 'true' || steps.versions.outputs.cli_changed == 'true'
         shell: bash
         run: |
           set -euo pipefail
 
           publish_with_oidc() {
-            npm publish --provenance --access public
+            local package_name="$1"
+            local package_dir="$2"
+            echo "Attempting npm publish for $package_name from $package_dir via OIDC trusted publishing..."
+            (cd "$package_dir" && env -u NODE_AUTH_TOKEN npm publish --provenance --access public)
           }
 
           publish_with_token() {
-            npm publish --access public
+            local package_name="$1"
+            local package_dir="$2"
+            echo "Attempting npm publish for $package_name from $package_dir via token fallback..."
+            (cd "$package_dir" && NODE_AUTH_TOKEN="$token_value" npm publish --access public)
           }
 
           looks_like_npm_token() {
@@ -72,9 +123,9 @@ jobs:
             local candidate="${1:-}"
             local source="$2"
             if looks_like_npm_token "$candidate"; then
-              export NODE_AUTH_TOKEN="$candidate"
               token_available=true
               token_source="$source"
+              token_value="$candidate"
               return 0
             fi
             if [ -n "$candidate" ]; then
@@ -85,6 +136,7 @@ jobs:
 
           token_available=false
           token_source="none"
+          token_value=""
           if use_token_if_valid "${NODE_AUTH_TOKEN:-}" "NODE_AUTH_TOKEN"; then
             :
           elif use_token_if_valid "${NPM_TOKEN:-}" "NPM_TOKEN"; then
@@ -95,37 +147,78 @@ jobs:
 
           echo "Token fallback available: $token_available (source: $token_source)"
 
-          echo "Attempting npm publish via OIDC trusted publishing..."
-          if publish_with_oidc; then
-            echo "mode=oidc" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          publish_package() {
+            local key="$1"
+            local package_name="$2"
+            local package_dir="$3"
 
-          echo "OIDC publish failed. Attempting token-based publish fallback..."
-          if [ "$token_available" = "true" ]; then
-            if publish_with_token; then
-              echo "mode=token" >> "$GITHUB_OUTPUT"
-              exit 0
+            if publish_with_oidc "$package_name" "$package_dir"; then
+              echo "${key}_mode=oidc" >> "$GITHUB_OUTPUT"
+              return 0
             fi
-            echo "Token-based publish failed. Ensure NODE_AUTH_TOKEN/NPM_TOKEN is valid and has publish rights for @vibebrowser/mcp." >&2
+
+            echo "OIDC publish failed for $package_name. Attempting token-based publish fallback..."
+            if [ "$token_available" = "true" ]; then
+              if publish_with_token "$package_name" "$package_dir"; then
+                echo "${key}_mode=token" >> "$GITHUB_OUTPUT"
+                return 0
+              fi
+              echo "Token-based publish failed for $package_name." >&2
+              echo "Ensure NODE_AUTH_TOKEN/NPM_TOKEN is valid and has publish rights for @vibebrowser/mcp and @vibebrowser/cli." >&2
+              exit 1
+            fi
+
+            echo "No valid npm auth path available for $package_name." >&2
+            echo "Configure npm trusted publishing for this repository/workflow OR set a valid NODE_AUTH_TOKEN/NPM_TOKEN secret for @vibebrowser/mcp and @vibebrowser/cli." >&2
             exit 1
+          }
+
+          if [ "${{ steps.versions.outputs.root_changed }}" = "true" ]; then
+            publish_package "root" "${{ steps.versions.outputs.root_name }}" "${{ steps.versions.outputs.root_dir }}"
           fi
 
-          echo "No valid npm auth path available." >&2
-          echo "Configure npm trusted publishing for this repository/workflow OR set a valid NODE_AUTH_TOKEN/NPM_TOKEN secret." >&2
-          exit 1
+          if [ "${{ steps.versions.outputs.cli_changed }}" = "true" ]; then
+            publish_package "cli" "${{ steps.versions.outputs.cli_name }}" "${{ steps.versions.outputs.cli_dir }}"
+          fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN_FALLBACK: ${{ secrets.NODE_AUTH_TOKEN }}
-      
-      - name: Create Git tag
-        if: steps.version.outputs.changed == 'true'
+
+      - name: Create Git tags
+        if: steps.versions.outputs.root_changed == 'true' || steps.versions.outputs.cli_changed == 'true'
+        shell: bash
         run: |
+          set -euo pipefail
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.version.outputs.current }}" -m "Release v${{ steps.version.outputs.current }}" || true
-          git push origin "v${{ steps.version.outputs.current }}" || true
-      
+
+          create_tag_if_missing() {
+            local tag="$1"
+            local message="$2"
+
+            if git rev-parse "$tag" >/dev/null 2>&1; then
+              echo "Tag $tag already exists locally, skipping"
+              return 0
+            fi
+
+            if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+              echo "Tag $tag already exists on origin, skipping"
+              return 0
+            fi
+
+            git tag -a "$tag" -m "$message"
+            git push origin "$tag" || echo "Tag $tag push failed or already exists, continuing"
+          }
+
+          if [ "${{ steps.versions.outputs.root_changed }}" = "true" ]; then
+            create_tag_if_missing "v${{ steps.versions.outputs.root_current }}" "Release v${{ steps.versions.outputs.root_current }}"
+          fi
+
+          if [ "${{ steps.versions.outputs.cli_changed }}" = "true" ]; then
+            create_tag_if_missing "cli-v${{ steps.versions.outputs.cli_current }}" "Release @vibebrowser/cli v${{ steps.versions.outputs.cli_current }}"
+          fi
+
       - name: Skip publish (version unchanged)
-        if: steps.version.outputs.changed == 'false'
-        run: echo "Version ${{ steps.version.outputs.current }} already published, skipping"
+        if: steps.versions.outputs.root_changed == 'false' && steps.versions.outputs.cli_changed == 'false'
+        run: echo "@vibebrowser/mcp ${{ steps.versions.outputs.root_current }} and @vibebrowser/cli ${{ steps.versions.outputs.cli_current }} already published, skipping"

--- a/README.md
+++ b/README.md
@@ -268,10 +268,14 @@ When multiple agents connect, Vibe MCP automatically spawns a relay daemon:
 
 ### Cloud OpenClaw -> Local Browser
 
-If your agent runs in the cloud but you want it to control the user's real local browser, run `vibebrowser-mcp` in HTTP mode and connect it to the Vibe extension in remote relay mode.
+If your agent runs in the cloud but you want it to control the user's real local browser, run `vibebrowser-mcp` in HTTP mode and connect it to the Vibe extension in remote relay mode. Pass either the extension UUID or the full WebSocket relay URL to `--remote`.
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remote <extension-uuid>
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+
+npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remote "$VIBE_REMOTE_UUID"
+npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remote "$VIBE_REMOTE_URL"
 ```
 
 This exposes a local MCP endpoint at `http://127.0.0.1:8788/mcp` by default.
@@ -279,45 +283,70 @@ This exposes a local MCP endpoint at `http://127.0.0.1:8788/mcp` by default.
 When OpenClaw runs on a different machine (for example cloud-hosted), provide a reachable URL:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <extension-uuid> --public-url https://<reachable-host>/mcp
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+PUBLIC_MCP_URL="https://browser-bridge.example.com/mcp"
+
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
 ```
 
 You can print the exact OpenClaw-friendly setup with:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <extension-uuid>
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID"
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL"
 ```
+
+Use `--remote <uuid>` with the default public relay, or `--remote <full-ws-url>` when you need an explicit relay endpoint.
+
+For direct browser CLI checks, use `@vibebrowser/cli`:
+
+```bash
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" --json status
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json status
+```
+
+`--remote <uuid>` uses the default public relay. `--remote <full-ws-url>` targets an explicit relay endpoint.
 
 For the full walkthrough, see `docs/openclaw-local-browser.md`.
 
 ### OpenClaw-Compatible Browser CLI
 
-`vibebrowser-cli` mirrors the OpenClaw browser CLI shape for the real local-browser path:
+`@vibebrowser/cli` mirrors the OpenClaw browser CLI shape for the real local-browser path:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-cli sessions
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> status
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> tabs
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> open https://example.com
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> snapshot
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> click 12
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> type 23 "hello" --submit
-npx -y --package @vibebrowser/mcp vibebrowser-cli --devtools status
+npx @vibebrowser/cli sessions
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" status
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" tabs
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" open https://example.com
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" snapshot
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" click 12
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" type 23 "hello" --submit
+npx @vibebrowser/cli --devtools status
 ```
 
-The package now exposes two executables:
+Use the MCP package for MCP server workflows and the CLI package for direct browser control:
 
 - `vibebrowser-mcp` for MCP server, HTTP bridge, and helper commands
-- `vibebrowser-cli` for OpenClaw-inspired browser control against the real Vibe-connected session
+- `@vibebrowser/cli` for OpenClaw-inspired browser control against the real Vibe-connected session
 
-`vibebrowser-cli` accepts the OpenClaw-style `--browser-profile` flag for compatibility and supports `--json` for machine-readable output. Unlike OpenClaw's managed `openclaw` browser profile, this CLI always targets the real Vibe-connected browser session.
+`@vibebrowser/cli` accepts the OpenClaw-style `--browser-profile` flag for compatibility and supports `--json` for machine-readable output. Unlike OpenClaw's managed `openclaw` browser profile, this CLI always targets the real Vibe-connected browser session.
 
 Local-session selection:
 
-- `vibebrowser-cli sessions` lists connected local browser sessions.
-- `vibebrowser-cli --session <id> ...` targets a specific local session.
+- `npx @vibebrowser/cli sessions` lists connected local browser sessions.
+- `npx @vibebrowser/cli --session <id> ...` targets a specific local session.
 - If `--session` is omitted in local mode, the CLI uses the first connected session.
-- In remote mode, `--remote <extension-uuid>` remains the explicit browser selector.
+- In remote mode, pass either `--remote <uuid>` to use the default public relay or `--remote <full-ws-url>` to use an explicit relay endpoint.
 
 Snapshot behavior is tool-only (no legacy snapshot RPC shortcut):
 
@@ -340,7 +369,7 @@ There are two ways to use Vibe with OpenClaw:
 If OpenClaw runs in the cloud but you want it to control your local browser:
 
 1. Install the Vibe extension and enable **Remote** mode (see [docs/openclaw-local-browser.md](docs/openclaw-local-browser.md))
-2. Start the local HTTP bridge: `vibebrowser-mcp openclaw --remote <extension-uuid> [--public-url <url>]`
+2. Start the local HTTP bridge: `vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID" [--public-url "$PUBLIC_MCP_URL"]` or `vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL" [--public-url "$PUBLIC_MCP_URL"]`
 3. Register the MCP URL in OpenClaw
 
 **Option B: OpenClaw skill for local agents**
@@ -348,8 +377,8 @@ If OpenClaw runs in the cloud but you want it to control your local browser:
 For OpenClaw agents that need your real browser context (logged-in sessions, existing tabs):
 
 1. Copy the Vibe skill from this package to your OpenClaw skills folder
-2. Set `VIBE_EXTENSION_UUID` environment variable
-3. Use `vibebrowser-cli` commands in your agent prompts
+2. Use the extension UUID or full WebSocket relay URL with `--remote`
+3. Use `@vibebrowser/cli` commands in your agent prompts
 
 The skill is located at [`openclaw/vibebrowser/SKILL.md`](openclaw/vibebrowser/SKILL.md) and provides:
 - Full OpenClaw-compatible CLI commands (`status`, `tabs`, `snapshot`, `click`, `type`, etc.)
@@ -387,7 +416,7 @@ npx -y --package @vibebrowser/mcp vibebrowser-mcp serve mistral       # Lightwei
 
 ### Options
 
-```bash
+```text
 npx -y --package @vibebrowser/mcp vibebrowser-mcp serve <model> [options]
 
 Options:
@@ -406,9 +435,9 @@ The extension connects to `http://localhost:11434/v1` automatically.
 
 ## CLI Options
 
-```bash
+```text
 npx -y --package @vibebrowser/mcp vibebrowser-mcp --help
-npx -y --package @vibebrowser/mcp vibebrowser-cli --help
+npx @vibebrowser/cli --help
 
 # MCP server (default)
 npx -y --package @vibebrowser/mcp vibebrowser-mcp [start] [options]
@@ -419,24 +448,35 @@ npx -y --package @vibebrowser/mcp vibebrowser-mcp [start] [options]
   --http-port <number> Port for streamable HTTP MCP transport (default: 8788)
   --http-path <path>   Path for streamable HTTP MCP transport (default: /mcp)
   --allow-host <host>  Allowed host header for HTTP transport (repeatable)
-  -r, --remote <uuid>  Connect to a remote extension via public relay
+  -r, --remote <uuid-or-url>  Extension UUID, or full ws(s) remote URL
   --devtools           Use only chrome-devtools backend (bypasses extension relay)
-  --relay-url <url>    Custom relay server URL
 
+# MCP server tool
+set_remote { "url": "wss://relay.api.vibebrowser.app/<extension-uuid>" }
+```
+
+The `set_remote` MCP server tool hot-reconnects the running MCP server to a different remote relay URL. It is an MCP tool, not a browser CLI subcommand.
+
+```bash
 # OpenClaw helper
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <extension-uuid> [--public-url <url>]
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+PUBLIC_MCP_URL="https://browser-bridge.example.com/mcp"
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
 
 # OpenClaw-compatible browser CLI
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> status
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> status --wait-for-extension --wait-timeout 10000
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> tabs
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> snapshot --json
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> click 12
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> type 23 "hello" --submit
-npx -y --package @vibebrowser/mcp vibebrowser-cli --devtools tabs
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" status
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" status --wait-for-extension --wait-timeout 10000
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" tabs
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" snapshot --json
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" click 12
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" type 23 "hello" --submit
+npx @vibebrowser/cli --devtools tabs
 
 # Local LLM server
-npx -y --package @vibebrowser/mcp vibebrowser-mcp serve <model> [options]
+MODEL="qwen3.5"
+npx -y --package @vibebrowser/mcp vibebrowser-mcp serve "$MODEL"
   -p, --port <number>  Ollama API port (default: 11434)
   -y, --yes            Skip confirmation prompts
   -d, --debug          Enable debug logging

--- a/dist/server.js
+++ b/dist/server.js
@@ -17,6 +17,20 @@ const SERVER_NAME = 'vibebrowser-mcp';
 const SERVER_VERSION = getPackageVersion();
 const STARTUP_TOOLS_REFRESH_TIMEOUT_MS = 4_000;
 const STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS = 1_500;
+const SET_REMOTE_TOOL = {
+    name: 'set_remote',
+    description: 'Reconnect this MCP server to a full Vibe remote websocket relay URL.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            url: {
+                type: 'string',
+                description: 'Full websocket relay URL, for example wss://relay.api.vibebrowser.app/<extension-uuid>',
+            },
+        },
+        required: ['url'],
+    },
+};
 /**
  * Vibe MCP Server
  *
@@ -207,7 +221,7 @@ export class VibeMcpServer {
                 }
             }
             return {
-                tools: this.connection.getTools().map((tool) => ({
+                tools: [SET_REMOTE_TOOL, ...this.connection.getTools()].map((tool) => ({
                     name: tool.name,
                     description: tool.description,
                     inputSchema: tool.inputSchema,
@@ -217,6 +231,9 @@ export class VibeMcpServer {
         server.setRequestHandler(CallToolRequestSchema, async (request) => {
             const { name, arguments: args } = request.params;
             try {
+                if (normalizeToolName(name) === SET_REMOTE_TOOL.name) {
+                    return await this.handleSetRemoteTool(toRecord(args));
+                }
                 const preparedArgs = this.withDefaultPageStateFormat(name, toRecord(args));
                 const result = await this.connection.callTool(name, preparedArgs);
                 const enriched = await this.withFallbackPageContent(name, preparedArgs, result);
@@ -234,6 +251,33 @@ export class VibeMcpServer {
             }
         });
         return server;
+    }
+    async handleSetRemoteTool(args) {
+        if (!(this.connection instanceof ExtensionConnection)) {
+            return {
+                content: [{ type: 'text', text: 'Error: set_remote is not supported when using the chrome-devtools fallback backend' }],
+                isError: true,
+            };
+        }
+        if (typeof args.url !== 'string' || args.url.trim().length === 0) {
+            return {
+                content: [{ type: 'text', text: 'Error: set_remote requires a non-empty string url' }],
+                isError: true,
+            };
+        }
+        const remote = await this.connection.setRemoteUrl(args.url.trim());
+        this.notifyToolListChanged();
+        return {
+            content: [{
+                    type: 'text',
+                    text: JSON.stringify({
+                        ok: true,
+                        mode: 'remote',
+                        relayUrl: remote.relayUrl,
+                        uuid: remote.uuid,
+                    }),
+                }],
+        };
     }
     withDefaultPageStateFormat(name, args) {
         const tool = this.findToolByName(name);
@@ -287,7 +331,7 @@ export class VibeMcpServer {
                 // ignore and continue with cached tools
             }
         }
-        const snapshotTool = this.findToolByName('take_md_snapshot');
+        const snapshotTool = this.findToolByName('take_snapshot');
         if (!snapshotTool) {
             return undefined;
         }
@@ -301,7 +345,10 @@ export class VibeMcpServer {
                 callArgs.tabId = pageId;
             }
         }
-        if (Object.prototype.hasOwnProperty.call(properties, 'pageStateFormat')) {
+        if (Object.prototype.hasOwnProperty.call(properties, 'format')) {
+            callArgs.format = 'markdown';
+        }
+        else if (Object.prototype.hasOwnProperty.call(properties, 'pageStateFormat')) {
             callArgs.pageStateFormat = 'markdown';
         }
         else if (Object.prototype.hasOwnProperty.call(properties, 'page_state_format')) {

--- a/docs/openclaw-local-browser.md
+++ b/docs/openclaw-local-browser.md
@@ -82,18 +82,22 @@ The user needs three pieces:
 3. Go to **Settings** (gear icon)
 4. Find **MCP External** (or "MCP External Control")
 5. Enable it and select **Remote** mode
-6. Copy the **Extension UUID** shown - you'll need this for the next step
+6. Copy either the extension UUID or the full WebSocket relay URL shown, for example `wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84`
 
-> **Note**: The Extension UUID is a unique identifier that allows `vibebrowser-mcp` to connect to your specific browser session through the Vibe relay.
+> **Note**: `--remote <uuid>` uses the default public relay. `--remote <full-ws-url>` targets an explicit relay endpoint.
 
 ## Step 2: Start the local HTTP bridge
 
-On the same machine where the browser extension is installed, run:
+On the same machine where the browser extension is installed, run one of these remote forms.
 
 **Option A: Using the helper command (recommended)**
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <extension-uuid>
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID"
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL"
 ```
 
 This prints the exact commands and MCP URL you need.
@@ -101,13 +105,22 @@ This prints the exact commands and MCP URL you need.
 If OpenClaw is running on another machine (for example in the cloud), provide a reachable URL:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <extension-uuid> --public-url https://<reachable-host>/mcp
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+PUBLIC_MCP_URL="https://browser-bridge.example.com/mcp"
+
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
+npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
 ```
 
 **Option B: Manual command**
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remote <extension-uuid>
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+
+npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remote "$VIBE_REMOTE_UUID"
+npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remote "$VIBE_REMOTE_URL"
 ```
 
 By default this starts a local MCP endpoint at:
@@ -123,11 +136,25 @@ Keep this terminal open - the bridge must stay running for OpenClaw to connect.
 For operator workflows and OpenClaw skills, you can also use the OpenClaw-compatible browser CLI surface directly:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-cli sessions
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> status
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> tabs
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote <extension-uuid> snapshot --json
+npx @vibebrowser/cli sessions
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" status
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" tabs
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" snapshot --json
 ```
+
+The CLI accepts only these remote forms:
+
+```bash
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" --json status
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json status
+```
+
+`--remote <uuid>` uses the default public relay. `--remote <full-ws-url>` targets an explicit relay endpoint.
 
 `snapshot` in `vibebrowser-cli` is tool-only and maps directly to extension snapshot tools:
 
@@ -138,7 +165,7 @@ Use `--page-id <id>` (or `--pageId <id>`) to target a specific tab without switc
 
 For local relay mode with multiple connected browsers/profiles:
 
-- run `vibebrowser-cli sessions` to list available local session IDs
+- run `npx @vibebrowser/cli sessions` to list available local session IDs
 - pass `--session <id>` to target one explicitly
 - if omitted, the CLI uses the first connected local session
 
@@ -164,6 +191,14 @@ Use that loopback URL only for same-machine setups. For cloud OpenClaw, set `"ur
 
 Once that is configured, the cloud OpenClaw agent can use the Vibe browser tools through the local bridge.
 
+If the browser relay URL changes while the MCP server is already running, call the MCP server tool `set_remote` with the new full URL to hot-reconnect without restarting the server:
+
+```json
+{ "url": "wss://relay.api.vibebrowser.app/<extension-uuid>" }
+```
+
+`set_remote` is an MCP tool exposed by the server, not a `vibebrowser-cli` subcommand.
+
 ## Optional: Use the OpenClaw skill for local agents
 
 For OpenClaw agents running locally (not in the cloud) that need access to your real browser, you can use the Vibe skill instead of configuring an MCP server URL.
@@ -174,29 +209,35 @@ Copy `openclaw/vibebrowser/SKILL.md` from this package to your OpenClaw skills d
 
 ### Configure environment
 
-Set the extension UUID in your shell:
+Use either remote form in commands:
 
 ```bash
-export VIBE_EXTENSION_UUID="<your-extension-uuid>"
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" --json status
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json status
 ```
 
 ### Available commands
 
 ```bash
 # Check status
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json status
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" --json status
 
 # List tabs
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json tabs
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json tabs
 
 # Open a page
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json open https://example.com
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" --json open https://example.com
 
 # Click element by index
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json click 12
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json click 12
 
 # Type into element
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json type 23 "hello"
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" --json type 23 "hello"
 ```
 
 See [`openclaw/vibebrowser/SKILL.md`](../openclaw/vibebrowser/SKILL.md) for the full command reference.
@@ -248,9 +289,9 @@ The end result is simple:
 
 ## Troubleshooting
 
-### "Extension UUID not found"
+### "Remote relay URL not found"
 
-Make sure you've enabled **Remote** mode in the Vibe extension settings. The UUID only appears when Remote mode is active.
+Make sure you've enabled **Remote** mode in the Vibe extension settings. Use `--remote <uuid>` for the default public relay or `--remote <full-ws-url>` for an explicit relay endpoint.
 
 ### "Connection refused" errors
 

--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -9,7 +9,7 @@ metadata:
         "requires":
           {
             "bins": ["npx"],
-            "env": ["VIBE_EXTENSION_UUID"],
+            "env": ["VIBE_REMOTE_URL"],
           },
       },
   }
@@ -19,20 +19,25 @@ metadata:
 
 ## Installation
 
-1. **Get the Extension UUID**:
+1. **Get the remote value**:
    - Install the Vibe extension in Chrome
    - Open extension Settings → MCP External
-   - Enable Remote mode and copy the Extension UUID
+   - Enable Remote mode and copy either the extension UUID or full WebSocket relay URL
 
-2. **Set environment variable**:
-   ```bash
-   export VIBE_EXTENSION_UUID="<your-extension-uuid>"
-   ```
+2. **Set environment variables**:
+     ```bash
+     export VIBE_REMOTE_URL="<uuid>"
+     ```
+
+   Or target an explicit relay endpoint:
+       ```bash
+       export VIBE_REMOTE_URL="<full-ws-url>"
+       ```
 
 3. **Install the skill**:
    Copy this file to your OpenClaw skills directory (typically `~/.openclaw/skills/` or your project's `openclaw/skills/` folder).
 
-Use the `vibebrowser-cli` command when the user wants OpenClaw to drive their real local browser through the Vibe extension.
+Use the `@vibebrowser/cli` command when the user wants OpenClaw to drive their real local browser through the Vibe extension.
 
 Prefer this skill when the task depends on:
 
@@ -48,11 +53,10 @@ Do not use this skill for OpenClaw tenant cloud browsing.
 The shell running OpenClaw must have:
 
 ```bash
-export VIBE_EXTENSION_UUID="<extension-uuid>"
+export VIBE_REMOTE_URL="<uuid>"
 
-# Optional if you use a custom relay URL.
-# export VIBE_REMOTE_RELAY_URL="wss://relay.api.vibebrowser.app"
-# export VIBE_RELAY_URL="wss://relay.api.vibebrowser.app"  # legacy alias
+# Explicit relay endpoint:
+# export VIBE_REMOTE_URL="<full-ws-url>"
 
 # Optional compatibility label. Vibe always targets the real local browser path.
 # export VIBE_BROWSER_PROFILE="user"
@@ -63,26 +67,10 @@ export VIBE_EXTENSION_UUID="<extension-uuid>"
 Prefer this exact command pattern:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json <subcommand> ...
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json status
 ```
 
-If the package is already installed locally, you can use:
-
-```bash
-vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json <subcommand> ...
-```
-
-If you set `VIBE_RELAY_URL`, append:
-
-```bash
---relay-url "$VIBE_RELAY_URL"
-```
-
-If you set `VIBE_REMOTE_RELAY_URL`, use:
-
-```bash
---relay-url "$VIBE_REMOTE_RELAY_URL"
-```
+Pass only one of these remote forms: `--remote <uuid>` for the default public relay, or `--remote <full-ws-url>` for an explicit relay endpoint.
 
 ## Deterministic runbook (default)
 
@@ -90,29 +78,29 @@ Use this sequence when the task needs reliable, repeatable control:
 
 1. Verify connection:
    ```bash
-   npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json status --wait-for-extension --wait-timeout 10000
+   npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json status --wait-for-extension --wait-timeout 10000
    ```
 2. Resolve a target page id without changing focus:
    ```bash
    PAGE_ID="$(
-     npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json tabs \
+      npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json tabs \
      | jq -r '.pages[] | select(.active == true) | .id' \
      | head -n1
    )"
    ```
 3. Snapshot that page before acting:
    ```bash
-   npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id "$PAGE_ID" snapshot --format aria --interactive
+   npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json --page-id "$PAGE_ID" snapshot --format aria --interactive
    ```
    If the aria snapshot is too verbose, try the default first and fall back:
    ```bash
-   npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id "$PAGE_ID" snapshot
+   npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json --page-id "$PAGE_ID" snapshot
    # If empty or only title returned, retry with aria:
-   npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id "$PAGE_ID" snapshot --format aria --interactive
+   npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json --page-id "$PAGE_ID" snapshot --format aria --interactive
    ```
 4. Perform action on the same page id:
    ```bash
-   npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id "$PAGE_ID" click 12
+   npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json --page-id "$PAGE_ID" click 12
    ```
 
 If `jq` is unavailable, parse `.pages` from `tabs --json` directly and still pass `--page-id <id>` on every action.
@@ -121,8 +109,8 @@ If `jq` is unavailable, parse `.pages` from `tabs --json` directly and still pas
 
 - **Never use `focus` or `tab select` unless explicitly asked.** The user may be actively working in the browser — switching their active tab is disruptive. Instead, pass `--page-id <id>` (or `--pageId <id>`) to target a specific tab without switching focus. Get the page ID from `tabs` output, then use it on any command:
   ```bash
-  vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id 2 snapshot
-  vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json --page-id 2 click 7
+  npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json --page-id 2 snapshot
+  npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json --page-id 2 click 7
   ```
 - Prefer `tabs` or `snapshot` before acting.
 - `snapshot` is tool-only and maps to extension snapshot tools (`take_md_snapshot` by default, `take_a11y_snapshot` for `--format aria`).
@@ -142,44 +130,44 @@ If `jq` is unavailable, parse `.pages` from `tabs --json` directly and still pas
 Status:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json status
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json status
 ```
 
 List pages:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json tabs
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json tabs
 ```
 
 Open a new page:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json open https://example.com
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json open https://example.com
 ```
 
 Take the default AI snapshot:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json snapshot
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json snapshot
 ```
 
 Take the ARIA / interactive snapshot:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json snapshot --format aria --interactive
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json snapshot --format aria --interactive
 ```
 
 Click and type using OpenClaw-style refs:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json click 12
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json type 23 "hello" --submit
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json click 12
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json type 23 "hello" --submit
 ```
 
 Evaluate JavaScript:
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-cli --remote "$VIBE_EXTENSION_UUID" --json evaluate --fn '() => document.title'
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json evaluate --fn '() => document.title'
 ```
 
 ## Snapshot format: `ai` vs `aria`
@@ -195,10 +183,10 @@ The `snapshot` command supports two extraction formats:
 
 ```bash
 # Default — may return empty for background tabs or SPAs like Notion
-vibebrowser-cli ... snapshot
+npx @vibebrowser/cli ... snapshot
 
 # Reliable fallback — uses Chrome DevTools Protocol directly, works on background tabs
-vibebrowser-cli ... snapshot --format aria --interactive
+npx @vibebrowser/cli ... snapshot --format aria --interactive
 ```
 
 **Known limitations of `--format ai`:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibebrowser/mcp",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "Apache-2.0",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "commander": "^12.0.0",
@@ -100,6 +103,10 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@vibebrowser/cli": {
+      "resolved": "packages/cli",
+      "link": true
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -1224,6 +1231,25 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "packages/cli": {
+      "name": "@vibebrowser/cli",
+      "version": "0.2.6",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "commander": "^12.0.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "vibebrowser-cli": "dist/browser-main.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "chrome-devtools-mcp": "^0.21.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "MCP server for browser automation - the only solution supporting multiple AI agents (Claude, Cursor, VS Code) simultaneously controlling your Chrome browser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "workspaces": [
+    "packages/*"
+  ],
   "bin": {
     "vibebrowser-mcp": "./dist/cli.js",
     "vibe-mcp": "./dist/cli.js",
@@ -14,7 +17,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/prepare-cli-package.mjs",
     "dev": "tsc --watch",
     "start": "node dist/cli.js",
     "prepublishOnly": "npm run build",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,13 @@
+# @vibebrowser/cli
+
+Standalone CLI for controlling a Vibe-connected browser session.
+
+```bash
+VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
+
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" --json status
+npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json tabs
+```
+
+`--remote <uuid>` uses the default public Vibe relay. `--remote <full-ws-url>` targets an explicit relay endpoint.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@vibebrowser/cli",
+  "version": "0.2.8",
+  "type": "module",
+  "description": "Standalone Vibe Browser CLI for controlling a Vibe-connected browser session",
+  "bin": {
+    "vibebrowser-cli": "./dist/browser-main.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "node ../../scripts/prepare-cli-package.mjs",
+    "prepack": "npm --prefix ../.. run build"
+  },
+  "keywords": [
+    "browser-automation",
+    "ai-agent",
+    "browser-cli",
+    "vibebrowser",
+    "openclaw"
+  ],
+  "author": "Vibe Technologies",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VibeTechnologies/vibe-mcp.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://vibebrowser.app",
+  "bugs": {
+    "url": "https://github.com/VibeTechnologies/vibe-mcp/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "commander": "^12.0.0",
+    "ws": "^8.18.0"
+  },
+  "optionalDependencies": {
+    "chrome-devtools-mcp": "^0.21.0"
+  },
+  "files": [
+    "dist/browser-main.js",
+    "dist/browser-cli.js",
+    "dist/connection.js",
+    "dist/devtools-fallback.js",
+    "dist/relay-daemon.js",
+    "dist/relay.js",
+    "dist/types.js",
+    "dist/version.js",
+    "README.md"
+  ]
+}

--- a/scripts/e2e-browser-cli.mjs
+++ b/scripts/e2e-browser-cli.mjs
@@ -15,6 +15,8 @@ const RELAY_URL = `ws://${HOST}:${RELAY_PORT}`;
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = resolve(SCRIPT_DIR, '..');
 const LOCAL_BROWSER_CLI = resolve(PACKAGE_ROOT, 'dist', 'browser-main.js');
+const DIST_CONNECTION = resolve(PACKAGE_ROOT, 'dist', 'connection.js');
+const CLI_PACKAGE_ROOT = resolve(PACKAGE_ROOT, 'packages', 'cli');
 const NPM_BIN = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const NPX_BIN = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 const E2E_BROWSER_CLI_SOURCE = (process.env.E2E_BROWSER_CLI_SOURCE || 'local').toLowerCase();
@@ -140,11 +142,32 @@ try {
     });
   });
 
+  const { parseRemoteRelayUrl } = await import(DIST_CONNECTION);
+  const parsedWssRemote = parseRemoteRelayUrl(`wss://relay.example.test/nested/${REMOTE_UUID}`);
+  assert(parsedWssRemote.relayUrl === 'wss://relay.example.test/nested', `wss remote relay base parsed incorrectly: ${JSON.stringify(parsedWssRemote)}`);
+  assert(parsedWssRemote.uuid === REMOTE_UUID, `wss remote UUID parsed incorrectly: ${JSON.stringify(parsedWssRemote)}`);
+
   const status = await runCli(['status']);
   assert(status.ok === true, `status failed: ${JSON.stringify(status)}`);
   assert(status.extensionConnected === true, `expected extension connected: ${JSON.stringify(status)}`);
   assert(Number(status.toolCount) >= 10, `expected toolCount >= 10: ${JSON.stringify(status)}`);
   assert(status.sessionId === REMOTE_UUID, `expected status sessionId=${REMOTE_UUID}: ${JSON.stringify(status)}`);
+
+  const uuidStatus = await runCli(['status'], { remoteValue: REMOTE_UUID });
+  if (E2E_BROWSER_CLI_SOURCE === 'local') {
+    assert(uuidStatus.ok === true, `UUID-only remote should return structured status locally: ${JSON.stringify(uuidStatus)}`);
+    assert(uuidStatus.mode === 'remote', `UUID-only status should still be remote mode: ${JSON.stringify(uuidStatus)}`);
+    assert(uuidStatus.extensionConnected === false, `UUID-only remote without public relay should report disconnected extension locally: ${JSON.stringify(uuidStatus)}`);
+    assert(uuidStatus.sessionId === REMOTE_UUID, `UUID-only status should parse UUID as sessionId: ${JSON.stringify(uuidStatus)}`);
+  }
+
+  const envStatus = await runCli(['status'], {
+    remoteFromEnv: true,
+    env: { VIBE_REMOTE_URL: `${RELAY_URL}/${REMOTE_UUID}` },
+  });
+  assert(envStatus.ok === true, `status via VIBE_REMOTE_URL failed: ${JSON.stringify(envStatus)}`);
+  assert(envStatus.extensionConnected === true, `VIBE_REMOTE_URL should connect extension: ${JSON.stringify(envStatus)}`);
+  assert(envStatus.sessionId === REMOTE_UUID, `VIBE_REMOTE_URL should target ${REMOTE_UUID}: ${JSON.stringify(envStatus)}`);
 
   const sessions = await runCli(['sessions']);
   assert(Array.isArray(sessions.sessions) && sessions.sessions.length === 1, `sessions missing session list: ${JSON.stringify(sessions)}`);
@@ -301,15 +324,6 @@ try {
 function handleToolCall(name, args) {
   const hasExplicitPageContext = Number.isFinite(args.pageId) || Number.isFinite(args.tabId);
 
-  if (name === 'new_page' && args.__skipPageContent !== true) {
-    throw new Error(`Expected __skipPageContent=true for ${name} without explicit page context: ${JSON.stringify(args)}`);
-  }
-  if (name === 'click' && !hasExplicitPageContext && args.__skipPageContent !== true) {
-    throw new Error(`Expected __skipPageContent=true for ${name} without explicit page context: ${JSON.stringify(args)}`);
-  }
-  if (name === 'fill' && !hasExplicitPageContext && args.__skipPageContent !== true) {
-    throw new Error(`Expected __skipPageContent=true for ${name} without explicit page context: ${JSON.stringify(args)}`);
-  }
   if ((name === 'navigate_page' || name === 'select_page' || name === 'close_page' || name === 'switch_to_page' || name === 'click' || name === 'fill')
     && hasExplicitPageContext
     && args.__skipPageContent === true) {
@@ -413,16 +427,16 @@ function tool(name, properties) {
   };
 }
 
-async function runCli(args) {
+async function runCli(args, options = {}) {
   const invocation = getCliInvocation();
+  const remoteArgs = options.remoteFromEnv
+    ? []
+    : ['--remote', options.remoteValue ?? `${RELAY_URL}/${REMOTE_UUID}`];
   const child = spawn(
     invocation.command,
     [
       ...invocation.args,
-      '--remote',
-      REMOTE_UUID,
-      '--relay-url',
-      RELAY_URL,
+      ...remoteArgs,
       '--browser-profile',
       'user',
       '--json',
@@ -431,6 +445,10 @@ async function runCli(args) {
     {
       cwd: PACKAGE_ROOT,
       stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        ...(options.env ?? {}),
+      },
     },
   );
 
@@ -524,12 +542,12 @@ function getCliInvocation() {
 
   const packageSpec = E2E_BROWSER_CLI_SOURCE === 'pack'
     ? resolvePackedPackageSpec()
-    : '@vibebrowser/mcp@latest';
+    : '@vibebrowser/cli@latest';
 
   cliInvocation = {
     source: E2E_BROWSER_CLI_SOURCE,
     command: NPX_BIN,
-    args: ['-y', '--package', packageSpec, 'vibebrowser-cli'],
+    args: ['-y', packageSpec],
   };
   return cliInvocation;
 }
@@ -548,7 +566,7 @@ function resolvePackedPackageSpec() {
     NPM_BIN,
     ['pack', '--json', '--pack-destination', packedPackageDir],
     {
-      cwd: PACKAGE_ROOT,
+      cwd: CLI_PACKAGE_ROOT,
       encoding: 'utf-8',
     },
   );
@@ -569,7 +587,7 @@ function resolvePackedPackageSpec() {
     throw new Error(`npm pack did not report a filename: ${result.stdout}`);
   }
 
-  return join(packedPackageDir, filename);
+  return `file:${join(packedPackageDir, filename)}`;
 }
 
 function normalizePackageSpec(spec) {

--- a/scripts/e2e-devtools-flag.mjs
+++ b/scripts/e2e-devtools-flag.mjs
@@ -149,9 +149,7 @@ async function main() {
     const browserStatus = await runJsonCli(BROWSER_CLI, [
       '--devtools',
       '--remote',
-      REMOTE_UUID,
-      '--relay-url',
-      relayUrl,
+      `${relayUrl}/${REMOTE_UUID}`,
       'status',
     ]);
     assert(browserStatus.command === 'status', `Unexpected browser status payload: ${JSON.stringify(browserStatus)}`);
@@ -171,9 +169,7 @@ async function main() {
         String(httpPort),
         '--devtools',
         '--remote',
-        REMOTE_UUID,
-        '--relay-url',
-        relayUrl,
+        `${relayUrl}/${REMOTE_UUID}`,
       ],
       {
         cwd: PACKAGE_ROOT,

--- a/scripts/e2e-http-streamable.mjs
+++ b/scripts/e2e-http-streamable.mjs
@@ -17,9 +17,14 @@ const RESERVED_PORTS = new Set();
 const MCP_HTTP_PORT = configuredHttpPort ?? await findFreePort(RESERVED_PORTS);
 RESERVED_PORTS.add(MCP_HTTP_PORT);
 const RELAY_PORT = configuredRelayPort ?? await findFreePort(RESERVED_PORTS);
+RESERVED_PORTS.add(RELAY_PORT);
+const RELAY_PORT_B = await findFreePort(RESERVED_PORTS);
 const RELAY_URL = `ws://${RELAY_HOST}:${RELAY_PORT}`;
+const RELAY_URL_B = `ws://${RELAY_HOST}:${RELAY_PORT_B}`;
 const REMOTE_UUID = 'test-http-relay-uuid';
+const REMOTE_UUID_B = 'test-http-relay-uuid-b';
 const SESSION_ID = REMOTE_UUID;
+const SESSION_ID_B = REMOTE_UUID_B;
 const MCP_URL = `http://${RELAY_HOST}:${MCP_HTTP_PORT}/mcp`;
 
 function getConfiguredPort(...names) {
@@ -105,8 +110,18 @@ function waitForWebSocketMessage(ws, predicate, timeoutMs = 10_000) {
   });
 }
 
+function withTimeout(promise, label, timeoutMs = 10_000) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 async function main() {
-  let wss;
+  let remoteA;
+  let remoteB;
   let serverProcess;
   const stateDir = mkdtempSync(join(tmpdir(), 'vibe-mcp-http-e2e-'));
 
@@ -117,20 +132,12 @@ async function main() {
     if (await probePort(RELAY_PORT)) {
       throw new Error(`Relay test port ${RELAY_PORT} is already in use`);
     }
+    if (await probePort(RELAY_PORT_B)) {
+      throw new Error(`Relay test port ${RELAY_PORT_B} is already in use`);
+    }
 
-    wss = new WebSocketServer({ host: RELAY_HOST, port: RELAY_PORT });
-
-    const extensionConnected = new Promise((resolve) => {
-      wss.on('connection', (ws, req) => {
-        if (req.url !== `/${REMOTE_UUID}`) {
-          ws.close();
-          return;
-        }
-        ws.send(JSON.stringify({ type: 'extension_status', connected: true }));
-        ws.send(JSON.stringify({ type: 'connected', sessionId: SESSION_ID }));
-        resolve(ws);
-      });
-    });
+    remoteA = startFakeRemoteRelay(RELAY_PORT, REMOTE_UUID, SESSION_ID);
+    remoteB = startFakeRemoteRelay(RELAY_PORT_B, REMOTE_UUID_B, SESSION_ID_B);
 
     serverProcess = spawn(
       process.execPath,
@@ -144,9 +151,7 @@ async function main() {
         '--http-port',
         String(MCP_HTTP_PORT),
         '--remote',
-        REMOTE_UUID,
-        '--relay-url',
-        RELAY_URL,
+        `${RELAY_URL}/${REMOTE_UUID}`,
       ],
       {
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -163,14 +168,14 @@ async function main() {
     });
 
     const [extensionWs] = await Promise.all([
-      extensionConnected,
+      remoteA.connected,
       waitForPort(MCP_HTTP_PORT),
     ]);
 
     const transport = new StreamableHTTPClientTransport(new URL(MCP_URL));
     const client = new Client({ name: 'vibe-mcp-http-e2e', version: '1.0.0' });
 
-    await client.connect(transport);
+    await withTimeout(client.connect(transport), 'MCP client connect');
     const listToolsPromise = waitForWebSocketMessage(
       extensionWs,
       (message) => message.type === 'list_tools',
@@ -196,7 +201,7 @@ async function main() {
       ],
     }));
 
-    const tools = await toolsPromise;
+    const tools = await withTimeout(toolsPromise, 'initial tools/list response');
     if (!tools.tools.some((tool) => tool.name === 'echo')) {
       throw new Error(`Expected echo tool in listTools response: ${JSON.stringify(tools)}`);
     }
@@ -220,7 +225,7 @@ async function main() {
       },
     }));
 
-    const callResult = await callResultPromise;
+    const callResult = await withTimeout(callResultPromise, 'initial echo call response');
     const textContent = callResult.content.find((item) => item.type === 'text');
     if (!textContent || textContent.text !== 'hello from http') {
       throw new Error(`Unexpected tool result: ${JSON.stringify(callResult)}`);
@@ -276,9 +281,6 @@ async function main() {
       arguments: { url: 'https://example.com' },
     });
     const openToolCall = await openToolCallPromise;
-    if (openToolCall.data?.arguments?.__skipPageContent !== true) {
-      throw new Error(`Expected __skipPageContent=true for new_page without explicit pageId: ${JSON.stringify(openToolCall)}`);
-    }
 
     extensionWs.send(JSON.stringify({
       type: 'tool_result',
@@ -289,7 +291,7 @@ async function main() {
       },
     }));
 
-    const openResult = await openResultPromise;
+    const openResult = await withTimeout(openResultPromise, 'new_page call response');
     const openText = openResult.content.find((item) => item.type === 'text');
     if (!openText || !openText.text.includes('"pageId":77')) {
       throw new Error(`Expected structured new_page response without fallback snapshot: ${JSON.stringify(openResult)}`);
@@ -298,32 +300,153 @@ async function main() {
       throw new Error(`Did not expect implicit snapshot fallback in MCP response: ${JSON.stringify(openResult)}`);
     }
 
-    await client.close();
+    const setRemoteResultPromise = client.callTool({
+      name: 'set_remote',
+      arguments: { url: `${RELAY_URL_B}/${REMOTE_UUID_B}` },
+    });
+    const [extensionWsB, setRemoteResult] = await withTimeout(Promise.all([
+      remoteB.connected,
+      setRemoteResultPromise,
+    ]), 'set_remote response and relay B connection');
+
+    const setRemoteText = setRemoteResult.content.find((item) => item.type === 'text');
+    if (!setRemoteText) {
+      throw new Error(`Expected set_remote text result: ${JSON.stringify(setRemoteResult)}`);
+    }
+    const setRemotePayload = JSON.parse(setRemoteText.text);
+    if (setRemotePayload.ok !== true || setRemotePayload.mode !== 'remote' || setRemotePayload.relayUrl !== RELAY_URL_B || setRemotePayload.uuid !== REMOTE_UUID_B) {
+      throw new Error(`Unexpected set_remote payload: ${JSON.stringify(setRemotePayload)}`);
+    }
+
+    const listToolsBPromise = waitForWebSocketMessage(
+      extensionWsB,
+      (message) => message.type === 'list_tools',
+    );
+    const toolsBPromise = client.listTools();
+    const listToolsBRequest = await listToolsBPromise;
+
+    extensionWsB.send(JSON.stringify({
+      type: 'tools_list',
+      requestId: listToolsBRequest.requestId,
+      data: [
+        {
+          name: 'echo_b',
+          description: 'Echo from relay B',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              text: { type: 'string' },
+            },
+            required: ['text'],
+          },
+        },
+      ],
+    }));
+
+    const toolsB = await withTimeout(toolsBPromise, 'relay B tools/list response');
+    if (!toolsB.tools.some((tool) => tool.name === 'set_remote')) {
+      throw new Error(`Expected set_remote tool after switching remotes: ${JSON.stringify(toolsB)}`);
+    }
+    if (!toolsB.tools.some((tool) => tool.name === 'echo_b')) {
+      throw new Error(`Expected relay B tool after set_remote: ${JSON.stringify(toolsB)}`);
+    }
+    if (toolsB.tools.some((tool) => tool.name === 'echo')) {
+      throw new Error(`Did not expect stale relay A tools after set_remote: ${JSON.stringify(toolsB)}`);
+    }
+
+    const callToolBPromise = waitForWebSocketMessage(
+      extensionWsB,
+      (message) => message.type === 'call_tool' && message.data?.name === 'echo_b',
+    );
+    const callResultBPromise = client.callTool({
+      name: 'echo_b',
+      arguments: { text: 'hello from relay b' },
+    });
+    const callRequestB = await callToolBPromise;
+
+    extensionWsB.send(JSON.stringify({
+      type: 'tool_result',
+      requestId: callRequestB.requestId,
+      data: {
+        success: true,
+        content: [{ type: 'text', text: 'hello from relay b' }],
+      },
+    }));
+
+    const callResultB = await withTimeout(callResultBPromise, 'relay B echo call response');
+    const textContentB = callResultB.content.find((item) => item.type === 'text');
+    if (!textContentB || textContentB.text !== 'hello from relay b') {
+      throw new Error(`Unexpected relay B tool result: ${JSON.stringify(callResultB)}`);
+    }
+
+    await withTimeout(client.close(), 'MCP client close');
     console.log('http e2e ok');
   } finally {
     if (serverProcess) {
       serverProcess.kill('SIGTERM');
-      await onceProcessExit(serverProcess);
+      await waitForProcessExit(serverProcess);
     }
-    if (wss) {
-      await new Promise((resolve, reject) => {
-        wss.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
-    }
+    await closeFakeRemoteRelay(remoteA);
+    await closeFakeRemoteRelay(remoteB);
     rmSync(stateDir, { recursive: true, force: true });
   }
 }
 
-function onceProcessExit(child) {
+function startFakeRemoteRelay(port, uuid, sessionId) {
+  const server = new WebSocketServer({ host: RELAY_HOST, port });
+  const connected = new Promise((resolve) => {
+    server.on('connection', (ws, req) => {
+      if (req.url !== `/${uuid}`) {
+        ws.close();
+        return;
+      }
+      ws.send(JSON.stringify({ type: 'extension_status', connected: true }));
+      ws.send(JSON.stringify({ type: 'connected', sessionId }));
+      resolve(ws);
+    });
+  });
+
+  return { server, connected };
+}
+
+async function closeFakeRemoteRelay(remote) {
+  if (!remote) {
+    return;
+  }
+
+  for (const client of remote.server.clients) {
+    client.terminate();
+  }
+
+  await new Promise((resolve, reject) => {
+    remote.server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function waitForProcessExit(child, timeoutMs = 5_000) {
   return new Promise((resolve) => {
-    child.once('exit', () => resolve());
-    child.once('close', () => resolve());
+    let settled = false;
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish();
+    }, timeoutMs);
+
+    child.once('exit', finish);
+    child.once('close', finish);
   });
 }
 

--- a/scripts/prepare-cli-package.mjs
+++ b/scripts/prepare-cli-package.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const source = resolve(root, 'dist');
+const target = resolve(root, 'packages', 'cli', 'dist');
+
+if (!existsSync(source)) {
+  throw new Error(`Build output not found at ${source}. Run npm run build from the repository root first.`);
+}
+
+mkdirSync(dirname(target), { recursive: true });
+rmSync(target, { recursive: true, force: true });
+cpSync(source, target, { recursive: true });

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -27,8 +27,7 @@ const MIME_TYPE_BY_EXTENSION: Record<string, string> = {
   '.xml': 'application/xml',
 };
 const DEFAULT_BROWSER_PROFILE = process.env.VIBE_BROWSER_PROFILE || 'user';
-const DEFAULT_REMOTE_UUID = process.env.VIBE_REMOTE_URL || process.env.VIBE_EXTENSION_UUID || process.env.VIBE_RELAY_UUID;
-const DEFAULT_REMOTE_RELAY_URL = process.env.VIBE_REMOTE_RELAY_URL || process.env.VIBE_RELAY_URL;
+const DEFAULT_REMOTE = process.env.VIBE_REMOTE_URL || process.env.VIBE_EXTENSION_UUID || process.env.VIBE_RELAY_UUID;
 
 type JsonPrimitive = null | boolean | number | string;
 type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
@@ -41,7 +40,6 @@ interface BrowserCommandOptions {
   devtools: boolean;
   remote?: string;
   session?: string;
-  relayUrl?: string;
   json: boolean;
   timeout: string;
   pageId?: string;
@@ -87,7 +85,6 @@ interface CommandContextInit {
   devtools: boolean;
   remoteUuid?: string;
   sessionId?: string;
-  relayUrl?: string;
   profile: string;
   json: boolean;
   timeoutMs: number;
@@ -120,9 +117,8 @@ function buildBrowserCommand(command: Command): Command {
     .option('-p, --port <number>', 'WebSocket port for local relay (agent) connection', String(DEFAULT_WS_PORT))
     .option('-d, --debug', 'Enable debug logging', false)
     .option('--devtools', 'Use only chrome-devtools backend (bypasses extension relay)', false)
-    .option('-r, --remote <uuid>', 'Connect to a remote extension via public relay (provide the extension UUID)', DEFAULT_REMOTE_UUID)
+    .option('-r, --remote <uuid-or-url>', 'Connect to a remote extension via relay (provide the extension UUID or full ws(s) relay URL)', DEFAULT_REMOTE)
     .option('-s, --session <id>', 'Target a specific local browser session ID; defaults to the first connected session')
-    .option('--relay-url <url>', 'Custom relay server URL', DEFAULT_REMOTE_RELAY_URL)
     .option('--json', 'Emit machine-readable JSON output', false)
     .option('--timeout <ms>', 'Command timeout in milliseconds', String(DEFAULT_TIMEOUT_MS))
     .option('--page-id <id>', 'Target a specific page/tab by its numeric ID (avoids switching the user\'s active tab)')
@@ -478,7 +474,6 @@ async function runBrowserCommand(
     devtools: Boolean(globalOptions.devtools),
     remoteUuid: globalOptions.remote,
     sessionId: globalOptions.session,
-    relayUrl: globalOptions.relayUrl,
     profile: globalOptions.browserProfile || DEFAULT_BROWSER_PROFILE,
     json: Boolean(globalOptions.json),
     timeoutMs: parsePositiveInteger(globalOptions.timeout, '--timeout'),
@@ -524,7 +519,7 @@ class BrowserCliContext {
       : new ExtensionConnection(
         init.port,
         init.debug,
-        init.remoteUuid ? { uuid: init.remoteUuid, relayUrl: init.relayUrl } : undefined,
+        init.remoteUuid ? { uuid: init.remoteUuid } : undefined,
         init.remoteUuid ? undefined : { sessionId: init.sessionId },
       );
     this.profile = init.profile;
@@ -779,7 +774,7 @@ class BrowserCliContext {
       'snapshot',
       [
         {
-          names: ['take_snapshot'],
+          names: [wantsAria ? 'take_a11y_snapshot' : 'take_md_snapshot'],
           buildArgs: (tool: ToolDefinition) => withSnapshotArgs(tool, options),
         },
       ],
@@ -1249,7 +1244,7 @@ class BrowserCliContext {
     return {
       ...output,
       pageContent: fallback.content,
-      pageContentSource: 'take_snapshot',
+      pageContentSource: 'take_md_snapshot',
       ...(fallback.pageId !== targetPageId ? { pageId: fallback.pageId } : {}),
     };
   }
@@ -1288,7 +1283,7 @@ class BrowserCliContext {
       sessionId: this.currentSessionId(),
       requestedSessionId: this.requestedSessionId,
       ignoredCompatibilityOptions: this.ignoredCompatibilityOptions,
-      tool: 'take_snapshot',
+      tool: 'take_md_snapshot',
       recoveredFromTimeout: true,
       pageId: fallback.pageId,
       url,
@@ -1349,7 +1344,7 @@ class BrowserCliContext {
 
   private async takeMarkdownSnapshotForPage(pageId: number, timeoutMs: number = this.timeoutMs): Promise<string | undefined> {
     await this.ensureToolsLoaded();
-    const snapshotTool = this.tools.find((tool) => normalizeName(tool.name) === 'take_snapshot');
+    const snapshotTool = this.tools.find((tool) => normalizeName(tool.name) === 'take_md_snapshot');
     if (!snapshotTool) {
       return undefined;
     }
@@ -1359,9 +1354,9 @@ class BrowserCliContext {
     if (pageKey) {
       args[pageKey] = pageId;
     }
-    const formatKey = hasProperty(snapshotTool, 'format', 'pageStateFormat', 'page_state_format');
-    if (formatKey) {
-      args[formatKey] = 'markdown';
+    const pageStateKey = hasProperty(snapshotTool, 'pageStateFormat', 'page_state_format');
+    if (pageStateKey) {
+      args[pageStateKey] = 'markdown';
     }
 
     try {
@@ -1392,7 +1387,9 @@ class BrowserCliContext {
       return undefined;
     }
     if (this.remoteUuid) {
-      return this.remoteUuid;
+      return this.connection instanceof ExtensionConnection
+        ? this.connection.getRemoteConfig()?.uuid ?? this.remoteUuid
+        : this.remoteUuid;
     }
 
     const connectedSessionIds = new Set(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@
  *
  * Modes:
  *   Local (default): connects to local relay daemon on localhost
- *   Remote (--remote <uuid>): connects to public relay at relay.api.vibebrowser.app
+ *   Remote (--remote <uuid-or-url>): connects to public relay at relay.api.vibebrowser.app
  */
 
 import { program } from 'commander';
@@ -32,9 +32,8 @@ program
   .option('-p, --port <number>', 'WebSocket port for local relay (agent) connection', String(DEFAULT_WS_PORT))
   .option('-d, --debug', 'Enable debug logging', false)
   .option('--devtools', 'Use only chrome-devtools backend (bypasses extension relay)', false)
-  .option('-r, --remote <uuid>', 'Connect to a remote extension via public relay (provide the extension UUID)')
+  .option('-r, --remote <uuid-or-url>', 'Connect to a remote extension via relay (provide the extension UUID or full ws(s) relay URL)')
   .option('-s, --session <id>', 'Target a specific local browser session ID; defaults to the first connected session')
-  .option('--relay-url <url>', 'Custom relay server URL (default: wss://relay.api.vibebrowser.app)')
   .option('--transport <mode>', 'MCP transport to expose: stdio or http', 'stdio')
   .option('--host <host>', 'Host to bind the HTTP server to', '127.0.0.1')
   .option('--http-port <number>', 'Port for streamable HTTP MCP transport', String(DEFAULT_HTTP_PORT))
@@ -57,7 +56,6 @@ program
         allowedHosts: options.allowHost.length > 0 ? options.allowHost : undefined,
         remoteUuid: options.remote,
         sessionId: options.session,
-        remoteRelayUrl: options.relayUrl,
       });
 
       const httpUrl = server.getHttpUrl();
@@ -74,8 +72,7 @@ program
 program
   .command('openclaw')
   .description('Print OpenClaw-friendly configuration for cloud agent -> local browser relay')
-  .requiredOption('-r, --remote <uuid>', 'Extension UUID from Vibe extension Settings > MCP External > Remote')
-  .option('--relay-url <url>', 'Custom relay server URL (default: wss://relay.api.vibebrowser.app)')
+  .requiredOption('-r, --remote <uuid-or-url>', 'Extension UUID or full ws(s) relay URL from Vibe extension Settings > MCP External > Remote')
   .option('--host <host>', 'Host to bind the HTTP server to', '127.0.0.1')
   .option('--http-port <number>', 'Port for streamable HTTP MCP transport', String(DEFAULT_HTTP_PORT))
   .option('--http-path <path>', 'Path for streamable HTTP MCP transport', DEFAULT_HTTP_PATH)
@@ -108,9 +105,6 @@ program
       options.remote,
     ];
 
-    if (options.relayUrl) {
-      cliArgs.push('--relay-url', options.relayUrl);
-    }
     for (const allowedHost of options.allowHost as string[]) {
       cliArgs.push('--allow-host', allowedHost);
     }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -45,6 +45,66 @@ export interface RemoteConfig {
   relayUrl?: string; // defaults to DEFAULT_RELAY_URL
 }
 
+export interface ParsedRemoteRelayUrl {
+  relayUrl: string;
+  uuid: string;
+}
+
+function isRemoteRelayUrl(value: string): boolean {
+  return /^wss?:\/\//i.test(value);
+}
+
+export function parseRemoteRelayUrl(value: string): ParsedRemoteRelayUrl {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid remote relay URL: ${message}`);
+  }
+
+  if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+    throw new Error('Invalid remote relay URL: protocol must be ws:// or wss://');
+  }
+
+  const pathSegments = parsed.pathname.split('/').filter(Boolean);
+  const uuid = pathSegments[pathSegments.length - 1];
+  if (!uuid) {
+    throw new Error('Invalid remote relay URL: missing UUID path segment');
+  }
+
+  pathSegments.pop();
+  parsed.pathname = pathSegments.length > 0 ? `/${pathSegments.join('/')}` : '';
+  parsed.search = '';
+  parsed.hash = '';
+
+  return {
+    relayUrl: parsed.toString().replace(/\/$/, ''),
+    uuid,
+  };
+}
+
+export function normalizeRemoteConfig(remote?: RemoteConfig): RemoteConfig | undefined {
+  if (!remote) {
+    return undefined;
+  }
+
+  const relayUrl = remote.relayUrl?.replace(/\/$/, '');
+  if (!isRemoteRelayUrl(remote.uuid)) {
+    return { uuid: remote.uuid, relayUrl };
+  }
+
+  const parsed = parseRemoteRelayUrl(remote.uuid);
+  if (relayUrl && relayUrl !== parsed.relayUrl) {
+    throw new Error(`Remote relay URL mismatch: remote URL includes ${parsed.relayUrl}, but configured relay URL is ${relayUrl}`);
+  }
+
+  return {
+    uuid: parsed.uuid,
+    relayUrl: relayUrl || parsed.relayUrl,
+  };
+}
+
 export interface LocalSessionConfig {
   sessionId?: string;
 }
@@ -82,7 +142,7 @@ export class ExtensionConnection extends EventEmitter {
     super();
     this.port = port;
     this.debug = debug;
-    this.remoteConfig = remote || null;
+    this.remoteConfig = normalizeRemoteConfig(remote) || null;
     this.localSessionConfig = localSessionConfig || {};
   }
 
@@ -109,6 +169,27 @@ export class ExtensionConnection extends EventEmitter {
 
     // Connect to relay
     await this.connectToRelay();
+  }
+
+  async setRemoteUrl(url: string): Promise<ParsedRemoteRelayUrl> {
+    const parsed = parseRemoteRelayUrl(url);
+
+    this.stopping = true;
+    this.clearReconnectTimer();
+    this.rejectPendingRequests(new Error('Remote relay changed'));
+    this.closeSocket();
+
+    this.remoteConfig = { uuid: parsed.uuid, relayUrl: parsed.relayUrl };
+    this.tools = [];
+    this.sessions = [];
+    this.extensionConnected = false;
+    this.status = 'disconnected';
+    this.emit('tools_updated', this.tools);
+    this.emit('extension_status', false);
+
+    this.stopping = false;
+    await this.connectToRelay();
+    return parsed;
   }
 
   /**
@@ -180,6 +261,10 @@ export class ExtensionConnection extends EventEmitter {
       return `${base}/${this.remoteConfig.uuid}`;
     }
     return `ws://127.0.0.1:${this.port}`;
+  }
+
+  getRemoteConfig(): RemoteConfig | null {
+    return this.remoteConfig ? { ...this.remoteConfig } : null;
   }
 
   /**
@@ -267,30 +352,39 @@ export class ExtensionConnection extends EventEmitter {
    */
   async stop(): Promise<void> {
     this.stopping = true;
+    this.clearReconnectTimer();
+
+    this.rejectPendingRequests(new Error('Connection closed'));
+    this.closeSocket();
+
+    this.status = 'disconnected';
+  }
+
+  private clearReconnectTimer(): void {
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+  }
 
-    // Reject all pending requests
-    for (const [id, request] of this.pendingRequests) {
+  private rejectPendingRequests(error: Error): void {
+    for (const [, request] of this.pendingRequests) {
       clearTimeout(request.timeout);
-      request.reject(new Error('Connection closed'));
+      request.reject(error);
     }
     this.pendingRequests.clear();
+  }
 
-    if (this.ws) {
-      // Remove all listeners to prevent stray callbacks (e.g. the 'close'
-      // handler scheduling a reconnect or keeping the EventEmitter alive).
-      this.ws.removeAllListeners();
-      // terminate() destroys the underlying socket immediately instead of
-      // waiting for the TCP close handshake, which lets the Node.js event
-      // loop exit promptly.
-      this.ws.terminate();
-      this.ws = null;
+  private closeSocket(): void {
+    if (!this.ws) {
+      return;
     }
 
-    this.status = 'disconnected';
+    // Remove listeners so a deliberate reconnect does not trigger stale close
+    // handlers or schedule a reconnect against the previous relay URL.
+    this.ws.removeAllListeners();
+    this.ws.terminate();
+    this.ws = null;
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,20 @@ const SERVER_NAME = 'vibebrowser-mcp';
 const SERVER_VERSION = getPackageVersion();
 const STARTUP_TOOLS_REFRESH_TIMEOUT_MS = 4_000;
 const STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS = 1_500;
+const SET_REMOTE_TOOL: ToolDefinition = {
+  name: 'set_remote',
+  description: 'Reconnect this MCP server to a full Vibe remote websocket relay URL.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: {
+        type: 'string',
+        description: 'Full websocket relay URL, for example wss://relay.api.vibebrowser.app/<extension-uuid>',
+      },
+    },
+    required: ['url'],
+  },
+};
 
 type HttpTransport = StreamableHTTPServerTransport;
 type HttpRequest = IncomingMessage & { body?: unknown };
@@ -253,7 +267,7 @@ export class VibeMcpServer {
       }
 
       return {
-        tools: this.connection.getTools().map((tool: ToolDefinition) => ({
+        tools: [SET_REMOTE_TOOL, ...this.connection.getTools()].map((tool: ToolDefinition) => ({
           name: tool.name,
           description: tool.description,
           inputSchema: tool.inputSchema,
@@ -265,6 +279,10 @@ export class VibeMcpServer {
       const { name, arguments: args } = request.params;
 
       try {
+        if (normalizeToolName(name) === SET_REMOTE_TOOL.name) {
+          return await this.handleSetRemoteTool(toRecord(args));
+        }
+
         const preparedArgs = this.withDefaultPageStateFormat(name, toRecord(args));
         const result = await this.connection.callTool(name, preparedArgs);
         const enriched = await this.withFallbackPageContent(name, preparedArgs, result);
@@ -283,6 +301,37 @@ export class VibeMcpServer {
     });
 
     return server;
+  }
+
+  private async handleSetRemoteTool(args: Record<string, unknown>): Promise<{ content: ToolResult['content']; isError?: boolean }> {
+    if (!(this.connection instanceof ExtensionConnection)) {
+      return {
+        content: [{ type: 'text', text: 'Error: set_remote is not supported when using the chrome-devtools fallback backend' }],
+        isError: true,
+      };
+    }
+
+    if (typeof args.url !== 'string' || args.url.trim().length === 0) {
+      return {
+        content: [{ type: 'text', text: 'Error: set_remote requires a non-empty string url' }],
+        isError: true,
+      };
+    }
+
+    const remote = await this.connection.setRemoteUrl(args.url.trim());
+    this.notifyToolListChanged();
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          ok: true,
+          mode: 'remote',
+          relayUrl: remote.relayUrl,
+          uuid: remote.uuid,
+        }),
+      }],
+    };
   }
 
   private withDefaultPageStateFormat(name: string, args: Record<string, unknown>): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- Adds `@vibebrowser/cli` standalone npm package (`npx @vibebrowser/cli --remote <uuid-or-url>`)
- Simplifies `--remote` to accept either a UUID or full `wss://` URL (removes `--relay-url` from CLI surface)
- Adds `set_remote` MCP server tool for hot relay reconnect without process restart
- Adds `VIBE_REMOTE_URL` env variable support
- Updates CI publish workflow for dual-package publish (`@vibebrowser/mcp` + `@vibebrowser/cli`)
- Updates docs, SKILL.md, and agent knowledgebase
- Bumps to v0.2.8

## Testing
- All e2e tests pass: `browser cli e2e ok`, `http e2e ok`, `devtools flag e2e ok`
- `npm pack` smoke test for `@vibebrowser/cli` passed

Closes #54, closes #58