### PR TITLE
fix: increase call_tool timeout to 120s and handle tool_progress messages

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -116,6 +116,7 @@ interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
   timeout: NodeJS.Timeout;
+  timeoutMs: number;
 }
 
 /**
@@ -412,6 +413,18 @@ export class ExtensionConnection extends EventEmitter {
     if (message.requestId) {
       const pending = this.pendingRequests.get(message.requestId);
       if (pending) {
+        // Progress signals reset the timeout without completing the request.
+        // The extension sends these periodically for long-running tools so
+        // the client doesn't time out prematurely.
+        if (message.type === 'tool_progress') {
+          clearTimeout(pending.timeout);
+          pending.timeout = setTimeout(() => {
+            this.pendingRequests.delete(message.requestId!);
+            pending.reject(new Error(`Request timed out (progress-extended)`));
+          }, pending.timeoutMs);
+          return;
+        }
+
         clearTimeout(pending.timeout);
         this.pendingRequests.delete(message.requestId);
 
@@ -491,6 +504,7 @@ export class ExtensionConnection extends EventEmitter {
         resolve: resolve as (value: unknown) => void,
         reject,
         timeout,
+        timeoutMs,
       });
 
       const enrichedData = this.withSessionSelection(data);

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -47,7 +47,7 @@ const LOG_FILE = join(VIBE_DIR, 'relay.log');
  * Message from extension
  */
 interface ExtensionMessage {
-  type: 'connected' | 'disconnected' | 'tool_result' | 'tools_list' | 'error';
+  type: 'connected' | 'disconnected' | 'tool_result' | 'tool_progress' | 'tools_list' | 'error';
   requestId?: string;
   data?: unknown;
   error?: string;
@@ -332,6 +332,19 @@ export class RelayServer extends EventEmitter {
     if (message.requestId) {
       const pending = this.pendingRequests.get(message.requestId);
       if (pending) {
+        // Progress signals: forward to the agent but keep the pending entry.
+        if (message.type === 'tool_progress') {
+          const agent = this.agents.get(pending.agentId);
+          if (agent) {
+            agent.ws.send(JSON.stringify({
+              ...message,
+              sessionId: session.sessionId,
+              requestId: pending.originalRequestId,
+            }));
+          }
+          return;
+        }
+
         this.pendingRequests.delete(message.requestId);
 
         // Forward response to the requesting agent

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,14 @@ const SERVER_NAME = 'vibebrowser-mcp';
 const SERVER_VERSION = getPackageVersion();
 const STARTUP_TOOLS_REFRESH_TIMEOUT_MS = 4_000;
 const STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS = 1_500;
+/**
+ * Timeout for tool execution via the relay/extension pipeline.
+ * Page-interacting tools can take up to ~40s (CDP execution + post-action
+ * stabilization + page content extraction) and the relay adds forwarding
+ * latency.  120s provides headroom for heavy pages while still failing
+ * promptly on genuine hangs.
+ */
+const CALL_TOOL_TIMEOUT_MS = 120_000;
 const SET_REMOTE_TOOL: ToolDefinition = {
   name: 'set_remote',
   description: 'Reconnect this MCP server to a full Vibe remote websocket relay URL.',
@@ -284,7 +292,7 @@ export class VibeMcpServer {
         }
 
         const preparedArgs = this.withDefaultPageStateFormat(name, toRecord(args));
-        const result = await this.connection.callTool(name, preparedArgs);
+        const result = await this.connection.callTool(name, preparedArgs, CALL_TOOL_TIMEOUT_MS);
         const enriched = await this.withFallbackPageContent(name, preparedArgs, result);
 
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface RelaySessionSummary {
  * Message from extension to MCP server
  */
 export interface ExtensionMessage {
-  type: 'connected' | 'disconnected' | 'tool_result' | 'tools_list' | 'error' | 'extension_status' | 'extension_disconnected' | 'sessions_list';
+  type: 'connected' | 'disconnected' | 'tool_result' | 'tool_progress' | 'tools_list' | 'error' | 'extension_status' | 'extension_disconnected' | 'sessions_list';
   requestId?: string;
   data?: unknown;
   error?: string;


### PR DESCRIPTION
## Summary
Fixes VibeTechnologies/VibeWebAgent#1293

## Root Cause
The MCP server called connection.callTool() without a timeout override, defaulting to 30s. Page-interacting tools can take 40s+ through the relay pipeline. The 30s timeout expired before the extension responded, causing the pending request to be deleted and the tool_result silently dropped.

## Changes
- server.ts: Pass CALL_TOOL_TIMEOUT_MS (120s) to callTool()
- connection.ts: Handle tool_progress by resetting timeout, not resolving
- relay.ts: Forward tool_progress without deleting pending entry
- types.ts: Add tool_progress to ExtensionMessage type union

## Testing
All tests pass.