### PR TITLE
fix: remove legacy snapshot tool names, add tool-not-found validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,8 +350,8 @@ Local-session selection:
 
 Snapshot behavior is tool-only (no legacy snapshot RPC shortcut):
 
-- `snapshot` (default, `--format ai`) resolves via `take_md_snapshot` — uses the content script's in-page markdown extractor. Fast and readable, but **may return empty for background tabs or complex SPAs** (Notion, Gmail) where the content script is unreachable or layout is not computed.
-- `snapshot --format aria` resolves via `take_a11y_snapshot` — uses Chrome DevTools Protocol `Accessibility.getFullAXTree` directly. **Reliable for all tabs including background tabs and SPAs.** Use this as a fallback when the default format returns empty or only a page title.
+- `snapshot` (default, `--format ai`) resolves via `take_snapshot` with `format: 'markdown'` — uses the content script's in-page markdown extractor. Fast and readable, but **may return empty for background tabs or complex SPAs** (Notion, Gmail) where the content script is unreachable or layout is not computed.
+- `snapshot --format aria` resolves via `take_snapshot` with `format: 'aria'` — uses Chrome DevTools Protocol `Accessibility.getFullAXTree` directly. **Reliable for all tabs including background tabs and SPAs.** Use this as a fallback when the default format returns empty or only a page title.
 
 This keeps CLI behavior aligned with extension-supported tools and ensures page targeting works consistently with `--page-id`/`--pageId`.
 

--- a/dist/server.js
+++ b/dist/server.js
@@ -242,8 +242,18 @@ export class VibeMcpServer {
                 if (normalizeToolName(name) === SET_REMOTE_TOOL.name) {
                     return await this.handleSetRemoteTool(toRecord(args));
                 }
+                // Validate tool exists before forwarding to extension
+                const availableTools = this.connection.getTools();
+                const matchedTool = this.findToolByName(name);
+                if (!matchedTool && availableTools.length > 0) {
+                    const toolNames = availableTools.map(t => t.name);
+                    return {
+                        content: [{ type: 'text', text: `Error: Tool '${name}' does not exist. Available tools: ${toolNames.join(', ')}` }],
+                        isError: true,
+                    };
+                }
                 const preparedArgs = this.withDefaultPageStateFormat(name, toRecord(args));
-                const result = await this.connection.callTool(name, preparedArgs, CALL_TOOL_TIMEOUT_MS);
+                const result = await this.connection.callTool(matchedTool?.name ?? name, preparedArgs, CALL_TOOL_TIMEOUT_MS);
                 const enriched = await this.withFallbackPageContent(name, preparedArgs, result);
                 return {
                     content: enriched.content,

--- a/docs/openclaw-local-browser.md
+++ b/docs/openclaw-local-browser.md
@@ -158,8 +158,8 @@ npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json status
 
 `snapshot` in `vibebrowser-cli` is tool-only and maps directly to extension snapshot tools:
 
-- default (`--format ai`) -> `take_md_snapshot`
-- ARIA (`--format aria`) -> `take_a11y_snapshot`
+- default (`--format ai`) -> `take_snapshot` (format: markdown)
+- ARIA (`--format aria`) -> `take_snapshot` (format: aria)
 
 Use `--page-id <id>` (or `--pageId <id>`) to target a specific tab without switching user focus.
 

--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -113,7 +113,7 @@ If `jq` is unavailable, parse `.pages` from `tabs --json` directly and still pas
   npx @vibebrowser/cli --remote "$VIBE_REMOTE_URL" --json --page-id 2 click 7
   ```
 - Prefer `tabs` or `snapshot` before acting.
-- `snapshot` is tool-only and maps to extension snapshot tools (`take_md_snapshot` by default, `take_a11y_snapshot` for `--format aria`).
+- `snapshot` is tool-only and maps to the extension's `take_snapshot` tool (with `format` param for markdown vs aria).
 - Use `open <url>` to create a fresh page when possible.
 - Use `evaluate --fn ...` only for simple compatibility-safe expressions such as:
   - `() => 21 + 21`

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -774,7 +774,7 @@ class BrowserCliContext {
       'snapshot',
       [
         {
-          names: [wantsAria ? 'take_a11y_snapshot' : 'take_md_snapshot'],
+          names: ['take_snapshot'],
           buildArgs: (tool: ToolDefinition) => withSnapshotArgs(tool, options),
         },
       ],
@@ -1244,7 +1244,7 @@ class BrowserCliContext {
     return {
       ...output,
       pageContent: fallback.content,
-      pageContentSource: 'take_md_snapshot',
+      pageContentSource: 'take_snapshot',
       ...(fallback.pageId !== targetPageId ? { pageId: fallback.pageId } : {}),
     };
   }
@@ -1283,7 +1283,7 @@ class BrowserCliContext {
       sessionId: this.currentSessionId(),
       requestedSessionId: this.requestedSessionId,
       ignoredCompatibilityOptions: this.ignoredCompatibilityOptions,
-      tool: 'take_md_snapshot',
+      tool: 'take_snapshot',
       recoveredFromTimeout: true,
       pageId: fallback.pageId,
       url,
@@ -1344,7 +1344,7 @@ class BrowserCliContext {
 
   private async takeMarkdownSnapshotForPage(pageId: number, timeoutMs: number = this.timeoutMs): Promise<string | undefined> {
     await this.ensureToolsLoaded();
-    const snapshotTool = this.tools.find((tool) => normalizeName(tool.name) === 'take_md_snapshot');
+    const snapshotTool = this.tools.find((tool) => normalizeName(tool.name) === 'take_snapshot');
     if (!snapshotTool) {
       return undefined;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -291,8 +291,19 @@ export class VibeMcpServer {
           return await this.handleSetRemoteTool(toRecord(args));
         }
 
+        // Validate tool exists before forwarding to extension
+        const availableTools = this.connection.getTools();
+        const matchedTool = this.findToolByName(name);
+        if (!matchedTool && availableTools.length > 0) {
+          const toolNames = availableTools.map(t => t.name);
+          return {
+            content: [{ type: 'text', text: `Error: Tool '${name}' does not exist. Available tools: ${toolNames.join(', ')}` }],
+            isError: true,
+          };
+        }
+
         const preparedArgs = this.withDefaultPageStateFormat(name, toRecord(args));
-        const result = await this.connection.callTool(name, preparedArgs, CALL_TOOL_TIMEOUT_MS);
+        const result = await this.connection.callTool(matchedTool?.name ?? name, preparedArgs, CALL_TOOL_TIMEOUT_MS);
         const enriched = await this.withFallbackPageContent(name, preparedArgs, result);
 
         return {


### PR DESCRIPTION
## Summary
- Remove remaining references to `take_md_snapshot` and `take_a11y_snapshot` in browser-cli and docs — the extension only exposes `take_snapshot`
- Add server-side validation: when an agent calls a non-existent tool (e.g. hallucinated `take_content_snapshot`), return an error listing available tools so the LLM can self-correct