### PR TITLE
feat: allow direct npx execution for @vibebrowser/mcp

### DIFF
--- a/.agents/knowledgebase/architecture.md
+++ b/.agents/knowledgebase/architecture.md
@@ -6,7 +6,7 @@
 
 ## Main Entry Points
 
-- Package binaries from `package.json`: `vibebrowser-mcp`, legacy alias `vibe-mcp`, and standalone `vibebrowser-cli`.
+- Package binaries from `package.json`: `mcp` (direct package-exec entry), `vibebrowser-mcp`, legacy alias `vibe-mcp`, and standalone `vibebrowser-cli`.
 - `src/cli.ts`: MCP server CLI. Default command is `start`; supports stdio and streamable HTTP transports, local relay mode, remote relay mode, `--devtools`, and `openclaw` config printing.
 - `src/server.ts`: MCP protocol server. Exposes tool listing/calling over stdio or HTTP and delegates to an extension/relay connection or Chrome DevTools fallback.
 - `src/browser-main.ts` and `src/browser-cli.ts`: OpenClaw-compatible browser CLI surface for status, sessions, tabs, open/navigate, snapshots, clicks, typing, upload/drop, network, and evaluation helpers.

--- a/.agents/knowledgebase/operations.md
+++ b/.agents/knowledgebase/operations.md
@@ -7,7 +7,7 @@
 - TypeScript watch: `npm run dev`
 - Start local stdio MCP server from built output: `npm start`
 - Start HTTP MCP endpoint: `npm run build && node dist/cli.js start --transport http`
-- Print OpenClaw bridge config: `npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <uuid>` or `npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote <full-ws-url>`
+- Print OpenClaw bridge config: `npx -y @vibebrowser/mcp@latest openclaw --remote <uuid>` or `npx -y @vibebrowser/mcp@latest openclaw --remote <full-ws-url>`
 - Standalone CLI status: `npx @vibebrowser/cli --remote <uuid> --json status`
 - Standalone CLI tabs: `npx @vibebrowser/cli --remote <full-ws-url> --json tabs`
 - Prefer `--page-id <id>` for browser actions to avoid disrupting the user's active tab.
@@ -44,7 +44,7 @@ Pass signals from `docs/eval.md` and `AGENTS.md`:
 
 - `prepublishOnly` runs `npm run build`.
 - Published npm package includes `dist`, `openclaw`, `docs`, `README.md`, and `LICENSE`.
-- Current MCP package binaries are `vibebrowser-mcp`, `vibe-mcp`, and `vibebrowser-cli`; normal direct browser CLI docs use the separate `@vibebrowser/cli` package.
+- Current MCP package binaries are `mcp`, `vibebrowser-mcp`, `vibe-mcp`, and `vibebrowser-cli`; normal direct browser CLI docs use the separate `@vibebrowser/cli` package.
 - Package smoke check pattern: create a tarball with `npm pack --json --pack-destination <tmp>` and verify `vibebrowser-mcp --help` plus browser CLI help via the relevant package under test.
 - `docs/eval.md` records npm/publish verification history and should be updated when evaluation scope or pass criteria changes.
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,23 @@ Add to your Codex configuration:
 
 </details>
 
+### MCP command forms
+
+Use the shortest direct package invocation for the MCP server:
+
+```bash
+npx -y @vibebrowser/mcp@latest --help
+npx -y @vibebrowser/mcp@latest start --transport http
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID"
+```
+
+Backward-compatible aliases still work when you need explicit binaries:
+
+```bash
+npx -y -p @vibebrowser/mcp@latest vibebrowser-mcp --help
+npx -y -p @vibebrowser/mcp@latest vibe-mcp --help
+```
+
 ### 3. Connect the Extension
 
 1. Open Chrome with the Vibe extension installed
@@ -274,8 +291,8 @@ If your agent runs in the cloud but you want it to control the user's real local
 VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 
-npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remote "$VIBE_REMOTE_UUID"
-npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remote "$VIBE_REMOTE_URL"
+npx -y @vibebrowser/mcp@latest start --transport http --remote "$VIBE_REMOTE_UUID"
+npx -y @vibebrowser/mcp@latest start --transport http --remote "$VIBE_REMOTE_URL"
 ```
 
 This exposes a local MCP endpoint at `http://127.0.0.1:8788/mcp` by default.
@@ -287,8 +304,8 @@ VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 PUBLIC_MCP_URL="https://browser-bridge.example.com/mcp"
 
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
 ```
 
 You can print the exact OpenClaw-friendly setup with:
@@ -297,8 +314,8 @@ You can print the exact OpenClaw-friendly setup with:
 VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID"
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL"
 ```
 
 Use `--remote <uuid>` with the default public relay, or `--remote <full-ws-url>` when you need an explicit relay endpoint.
@@ -393,7 +410,7 @@ See [docs/openclaw-local-browser.md](docs/openclaw-local-browser.md) for the com
 Run a local LLM with one command — no cloud API keys required. Automatically installs [Ollama](https://ollama.com), downloads the model, and starts serving an OpenAI-compatible API.
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-mcp serve qwen3.5
+npx -y @vibebrowser/mcp@latest serve qwen3.5
 ```
 
 That's it. Works on **macOS**, **Linux**, and **Windows**.
@@ -408,16 +425,16 @@ That's it. Works on **macOS**, **Linux**, and **Windows**.
 ### Recommended models
 
 ```bash
-npx -y --package @vibebrowser/mcp vibebrowser-mcp serve qwen3.5      # Best overall for agentic tasks
-npx -y --package @vibebrowser/mcp vibebrowser-mcp serve llama4        # Strong general reasoning
-npx -y --package @vibebrowser/mcp vibebrowser-mcp serve deepseek-r1   # Reasoning chains
-npx -y --package @vibebrowser/mcp vibebrowser-mcp serve mistral       # Lightweight & fast (7B)
+npx -y @vibebrowser/mcp@latest serve qwen3.5      # Best overall for agentic tasks
+npx -y @vibebrowser/mcp@latest serve llama4        # Strong general reasoning
+npx -y @vibebrowser/mcp@latest serve deepseek-r1   # Reasoning chains
+npx -y @vibebrowser/mcp@latest serve mistral       # Lightweight & fast (7B)
 ```
 
 ### Options
 
 ```text
-npx -y --package @vibebrowser/mcp vibebrowser-mcp serve <model> [options]
+npx -y @vibebrowser/mcp@latest serve <model> [options]
 
 Options:
   -p, --port <number>  Ollama API port (default: 11434)
@@ -436,11 +453,11 @@ The extension connects to `http://localhost:11434/v1` automatically.
 ## CLI Options
 
 ```text
-npx -y --package @vibebrowser/mcp vibebrowser-mcp --help
+npx -y @vibebrowser/mcp@latest --help
 npx @vibebrowser/cli --help
 
 # MCP server (default)
-npx -y --package @vibebrowser/mcp vibebrowser-mcp [start] [options]
+npx -y @vibebrowser/mcp@latest [start] [options]
   -p, --port <number>  WebSocket port for local relay (agent) connection (default: 19888)
   -d, --debug          Enable debug logging
   --transport <mode>   MCP transport to expose: stdio or http (default: stdio)
@@ -462,8 +479,8 @@ The `set_remote` MCP server tool hot-reconnects the running MCP server to a diff
 VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 PUBLIC_MCP_URL="https://browser-bridge.example.com/mcp"
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
 
 # OpenClaw-compatible browser CLI
 npx @vibebrowser/cli --remote "$VIBE_REMOTE_UUID" status
@@ -476,7 +493,7 @@ npx @vibebrowser/cli --devtools tabs
 
 # Local LLM server
 MODEL="qwen3.5"
-npx -y --package @vibebrowser/mcp vibebrowser-mcp serve "$MODEL"
+npx -y @vibebrowser/mcp@latest serve "$MODEL"
   -p, --port <number>  Ollama API port (default: 11434)
   -y, --yes            Skip confirmation prompts
   -d, --debug          Enable debug logging
@@ -506,7 +523,7 @@ Enable debug logging to diagnose issues:
   "mcpServers": {
     "vibe": {
       "command": "npx",
-      "args": ["-y", "--package", "@vibebrowser/mcp", "vibebrowser-mcp", "--debug"]
+      "args": ["-y", "@vibebrowser/mcp", "--debug"]
     }
   }
 }

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -7,6 +7,11 @@ This document tracks the current validation matrix for the `vibebrowser-mcp` and
 - published npm validation (`@vibebrowser/mcp@latest`)
 - real-extension browser evals versus fake-extension protocol evals
 
+Command convention for this document:
+
+- Direct package exec (preferred for MCP server): `npx -y @vibebrowser/mcp@latest ...`
+- Explicit bin aliases (backward compatibility checks): `npx -y -p @vibebrowser/mcp@latest vibebrowser-mcp ...` and `npx -y -p @vibebrowser/mcp@latest vibe-mcp ...`
+
 Evaluation date: **March 26, 2026 (America/Los_Angeles)**.
 
 ## Coverage Matrix
@@ -124,15 +129,16 @@ Pass signal:
 
 ```bash
 cd /Users/engineer/workspace/vibebrowser/vibe-mcp
-npx -y --package @vibebrowser/mcp@latest vibebrowser-mcp --version
-npx -y --package @vibebrowser/mcp@latest vibe-mcp --version
-npx -y --package @vibebrowser/mcp@latest vibebrowser-cli --version
+npx -y @vibebrowser/mcp@latest --version
+npx -y -p @vibebrowser/mcp@latest vibebrowser-mcp --version
+npx -y -p @vibebrowser/mcp@latest vibe-mcp --version
+npx -y -p @vibebrowser/mcp@latest vibebrowser-cli --version
 E2E_BROWSER_CLI_SOURCE=npm node scripts/e2e-browser-cli.mjs
 ```
 
 Pass signal:
 
-- all three binaries print the published version
+- direct package invocation and all aliases print the published version
 - `browser cli e2e ok` proves `vibebrowser-cli` works from the npm registry package, not only from a local tarball
 
 ### 5. Real-extension agent eval
@@ -247,14 +253,15 @@ Commands executed in this session:
 | `npx -y --package <local-tarball> vibebrowser-mcp --help` | PASS | branded `vibebrowser-mcp` binary available from package artifact |
 | `npx -y --package <local-tarball> vibebrowser-cli --help` | PASS | standalone `vibebrowser-cli` binary available from package artifact |
 | `gh workflow run "Publish to npm" --ref release/vibebrowser-cli-0.2.5` | PASS | GitHub publish workflow completed successfully |
-| `npm view @vibebrowser/mcp version dist-tags.latest bin --json` | PASS | npm `latest` is now `0.2.5` and includes `vibebrowser-mcp`, `vibe-mcp`, and `vibebrowser-cli` |
-| `npx -y --package @vibebrowser/mcp@latest vibebrowser-mcp --version` | PASS | published npm binary resolves to `0.2.5` |
-| `npx -y --package @vibebrowser/mcp@latest vibe-mcp --version` | PASS | legacy alias still resolves to `0.2.5` |
+| `npm view @vibebrowser/mcp version dist-tags.latest bin --json` | PASS | npm `latest` is now `0.2.5` and includes `mcp`, `vibebrowser-mcp`, `vibe-mcp`, and `vibebrowser-cli` |
+| `npx -y @vibebrowser/mcp@latest --version` | PASS | direct package invocation resolves to published CLI |
+| `npx -y -p @vibebrowser/mcp@latest vibebrowser-mcp --version` | PASS | published explicit binary resolves to `0.2.5` |
+| `npx -y -p @vibebrowser/mcp@latest vibe-mcp --version` | PASS | legacy alias still resolves to `0.2.5` |
 | `npm run test:e2e:agents` | PASS | local `dist/cli.js` path completed all three MiniWoB tasks with Codex + OpenCode against the live extension session |
 | `E2E_MCP_SOURCE=npm npm run test:e2e:agents` | PASS | published npm binary path completed the same three MiniWoB tasks end to end |
 | `E2E_DEBUG=1 E2E_TEST_BROWSER=1 E2E_VIBE_REPO_ROOT=/Users/engineer/workspace/vibebrowser/vibe E2E_TEST_EXTENSION_PATH=/Users/engineer/workspace/vibebrowser/vibe/dist/extension/dev E2E_MCP_SOURCE=npm node scripts/e2e-mcp-agents.mjs` | PASS | debug run against a separate Chrome for Testing instance with the unpacked extension build |
 | `E2E_TEST_BROWSER=1 E2E_VIBE_REPO_ROOT=/Users/engineer/workspace/vibebrowser/vibe E2E_TEST_EXTENSION_PATH=/Users/engineer/workspace/vibebrowser/vibe/dist/extension/dev E2E_MCP_SOURCE=npm npm run test:e2e:agents` | PASS | canonical repo entrypoint passed against the latest built extension in isolated browser mode |
-| `npx -y --package @vibebrowser/mcp@latest vibebrowser-cli --version` | PASS | standalone CLI is now available from npm `latest` |
+| `npx -y -p @vibebrowser/mcp@latest vibebrowser-cli --version` | PASS | standalone CLI is now available from npm `latest` |
 | `E2E_BROWSER_CLI_SOURCE=npm node scripts/e2e-browser-cli.mjs` | PASS | npm-installed `vibebrowser-cli` passed end to end |
 | `npm run test:e2e:browser-cli-live` | PASS | real extension run against X search URL; reported open latency `60718ms`, open content `9119` chars, snapshot content `9564` chars |
 | `E2E_MCP_SOURCE=pack node scripts/e2e-mcp-agents.mjs` | FAIL (environment) | timed out waiting for a live Vibe extension connection on the relay path |
@@ -278,6 +285,7 @@ Current npm state:
 
 - `npm view @vibebrowser/mcp version dist-tags.latest bin --json` returns `0.2.5`
 - `@latest` now includes:
+  - `mcp`
   - `vibebrowser-mcp`
   - `vibe-mcp`
   - `vibebrowser-cli`

--- a/docs/openclaw-local-browser.md
+++ b/docs/openclaw-local-browser.md
@@ -96,8 +96,8 @@ On the same machine where the browser extension is installed, run one of these r
 VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID"
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL"
 ```
 
 This prints the exact commands and MCP URL you need.
@@ -109,8 +109,8 @@ VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 PUBLIC_MCP_URL="https://browser-bridge.example.com/mcp"
 
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
-npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
 ```
 
 **Option B: Manual command**
@@ -119,8 +119,8 @@ npx -y --package @vibebrowser/mcp vibebrowser-mcp openclaw --remote "$VIBE_REMOT
 VIBE_REMOTE_UUID="2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/2d2f60a1-2031-4279-aa25-358f2c5b6f84"
 
-npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remote "$VIBE_REMOTE_UUID"
-npx -y --package @vibebrowser/mcp vibebrowser-mcp start --transport http --remote "$VIBE_REMOTE_URL"
+npx -y @vibebrowser/mcp@latest start --transport http --remote "$VIBE_REMOTE_UUID"
+npx -y @vibebrowser/mcp@latest start --transport http --remote "$VIBE_REMOTE_URL"
 ```
 
 By default this starts a local MCP endpoint at:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "ws": "^8.18.0"
       },
       "bin": {
+        "mcp": "dist/cli.js",
         "vibe-mcp": "dist/cli.js",
         "vibebrowser-cli": "dist/browser-main.js",
         "vibebrowser-mcp": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "packages/*"
   ],
   "bin": {
+    "mcp": "./dist/cli.js",
     "vibebrowser-mcp": "./dist/cli.js",
     "vibe-mcp": "./dist/cli.js",
     "vibebrowser-cli": "./dist/browser-main.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,9 +89,7 @@ program
 
     const cliArgs = [
       '-y',
-      '--package',
-      '@vibebrowser/mcp',
-      'vibebrowser-mcp',
+      '@vibebrowser/mcp@latest',
       'start',
       '--transport',
       'http',

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -2,7 +2,7 @@
  * Ollama integration — detect, install, pull, serve.
  *
  * Provides a cross-platform (macOS / Linux / Windows) one-liner experience:
- *   npx --yes --package @vibebrowser/mcp vibebrowser-mcp serve qwen3.5
+ *   npx -y @vibebrowser/mcp@latest serve qwen3.5
  */
 
 import { execSync, spawn, ChildProcess, execFileSync, SpawnOptions } from 'child_process';


### PR DESCRIPTION
## Summary
- add `mcp` bin alias in `@vibebrowser/mcp` so direct package invocation works (`npx -y @vibebrowser/mcp@latest ...`)
- keep existing explicit aliases (`vibebrowser-mcp`, `vibe-mcp`, `vibebrowser-cli`) unchanged for compatibility
- update OpenClaw helper output and docs to prefer direct package execution for MCP commands

## Why
Users expect MCP commands to be as short as CLI commands and asked to avoid repeating the binary token after `npx`. With the new alias, the package is directly executable in the same style.

## Validation
- `npm run build`
- `npm test`
- local package smoke checks:
  - `npx -y @vibebrowser/mcp@file:/tmp/opencode/vibe-mcp-issue-62 --help`
  - `npx -y @vibebrowser/mcp@file:/tmp/opencode/vibe-mcp-issue-62 --version`
  - `npx -y @vibebrowser/mcp@file:/tmp/opencode/vibe-mcp-issue-62 start --help`
  - `npx -y @vibebrowser/mcp@file:/tmp/opencode/vibe-mcp-issue-62 browser --help`
  - `npx -y @vibebrowser/mcp@file:/tmp/opencode/vibe-mcp-issue-62 openclaw --remote <uuid>` prints direct command form

## Note
Direct `@latest` command examples rely on this new bin being published. Existing explicit aliases continue to work before and after publish.

Closes #62