### PR TITLE
chore: release v0.2.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.2.9",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibebrowser/mcp",
-      "version": "0.2.9",
+      "version": "0.2.11",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -1236,7 +1236,7 @@
     },
     "packages/cli": {
       "name": "@vibebrowser/cli",
-      "version": "0.2.9",
+      "version": "0.2.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "MCP server for browser automation - the only solution supporting multiple AI agents (Claude, Cursor, VS Code) simultaneously controlling your Chrome browser",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibebrowser/cli",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "Standalone Vibe Browser CLI for controlling a Vibe-connected browser session",
   "bin": {


### PR DESCRIPTION
## Summary
- bump `@vibebrowser/mcp` to `0.2.11`
- bump `@vibebrowser/cli` to `0.2.11`

## Why
PR #63 added the `mcp` bin alias for direct package execution, but publish was skipped because version `0.2.10` was already on npm. This release bump triggers publish so npm `latest` includes that alias.

## Scope
Version bump only:
- `package.json`
- `packages/cli/package.json`
- `package-lock.json`

## Verification
- `npm run build` passes
- No functional code changes in this PR

Refs #64