### PR TITLE
fix: ship startup fallback and set_remote UUID support

### DIFF
--- a/.tasks/67/STATE.md
+++ b/.tasks/67/STATE.md
@@ -14,3 +14,7 @@
 - phase: 5b-code-fix-applied
 - phase: 5c-pass
 - phase: 5b-pass
+- phase: 6-pr-open
+- pr: 68
+- phase: 6-ci-green
+- phase: 7-ship-recommended

--- a/.tasks/67/STATE.md
+++ b/.tasks/67/STATE.md
@@ -1,0 +1,11 @@
+# Task 67 - STATE
+- phase: 1-done
+- issue: #67
+- branch: own/66-publish-recent-mcp
+- started: 2026-05-26T00:00:00Z
+- supervisor: gpt-5.3-codex
+- phase: 2-done
+- phase: 3-done
+- phase: 4-approved
+- phase: 5-group-A-done
+- phase: 5-group-B-done

--- a/.tasks/67/STATE.md
+++ b/.tasks/67/STATE.md
@@ -12,3 +12,5 @@
 - phase: 5-implemented
 - phase: 5b-loop-1
 - phase: 5b-code-fix-applied
+- phase: 5c-pass
+- phase: 5b-pass

--- a/.tasks/67/STATE.md
+++ b/.tasks/67/STATE.md
@@ -9,3 +9,6 @@
 - phase: 4-approved
 - phase: 5-group-A-done
 - phase: 5-group-B-done
+- phase: 5-implemented
+- phase: 5b-loop-1
+- phase: 5b-code-fix-applied

--- a/.tasks/67/decisions.md
+++ b/.tasks/67/decisions.md
@@ -25,3 +25,17 @@
 - reasoning: Parallel group must avoid shared files; version bump already owned by task 3.
 - alternatives: Run tasks sequentially.
 - evidence: plan rule in skill: same parallel group must not touch same file.
+
+## Decision 5
+- question: Resolve set_remote review blocker by changing docs back or adding UUID support?
+- decision: Add real UUID support in `ExtensionConnection.setRemoteUrl`.
+- reasoning: design and UX both require UUID-first flow for agents; docs-only rollback keeps friction and violates stated fix intent.
+- alternatives: Revert description to URL-only.
+- evidence: review blocker line 1; issue goal is easier remote connect path when tools missing.
+
+## Decision 6
+- question: How to surface local startup fallback error in non-debug mode?
+- decision: Emit explicit `console.error` warning in fallback branch.
+- reasoning: `this.log` is debug-gated; degraded startup must be visible by default.
+- alternatives: Keep debug-only log.
+- evidence: review warning line 2.

--- a/.tasks/67/decisions.md
+++ b/.tasks/67/decisions.md
@@ -1,0 +1,27 @@
+## Decision 1
+- question: Which issue should own this work?
+- decision: Create new issue #67 instead of reusing #66.
+- reasoning: #66 focuses on auth/permissions pipeline failure. Current task goal is delivering latest local startup fix release end-to-end.
+- alternatives: Reuse #66.
+- evidence: #66 body scoped to org auth mismatch; local code changes not tracked there.
+
+## Decision 2
+- question: What speed/quality tradeoff to choose under autopilot?
+- decision: Balanced.
+- reasoning: Need quick ship, but release-impact path requires regression guard and post-merge verification.
+- alternatives: Fast (skip new e2e), Thorough (full test matrix and cross-repo eval before publish).
+- evidence: task asks for latest code delivery; core risk is startup regression, addressable with focused e2e.
+
+## Decision 3
+- question: Ask user for plan approval at Phase 4?
+- decision: Autopilot override applied; proceed without blocking question.
+- reasoning: Invocation includes `--autopilot` and skill mandates no AskUserQuestion.
+- alternatives: Pause for explicit `go`.
+- evidence: skill section `Autopilot (--autopilot): No AskUserQuestion calls. Decide every fork yourself.`
+
+## Decision 4
+- question: How to parallelize tasks 2 and 3 without file conflicts?
+- decision: Remove `package.json` from task 2 scope; keep task 2 script-only.
+- reasoning: Parallel group must avoid shared files; version bump already owned by task 3.
+- alternatives: Run tasks sequentially.
+- evidence: plan rule in skill: same parallel group must not touch same file.

--- a/.tasks/67/design.md
+++ b/.tasks/67/design.md
@@ -1,0 +1,48 @@
+## Problem
+Latest local fixes for MCP startup reliability are not shipped in npm latest. Agents running `npx -g @vibebrowser/mcp` can still miss improved behavior when local relay startup fails before MCP transport is ready and can miss clear guidance that `set_remote` should be called first when browser tools are unavailable.
+
+## Goal
+Ship a new npm release containing startup resilience + stronger `set_remote` metadata so npx users get fixes without local binary override.
+
+## Success Metric
+`npm view @vibebrowser/mcp dist-tags.latest --json` equals released version from this branch, and `npx -g @vibebrowser/mcp --version` returns same version while `npx -g @vibebrowser/mcp --help` succeeds.
+
+## Out of Scope
+- Changing relay protocol semantics.
+- Reworking publish workflow auth model.
+- Extension-side tool broadcast behavior.
+
+## Current State
+- `src/server.ts:45` has old `set_remote` description that does not signal "call first" behavior.
+- `src/server.ts:116` calls `await this.connection.start()` directly; local relay startup failure can abort server startup before MCP transport is available.
+- Package currently at `0.2.11` in `package.json:3`; npm latest already `0.2.11`, so new delivery needs version bump.
+- Publish workflow exists in `.github/workflows/publish.yml` and auto-publishes changed versions.
+
+## Proposed Design
+1. Update `SET_REMOTE_TOOL` description/input docs in `src/server.ts` to explicitly instruct clients to call `set_remote` first when browser tools are missing and clarify accepted inputs (UUID or full relay URL).
+2. Wrap `this.connection.start()` in `start()` with guarded error handling: in local non-devtools mode, log and continue server startup instead of failing hard; keep remote/devtools behavior strict.
+3. Bump package version for both root and CLI workspace so publish workflow pushes a new tag/version.
+4. Run local build + focused reconnect e2e to validate no regression before PR.
+5. Merge PR; monitor publish workflow; verify npm latest and npx behavior.
+
+## Alternatives Considered
+1. Keep hard-fail startup and rely on users to retry/restart.
+   - Rejected: does not deliver resilient startup path; leaves zero-tool startup failures unresolved.
+2. Move resilience into `ExtensionConnection.start()` instead of server wrapper.
+   - Rejected: wider side effects across callers and modes; server-level policy is simpler and explicit.
+3. Skip release bump and rely on direct local binary path.
+   - Rejected: user asked for npx package path; no npm delivery means fix unavailable for default users.
+
+## Risks & Open Questions
+- Risk: Catching local startup errors may mask real defects.
+  - Mitigation: only allow non-fatal path in local non-devtools mode; keep remote/devtools strict and log full message.
+- Risk: version bump may trigger publish conflict if version already exists.
+  - Mitigation: bump to new patch version and verify `npm view` before merge if needed.
+- Open question: none blocking for this task.
+
+## Touched Surface
+- `src/server.ts`
+- `package.json`
+- `package-lock.json`
+- `packages/cli/package.json`
+- `.tasks/67/*`

--- a/.tasks/67/plan.md
+++ b/.tasks/67/plan.md
@@ -1,0 +1,31 @@
+## Approach Summary
+Implement startup resilience + stronger `set_remote` guidance in `src/server.ts`, then release via patch version bump so npm `latest` ships new behavior. Validate with build and targeted e2e startup-failure regression plus npm/npx post-merge checks.
+
+## Tradeoff: Speed vs Quality
+- chosen: balanced
+- rationale: task small code delta but release impact high; add one focused regression test + release verification without broad refactors.
+
+## Tasks
+| # | Title | Files | Depends on | Parallel group | Suggested model |
+|---|-------|-------|------------|----------------|-----------------|
+| 1 | Update `set_remote` metadata and local startup fallback handling | `src/server.ts` | - | A | sonnet |
+| 2 | Add focused regression e2e for local startup failure path | `scripts/e2e-local-startup-fallback.mjs` | 1 | B | gpt-5.1-codex |
+| 3 | Bump package versions for publishable release | `package.json`, `packages/cli/package.json`, `package-lock.json` | 1 | B | sonnet |
+| 4 | Run build + focused e2e and capture reports | `.tasks/67/test-report.md` | 2,3 | C | sonnet |
+| 5 | Open PR, watch CI, final review, merge, post-merge verify npm delivery | `.tasks/67/review.md`, `.tasks/67/verify.md`, `.tasks/67/STATE.md` | 4 | D | sonnet |
+
+## Parallel Groups
+- **A**: task 1.
+- **B**: tasks 2 and 3 can run together after task 1 (no shared files).
+- **C**: task 4 after B.
+- **D**: task 5 after C.
+
+## Done Criteria
+- Task 1: `src/server.ts` catches local non-devtools startup failures and `set_remote` description clearly documents first-call behavior and input forms.
+- Task 2: new e2e script fails on old behavior and passes on new behavior by proving MCP starts and exposes `set_remote` after forced local relay startup failure.
+- Task 3: package versions incremented to unreleased patch value consistently across root + CLI + lockfile.
+- Task 4: `npm run build` and `node scripts/e2e-local-startup-fallback.mjs` pass; outputs recorded in test report.
+- Task 5: PR merged, publish workflow green, npm latest equals new version, `npx -g @vibebrowser/mcp --version` + `--help` succeed.
+
+## Rollback Plan
+If regression found after merge, revert merge commit from `main`, unpublish not required (npm immutable). Ship follow-up patch restoring previous startup behavior and preserving compatible `set_remote` metadata.

--- a/.tasks/67/review.md
+++ b/.tasks/67/review.md
@@ -1,0 +1,2 @@
+.tasks/67/plan.md:27: WARNING Previous code-level findings are fixed, but plan done-criteria for Tasks 4-5 are still not evidenced in this branch (`.tasks/67/test-report.md` and `.tasks/67/verify.md` are missing, and npm/npx verification is not recorded). Add the missing verification artifacts to close the issue against its success metric.
+VERDICT: fix-required.

--- a/.tasks/67/review.md
+++ b/.tasks/67/review.md
@@ -1,5 +1,6 @@
-src/server.ts:42: INFO `set_remote` tool metadata now documents call-first behavior and accepts UUID or full relay URL inputs. Keep this copy aligned with runtime behavior.
-src/server.ts:113: INFO Local non-devtools startup errors are now caught, warned, and MCP startup continues without tools; remote/devtools paths still fail fast. Keep fallback scope restricted to local mode.
-src/connection.ts:85: INFO `set_remote` now accepts bare UUID and reuses current relay base (or default) while preserving full URL parsing. Keep UUID/URL validation centralized in this parser.
-scripts/e2e-local-startup-fallback.mjs:84: INFO Integration test now verifies fallback startup plus `set_remote` behavior for both full relay URL and bare UUID. Keep this script in release regression checks.
-VERDICT: pass
+src/server.ts:42: INFO `set_remote` metadata now matches design: call-first guidance is explicit and both UUID/full URL inputs are documented. Keep docs and parser behavior in sync.
+src/server.ts:113: INFO Startup fallback is scoped to local non-devtools mode, while remote/devtools still fail fast. Keep this guard narrow to avoid masking remote failures.
+src/connection.ts:85: INFO Bare UUID targets are supported and normalized against relay base, satisfying the design contract for low-friction reconnect. Keep UUID validation centralized here.
+scripts/e2e-local-startup-fallback.mjs:84: INFO Regression coverage verifies MCP availability after local startup failure and `set_remote` behavior for URL + UUID. Keep this in release-gating checks.
+.github/workflows/publish.yml:1: INFO CI for PR #68 is green (`gh pr checks 68` shows `build: pass`), so no blocking pipeline failures are present pre-merge.
+FINAL: ship.

--- a/.tasks/67/review.md
+++ b/.tasks/67/review.md
@@ -1,2 +1,5 @@
-.tasks/67/plan.md:27: WARNING Previous code-level findings are fixed, but plan done-criteria for Tasks 4-5 are still not evidenced in this branch (`.tasks/67/test-report.md` and `.tasks/67/verify.md` are missing, and npm/npx verification is not recorded). Add the missing verification artifacts to close the issue against its success metric.
-VERDICT: fix-required.
+src/server.ts:42: INFO `set_remote` tool metadata now documents call-first behavior and accepts UUID or full relay URL inputs. Keep this copy aligned with runtime behavior.
+src/server.ts:113: INFO Local non-devtools startup errors are now caught, warned, and MCP startup continues without tools; remote/devtools paths still fail fast. Keep fallback scope restricted to local mode.
+src/connection.ts:85: INFO `set_remote` now accepts bare UUID and reuses current relay base (or default) while preserving full URL parsing. Keep UUID/URL validation centralized in this parser.
+scripts/e2e-local-startup-fallback.mjs:84: INFO Integration test now verifies fallback startup plus `set_remote` behavior for both full relay URL and bare UUID. Keep this script in release regression checks.
+VERDICT: pass

--- a/.tasks/67/test-plan.md
+++ b/.tasks/67/test-plan.md
@@ -1,0 +1,19 @@
+## Modality
+CLI / MCP integration test against real server process via stdio transport (no mocks).
+
+## Setup
+1. `npm ci` (if dependencies missing)
+2. `npm run build`
+
+## Steps
+1. Run `node scripts/e2e-local-startup-fallback.mjs`.
+   - Expected: script prints fallback warning and pass marker `local startup fallback e2e ok`.
+2. During script execution, assert MCP `listTools` returns `set_remote` after forced local relay startup failure.
+   - Expected: no MCP startup crash; tools list includes `set_remote`.
+3. In same script, call `set_remote` with a full local relay URL and verify JSON response.
+   - Expected: `ok: true`, `relayUrl` normalized to relay base, `uuid` matches URL UUID.
+4. In same script, call `set_remote` with bare UUID and verify JSON response.
+   - Expected: `ok: true`, `relayUrl` reused from current remote base, `uuid` matches bare UUID.
+
+## Pass criterion
+Build succeeds and script exits 0 with pass marker; this proves startup fallback remains reachable and `set_remote` works for URL + UUID forms.

--- a/.tasks/67/test-report.md
+++ b/.tasks/67/test-report.md
@@ -1,0 +1,20 @@
+## Commands
+- `npm run build`
+- `node scripts/e2e-local-startup-fallback.mjs`
+
+## Results
+1. `npm run build` - PASS
+   - Output: TypeScript compile and `prepare-cli-package` completed.
+2. `node scripts/e2e-local-startup-fallback.mjs` - PASS
+   - Output included:
+     - `[vibebrowser-mcp] Warning: local extension startup failed; continuing without tools: Relay failed to start within timeout`
+     - `local startup fallback e2e ok`
+
+## Assertions Verified
+- MCP server remains available after forced local relay startup failure.
+- `listTools` includes `set_remote` in fallback state.
+- `set_remote` accepts full `ws://.../<uuid>` URL and returns `{ ok: true, relayUrl, uuid }`.
+- `set_remote` accepts bare UUID and reuses remote relay base from existing remote config.
+
+## RESULT
+RESULT: pass

--- a/.tasks/67/worklog.md
+++ b/.tasks/67/worklog.md
@@ -1,0 +1,2 @@
+- Cycle 1: Created issue #67, wrote design + plan, set success metric to npm latest/npx verification parity.
+- Cycle 2: Implemented server startup fallback + set_remote description, added startup-fallback e2e script, bumped versions to 0.2.12.

--- a/.tasks/67/worklog.md
+++ b/.tasks/67/worklog.md
@@ -2,3 +2,5 @@
 - Cycle 2: Implemented server startup fallback + set_remote description, added startup-fallback e2e script, bumped versions to 0.2.12.
 - Cycle 3: Independent review found blocker in set_remote UUID claim mismatch; entering fix loop 1.
 - Cycle 4: Fixed review blockers by adding bare-UUID set_remote parsing and non-debug stderr warning for local startup fallback.
+- Cycle 5: Executed real stdio integration test plan; build + startup fallback e2e passed with URL/UUID set_remote assertions.
+- Cycle 6: Re-ran independent review with test evidence; verdict switched to pass.

--- a/.tasks/67/worklog.md
+++ b/.tasks/67/worklog.md
@@ -1,2 +1,4 @@
 - Cycle 1: Created issue #67, wrote design + plan, set success metric to npm latest/npx verification parity.
 - Cycle 2: Implemented server startup fallback + set_remote description, added startup-fallback e2e script, bumped versions to 0.2.12.
+- Cycle 3: Independent review found blocker in set_remote UUID claim mismatch; entering fix loop 1.
+- Cycle 4: Fixed review blockers by adding bare-UUID set_remote parsing and non-debug stderr warning for local startup fallback.

--- a/.tasks/67/worklog.md
+++ b/.tasks/67/worklog.md
@@ -4,3 +4,5 @@
 - Cycle 4: Fixed review blockers by adding bare-UUID set_remote parsing and non-debug stderr warning for local startup fallback.
 - Cycle 5: Executed real stdio integration test plan; build + startup fallback e2e passed with URL/UUID set_remote assertions.
 - Cycle 6: Re-ran independent review with test evidence; verdict switched to pass.
+- Cycle 7: Pushed branch and opened PR #68; PR body malformed from shell interpolation and needs post-create correction via API-safe path.
+- Cycle 8: Corrected PR body via REST, CI passed, final independent PR review returned FINAL: ship.

--- a/dist/server.js
+++ b/dist/server.js
@@ -27,13 +27,13 @@ const STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS = 1_500;
 const CALL_TOOL_TIMEOUT_MS = 120_000;
 const SET_REMOTE_TOOL = {
     name: 'set_remote',
-    description: 'Reconnect this MCP server to a full Vibe remote websocket relay URL.',
+    description: 'Set the remote relay target for this MCP server. If browser tools are missing, call set_remote first to connect to a Vibe relay.',
     inputSchema: {
         type: 'object',
         properties: {
             url: {
                 type: 'string',
-                description: 'Full websocket relay URL, for example wss://relay.api.vibebrowser.app/<extension-uuid>',
+                description: 'Remote target as either an extension UUID or a full websocket relay URL (for example wss://relay.api.vibebrowser.app/<extension-uuid>). Call set_remote first when browser tools are unavailable.',
             },
         },
         required: ['url'],
@@ -81,7 +81,18 @@ export class VibeMcpServer {
      * Start the MCP server
      */
     async start() {
-        await this.connection.start();
+        try {
+            await this.connection.start();
+        }
+        catch (error) {
+            if (!this.config.remoteUuid && !this.config.devtools) {
+                const message = error instanceof Error ? error.message : String(error);
+                this.log(`Local extension startup failed; continuing without tools: ${message}`);
+            }
+            else {
+                throw error;
+            }
+        }
         if (this.config.devtools) {
             if (this.connection instanceof DevtoolsFallbackConnection && this.connection.isAvailable()) {
                 this.log('Connected to chrome-devtools backend');

--- a/dist/server.js
+++ b/dist/server.js
@@ -88,6 +88,7 @@ export class VibeMcpServer {
             if (!this.config.remoteUuid && !this.config.devtools) {
                 const message = error instanceof Error ? error.message : String(error);
                 this.log(`Local extension startup failed; continuing without tools: ${message}`);
+                console.error(`[${SERVER_NAME}] Warning: local extension startup failed; continuing without tools: ${message}`);
             }
             else {
                 throw error;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibebrowser/mcp",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -1236,7 +1236,7 @@
     },
     "packages/cli": {
       "name": "@vibebrowser/cli",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "description": "MCP server for browser automation - the only solution supporting multiple AI agents (Claude, Cursor, VS Code) simultaneously controlling your Chrome browser",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibebrowser/cli",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "description": "Standalone Vibe Browser CLI for controlling a Vibe-connected browser session",
   "bin": {

--- a/scripts/e2e-local-startup-fallback.mjs
+++ b/scripts/e2e-local-startup-fallback.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { randomUUID } from 'node:crypto';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import net from 'node:net';
 import { tmpdir } from 'node:os';
@@ -7,6 +8,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { WebSocketServer } from 'ws';
 
 const HOST = '127.0.0.1';
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -44,9 +46,13 @@ async function main() {
 
   const stateDir = mkdtempSync(join(tmpdir(), 'vibe-mcp-local-startup-fallback-'));
   const mismatchedAgentPort = await findFreePort();
+  const remoteRelayPort = await findFreePort();
   let client = null;
+  let remoteRelay = null;
 
   try {
+    remoteRelay = new WebSocketServer({ host: HOST, port: remoteRelayPort });
+
     const transport = new StdioClientTransport({
       command: process.execPath,
       args: [
@@ -78,6 +84,37 @@ async function main() {
       throw new Error(`Expected set_remote in tools list, got: ${JSON.stringify(toolNames)}`);
     }
 
+    const seedUuid = randomUUID();
+    const switchedUuid = randomUUID();
+    const remoteUrl = `ws://${HOST}:${remoteRelayPort}/${seedUuid}`;
+
+    const seedResult = await client.callTool({
+      name: 'set_remote',
+      arguments: { url: remoteUrl },
+    });
+
+    const seedPayload = seedResult.content.find((item) => item.type === 'text');
+    if (!seedPayload || !seedPayload.text) {
+      throw new Error(`Expected JSON response from set_remote with full URL, got: ${JSON.stringify(seedResult)}`);
+    }
+    const seedJson = JSON.parse(seedPayload.text);
+    if (!seedJson.ok || seedJson.uuid !== seedUuid || seedJson.relayUrl !== `ws://${HOST}:${remoteRelayPort}`) {
+      throw new Error(`Unexpected set_remote full URL payload: ${seedPayload.text}`);
+    }
+
+    const uuidResult = await client.callTool({
+      name: 'set_remote',
+      arguments: { url: switchedUuid },
+    });
+    const uuidPayload = uuidResult.content.find((item) => item.type === 'text');
+    if (!uuidPayload || !uuidPayload.text) {
+      throw new Error(`Expected JSON response from set_remote with UUID, got: ${JSON.stringify(uuidResult)}`);
+    }
+    const uuidJson = JSON.parse(uuidPayload.text);
+    if (!uuidJson.ok || uuidJson.uuid !== switchedUuid || uuidJson.relayUrl !== `ws://${HOST}:${remoteRelayPort}`) {
+      throw new Error(`Unexpected set_remote UUID payload: ${uuidPayload.text}`);
+    }
+
     console.log(PASS_MARKER);
   } finally {
     if (client) {
@@ -94,6 +131,18 @@ async function main() {
       } catch {
         // Ignore cleanup errors.
       }
+    }
+
+    if (remoteRelay) {
+      await new Promise((resolveClose, rejectClose) => {
+        remoteRelay.close((error) => {
+          if (error) {
+            rejectClose(error);
+            return;
+          }
+          resolveClose(undefined);
+        });
+      }).catch(() => {});
     }
 
     rmSync(stateDir, { recursive: true, force: true });

--- a/scripts/e2e-local-startup-fallback.mjs
+++ b/scripts/e2e-local-startup-fallback.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const HOST = '127.0.0.1';
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(SCRIPT_DIR, '..');
+const CLI_PATH = resolve(PACKAGE_ROOT, 'dist', 'cli.js');
+const PASS_MARKER = 'local startup fallback e2e ok';
+
+function findFreePort() {
+  return new Promise((resolvePort, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, HOST, () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        if (!port) {
+          reject(new Error('Failed to allocate a free port'));
+          return;
+        }
+        resolvePort(port);
+      });
+    });
+  });
+}
+
+async function main() {
+  if (!existsSync(CLI_PATH)) {
+    throw new Error(`Missing built CLI at ${CLI_PATH}. Run npm run build first.`);
+  }
+
+  const stateDir = mkdtempSync(join(tmpdir(), 'vibe-mcp-local-startup-fallback-'));
+  const mismatchedAgentPort = await findFreePort();
+  let client = null;
+
+  try {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [
+        CLI_PATH,
+        'start',
+        '--port',
+        String(mismatchedAgentPort),
+      ],
+      cwd: PACKAGE_ROOT,
+      env: {
+        ...process.env,
+        VIBE_MCP_STATE_DIR: stateDir,
+      },
+      stderr: 'pipe',
+    });
+
+    if (transport.stderr) {
+      transport.stderr.on('data', (chunk) => {
+        process.stderr.write(chunk.toString());
+      });
+    }
+
+    client = new Client({ name: 'vibe-mcp-e2e-local-startup-fallback', version: '1.0.0' });
+    await client.connect(transport);
+
+    const toolsResult = await client.listTools();
+    const toolNames = toolsResult.tools.map((tool) => tool.name);
+    if (!toolNames.includes('set_remote')) {
+      throw new Error(`Expected set_remote in tools list, got: ${JSON.stringify(toolNames)}`);
+    }
+
+    console.log(PASS_MARKER);
+  } finally {
+    if (client) {
+      await client.close().catch(() => {});
+    }
+
+    const relayPidFile = join(stateDir, 'relay.pid');
+    if (existsSync(relayPidFile)) {
+      try {
+        const relayPid = Number.parseInt(readFileSync(relayPidFile, 'utf-8').trim(), 10);
+        if (Number.isFinite(relayPid) && relayPid > 0) {
+          process.kill(relayPid, 'SIGTERM');
+        }
+      } catch {
+        // Ignore cleanup errors.
+      }
+    }
+
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : String(error));
+  process.exit(1);
+});

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -36,6 +36,7 @@ const RELAY_CONNECT_TIMEOUT = 10000;
 const RELAY_RECONNECT_DELAY = 2000;
 
 const DEFAULT_RELAY_URL = 'wss://relay.api.vibebrowser.app';
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /**
  * Remote relay configuration
@@ -81,6 +82,21 @@ export function parseRemoteRelayUrl(value: string): ParsedRemoteRelayUrl {
   return {
     relayUrl: parsed.toString().replace(/\/$/, ''),
     uuid,
+  };
+}
+
+function parseRemoteTarget(value: string, currentRelayUrl?: string): ParsedRemoteRelayUrl {
+  if (isRemoteRelayUrl(value)) {
+    return parseRemoteRelayUrl(value);
+  }
+
+  if (!UUID_PATTERN.test(value)) {
+    throw new Error('Invalid remote target: expected a UUID or ws(s) relay URL');
+  }
+
+  return {
+    relayUrl: (currentRelayUrl || DEFAULT_RELAY_URL).replace(/\/$/, ''),
+    uuid: value,
   };
 }
 
@@ -173,7 +189,7 @@ export class ExtensionConnection extends EventEmitter {
   }
 
   async setRemoteUrl(url: string): Promise<ParsedRemoteRelayUrl> {
-    const parsed = parseRemoteRelayUrl(url);
+    const parsed = parseRemoteTarget(url, this.remoteConfig?.relayUrl);
 
     this.stopping = true;
     this.clearReconnectTimer();

--- a/src/server.ts
+++ b/src/server.ts
@@ -119,6 +119,7 @@ export class VibeMcpServer {
       if (!this.config.remoteUuid && !this.config.devtools) {
         const message = error instanceof Error ? error.message : String(error);
         this.log(`Local extension startup failed; continuing without tools: ${message}`);
+        console.error(`[${SERVER_NAME}] Warning: local extension startup failed; continuing without tools: ${message}`);
       } else {
         throw error;
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,13 +42,13 @@ const STARTUP_TOOLS_EVENT_WAIT_TIMEOUT_MS = 1_500;
 const CALL_TOOL_TIMEOUT_MS = 120_000;
 const SET_REMOTE_TOOL: ToolDefinition = {
   name: 'set_remote',
-  description: 'Reconnect this MCP server to a full Vibe remote websocket relay URL.',
+  description: 'Set the remote relay target for this MCP server. If browser tools are missing, call set_remote first to connect to a Vibe relay.',
   inputSchema: {
     type: 'object',
     properties: {
       url: {
         type: 'string',
-        description: 'Full websocket relay URL, for example wss://relay.api.vibebrowser.app/<extension-uuid>',
+        description: 'Remote target as either an extension UUID or a full websocket relay URL (for example wss://relay.api.vibebrowser.app/<extension-uuid>). Call set_remote first when browser tools are unavailable.',
       },
     },
     required: ['url'],
@@ -113,7 +113,17 @@ export class VibeMcpServer {
    * Start the MCP server
    */
   async start(): Promise<void> {
-    await this.connection.start();
+    try {
+      await this.connection.start();
+    } catch (error) {
+      if (!this.config.remoteUuid && !this.config.devtools) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.log(`Local extension startup failed; continuing without tools: ${message}`);
+      } else {
+        throw error;
+      }
+    }
+
     if (this.config.devtools) {
       if (this.connection instanceof DevtoolsFallbackConnection && this.connection.isAvailable()) {
         this.log('Connected to chrome-devtools backend');


### PR DESCRIPTION
## Summary
- keep MCP server startup alive in local mode when relay startup fails, with explicit warning output
- improve `set_remote` discoverability and implement bare UUID input support in addition to full relay URLs
- add real stdio integration regression coverage for startup fallback + `set_remote` URL/UUID behavior and bump release versions to `0.2.12`

## Closes
Closes #67

## Test plan
- [x] `npm run build`
- [x] `node scripts/e2e-local-startup-fallback.mjs`

## Notes
- design: `.tasks/67/design.md`
- plan: `.tasks/67/plan.md`
- review: `.tasks/67/review.md`
- tests: `.tasks/67/test-report.md`