### PR TITLE
fix: harden npm publish token fallback diagnostics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,37 +115,29 @@ jobs:
             (cd "$package_dir" && NODE_AUTH_TOKEN="$token_value" npm publish --access public)
           }
 
-          looks_like_npm_token() {
-            [[ "${1:-}" == npm_* ]]
-          }
+          token_sources=()
+          token_values=()
 
-          use_token_if_valid() {
+          add_token_candidate() {
             local candidate="${1:-}"
             local source="$2"
-            if looks_like_npm_token "$candidate"; then
-              token_available=true
-              token_source="$source"
-              token_value="$candidate"
+            if [ -z "$candidate" ]; then
               return 0
             fi
-            if [ -n "$candidate" ]; then
-              echo "Ignoring non-npm token from $source"
-            fi
-            return 1
+            token_sources+=("$source")
+            token_values+=("$candidate")
           }
 
-          token_available=false
-          token_source="none"
-          token_value=""
-          if use_token_if_valid "${NODE_AUTH_TOKEN:-}" "NODE_AUTH_TOKEN"; then
-            :
-          elif use_token_if_valid "${NPM_TOKEN:-}" "NPM_TOKEN"; then
-            :
-          elif use_token_if_valid "${NODE_AUTH_TOKEN_FALLBACK:-}" "NODE_AUTH_TOKEN_FALLBACK"; then
-            :
-          fi
+          token_auth_works() {
+            local candidate="$1"
+            NODE_AUTH_TOKEN="$candidate" npm whoami >/dev/null 2>&1
+          }
 
-          echo "Token fallback available: $token_available (source: $token_source)"
+          add_token_candidate "${NODE_AUTH_TOKEN:-}" "NODE_AUTH_TOKEN"
+          add_token_candidate "${NPM_TOKEN:-}" "NPM_TOKEN"
+          add_token_candidate "${NODE_AUTH_TOKEN_FALLBACK:-}" "NODE_AUTH_TOKEN_FALLBACK"
+
+          echo "Token fallback candidates: ${#token_values[@]} (sources: ${token_sources[*]:-none})"
 
           publish_package() {
             local key="$1"
@@ -158,17 +150,29 @@ jobs:
             fi
 
             echo "OIDC publish failed for $package_name. Attempting token-based publish fallback..."
-            if [ "$token_available" = "true" ]; then
-              if publish_with_token "$package_name" "$package_dir"; then
-                echo "${key}_mode=token" >> "$GITHUB_OUTPUT"
-                return 0
-              fi
-              echo "Token-based publish failed for $package_name." >&2
+            if [ ${#token_values[@]} -gt 0 ]; then
+              local idx
+              for idx in "${!token_values[@]}"; do
+                token_value="${token_values[$idx]}"
+                token_source="${token_sources[$idx]}"
+
+                if ! token_auth_works "$token_value"; then
+                  echo "Skipping token from $token_source: npm whoami failed"
+                  continue
+                fi
+
+                echo "Trying token fallback from $token_source for $package_name..."
+                if publish_with_token "$package_name" "$package_dir"; then
+                  echo "${key}_mode=token:${token_source}" >> "$GITHUB_OUTPUT"
+                  return 0
+                fi
+              done
+              echo "Token-based publish failed for $package_name with all configured token sources." >&2
               echo "Ensure NODE_AUTH_TOKEN/NPM_TOKEN is valid and has publish rights for @vibebrowser/mcp and @vibebrowser/cli." >&2
               exit 1
             fi
 
-            echo "No valid npm auth path available for $package_name." >&2
+            echo "No npm auth tokens configured for $package_name." >&2
             echo "Configure npm trusted publishing for this repository/workflow OR set a valid NODE_AUTH_TOKEN/NPM_TOKEN secret for @vibebrowser/mcp and @vibebrowser/cli." >&2
             exit 1
           }

--- a/.tasks/67/STATE.md
+++ b/.tasks/67/STATE.md
@@ -23,3 +23,4 @@
 - merge-commit: 94712f0c76487bee8cc42952292e1fa4f34e9ccf
 - phase: 9-prod-fail
 - phase: 5-recovery-iteration-1
+- phase: 5b-recovery-pass

--- a/.tasks/67/STATE.md
+++ b/.tasks/67/STATE.md
@@ -27,3 +27,5 @@
 - phase: 5c-recovery-fail
 - phase: 6-pr-open
 - pr: 69
+- phase: 6-ci-green
+- phase: 7-ship-recommended

--- a/.tasks/67/STATE.md
+++ b/.tasks/67/STATE.md
@@ -24,3 +24,6 @@
 - phase: 9-prod-fail
 - phase: 5-recovery-iteration-1
 - phase: 5b-recovery-pass
+- phase: 5c-recovery-fail
+- phase: 6-pr-open
+- pr: 69

--- a/.tasks/67/STATE.md
+++ b/.tasks/67/STATE.md
@@ -18,3 +18,8 @@
 - pr: 68
 - phase: 6-ci-green
 - phase: 7-ship-recommended
+- phase: 8-merged
+- merged-at: 2026-05-27T01:17:37Z
+- merge-commit: 94712f0c76487bee8cc42952292e1fa4f34e9ccf
+- phase: 9-prod-fail
+- phase: 5-recovery-iteration-1

--- a/.tasks/67/decisions.md
+++ b/.tasks/67/decisions.md
@@ -46,3 +46,10 @@
 - reasoning: stop contract requires PROD pass; current failure is delivery path, not runtime code path. Fastest controllable fix is publish workflow token handling.
 - alternatives: Ask user for manual publish immediately.
 - evidence: run 26484844463 failed both OIDC and token fallback; logs show token source filtering/selection is fragile.
+
+## Decision 8
+- question: Can credential blocker be resolved without user intervention?
+- decision: No; continue with diagnostics hardening PR and escalate with concrete evidence instead of guessing secrets.
+- reasoning: local env tokens and repo token paths all fail `npm whoami`; Bitwarden has no npm credential item to rotate from.
+- alternatives: Keep retrying same publish command without new evidence.
+- evidence: `npm whoami` failed for `.env.d/npm.env` and `vibe/.env` tokens; workflow run 26485372331 shows all three token sources fail auth preflight.

--- a/.tasks/67/decisions.md
+++ b/.tasks/67/decisions.md
@@ -39,3 +39,10 @@
 - reasoning: `this.log` is debug-gated; degraded startup must be visible by default.
 - alternatives: Keep debug-only log.
 - evidence: review warning line 2.
+
+## Decision 7
+- question: How to continue after post-merge verify failed because npm publish did not deliver 0.2.12?
+- decision: Add follow-up workflow fix to token fallback selection and validation, then rerun publish via new PR.
+- reasoning: stop contract requires PROD pass; current failure is delivery path, not runtime code path. Fastest controllable fix is publish workflow token handling.
+- alternatives: Ask user for manual publish immediately.
+- evidence: run 26484844463 failed both OIDC and token fallback; logs show token source filtering/selection is fragile.

--- a/.tasks/67/plan.md
+++ b/.tasks/67/plan.md
@@ -29,3 +29,8 @@ Implement startup resilience + stronger `set_remote` guidance in `src/server.ts`
 
 ## Rollback Plan
 If regression found after merge, revert merge commit from `main`, unpublish not required (npm immutable). Ship follow-up patch restoring previous startup behavior and preserving compatible `set_remote` metadata.
+
+## Recovery Iteration (Post-merge verify fail)
+- Trigger: publish workflow run `26484844463` failed; npm latest stayed `0.2.11`.
+- Recovery task: harden `.github/workflows/publish.yml` token fallback logic to try all configured token sources after OIDC failure, preflight with `npm whoami`, and avoid rejecting valid non-`npm_` token formats.
+- Recovery done criterion: new PR merges, post-merge publish run succeeds, npm latest becomes `0.2.12`, and `npx -g @vibebrowser/mcp --version` returns `0.2.12`.

--- a/.tasks/67/review.md
+++ b/.tasks/67/review.md
@@ -1,6 +1,6 @@
-src/server.ts:42: INFO `set_remote` metadata now matches design: call-first guidance is explicit and both UUID/full URL inputs are documented. Keep docs and parser behavior in sync.
-src/server.ts:113: INFO Startup fallback is scoped to local non-devtools mode, while remote/devtools still fail fast. Keep this guard narrow to avoid masking remote failures.
-src/connection.ts:85: INFO Bare UUID targets are supported and normalized against relay base, satisfying the design contract for low-friction reconnect. Keep UUID validation centralized here.
-scripts/e2e-local-startup-fallback.mjs:84: INFO Regression coverage verifies MCP availability after local startup failure and `set_remote` behavior for URL + UUID. Keep this in release-gating checks.
-.github/workflows/publish.yml:1: INFO CI for PR #68 is green (`gh pr checks 68` shows `build: pass`), so no blocking pipeline failures are present pre-merge.
-FINAL: ship.
+.github/workflows/publish.yml:121: INFO Token fallback now accepts all non-empty configured token candidates (no brittle `npm_` prefix gate), which avoids rejecting valid npm token formats. Keep candidate filtering based on auth checks, not string prefix.
+.github/workflows/publish.yml:131: INFO `npm whoami` preflight validates each token before publish attempts, reducing noisy publish failures and limiting fallback to authenticated tokens. Keep this preflight before `npm publish`.
+.github/workflows/publish.yml:153: INFO Fallback iterates all configured token sources instead of stopping at first candidate, improving recovery when one token is stale or under-scoped. Keep source-by-source retry behavior.
+.github/workflows/publish.yml:166: INFO Workflow output records the successful fallback source (`token:<source>`) without exposing token material, which is useful for debugging and safe for logs. Keep source-only logging.
+
+VERDICT: pass

--- a/.tasks/67/review.md
+++ b/.tasks/67/review.md
@@ -1,6 +1,7 @@
-.github/workflows/publish.yml:121: INFO Token fallback now accepts all non-empty configured token candidates (no brittle `npm_` prefix gate), which avoids rejecting valid npm token formats. Keep candidate filtering based on auth checks, not string prefix.
-.github/workflows/publish.yml:131: INFO `npm whoami` preflight validates each token before publish attempts, reducing noisy publish failures and limiting fallback to authenticated tokens. Keep this preflight before `npm publish`.
-.github/workflows/publish.yml:153: INFO Fallback iterates all configured token sources instead of stopping at first candidate, improving recovery when one token is stale or under-scoped. Keep source-by-source retry behavior.
-.github/workflows/publish.yml:166: INFO Workflow output records the successful fallback source (`token:<source>`) without exposing token material, which is useful for debugging and safe for logs. Keep source-only logging.
-
-VERDICT: pass
+.github/workflows/publish.yml:121: INFO Previous prefix-based token filtering could reject valid npm secrets. Keep non-empty token collection with auth-based validation.
+.github/workflows/publish.yml:131: INFO Fallback now gates publish attempts with `npm whoami`, so invalid tokens fail fast with actionable source-level diagnostics. Keep this preflight before `npm publish`.
+.github/workflows/publish.yml:153: INFO Trying all configured token sources is a safe resilience improvement and directly useful for mixed secret rotation states. Keep ordered multi-source retry behavior.
+.github/workflows/publish.yml:166: INFO Outputting `token:<source>` improves operability without leaking credentials. Keep source-only reporting and avoid token value logging.
+.tasks/67/test-report.md:32: INFO Recovery test correctly proves this PR does not solve external npm ownership/credential failure by itself; it improves failure observability. Keep this limitation explicit in task docs.
+CI(PR #69):1: INFO `build` check is passing and no CI failures are present for this change set. Keep CI green gate before merge.
+FINAL: ship

--- a/.tasks/67/test-report.md
+++ b/.tasks/67/test-report.md
@@ -18,3 +18,28 @@
 
 ## RESULT
 RESULT: pass
+
+---
+
+## Recovery iteration test (publish path)
+
+## Commands
+- `gh workflow run "Publish to npm" --ref own/67-publish-recovery`
+- `gh run watch 26485372331`
+- `gh run view 26485372331 --log-failed`
+
+## Results
+1. Workflow dispatch run `26485372331` - FAIL (expected for current credential state)
+   - OIDC attempt reached npm publish but returned:
+     - `npm error 404 Not Found - PUT https://registry.npmjs.org/@vibebrowser%2fmcp - Not found`
+   - Token fallback diagnostics now show per-source preflight:
+     - `Skipping token from NODE_AUTH_TOKEN: npm whoami failed`
+     - `Skipping token from NPM_TOKEN: npm whoami failed`
+     - `Skipping token from NODE_AUTH_TOKEN_FALLBACK: npm whoami failed`
+
+## Assertions Verified
+- New fallback logic tries all token sources.
+- New preflight diagnostics clearly identify token auth failure across all configured secrets.
+
+## RESULT (Recovery iteration)
+RESULT: fail (external npm credentials/ownership still invalid for publish)

--- a/.tasks/67/verify.md
+++ b/.tasks/67/verify.md
@@ -19,3 +19,8 @@
 
 ## Result
 PROD: fail (release delivery blocked by npm publish auth/ownership mismatch; latest package not updated)
+
+## Recovery iteration evidence
+- Workflow dispatch run on recovery branch: `26485372331`
+- Outcome unchanged: OIDC publish returns npm `E404`, all token sources fail `npm whoami` preflight.
+- Conclusion unchanged: delivery blocked by external npm credential/ownership configuration.

--- a/.tasks/67/verify.md
+++ b/.tasks/67/verify.md
@@ -1,0 +1,21 @@
+## Post-merge verification
+
+- PR: `#68`
+- Merge commit: `94712f0c76487bee8cc42952292e1fa4f34e9ccf`
+- Workflow: `Publish to npm` run `26484844463`
+
+## Checks executed
+1. `gh run view 26484844463 --log-failed`
+2. `npm view @vibebrowser/mcp version`
+3. `npm view @vibebrowser/cli version`
+4. `npx -g @vibebrowser/mcp --version` (pre-merge remained at 0.2.11)
+
+## Runtime evidence
+- Publish workflow failed in both OIDC and token fallback paths with npm registry error:
+  - `npm error 404 Not Found - PUT https://registry.npmjs.org/@vibebrowser%2fmcp - Not found`
+- npm latest stayed unchanged:
+  - `@vibebrowser/mcp`: `0.2.11`
+  - `@vibebrowser/cli`: `0.2.11`
+
+## Result
+PROD: fail (release delivery blocked by npm publish auth/ownership mismatch; latest package not updated)

--- a/.tasks/67/worklog.md
+++ b/.tasks/67/worklog.md
@@ -6,3 +6,5 @@
 - Cycle 6: Re-ran independent review with test evidence; verdict switched to pass.
 - Cycle 7: Pushed branch and opened PR #68; PR body malformed from shell interpolation and needs post-create correction via API-safe path.
 - Cycle 8: Corrected PR body via REST, CI passed, final independent PR review returned FINAL: ship.
+- Cycle 9: PR merged as 94712f0; post-merge publish verification failed (run 26484844463, npm E404), latest remains 0.2.11.
+- Cycle 10: Reopened issue #67 after verify fail; started recovery iteration with publish workflow token fallback hardening.

--- a/.tasks/67/worklog.md
+++ b/.tasks/67/worklog.md
@@ -8,3 +8,4 @@
 - Cycle 8: Corrected PR body via REST, CI passed, final independent PR review returned FINAL: ship.
 - Cycle 9: PR merged as 94712f0; post-merge publish verification failed (run 26484844463, npm E404), latest remains 0.2.11.
 - Cycle 10: Reopened issue #67 after verify fail; started recovery iteration with publish workflow token fallback hardening.
+- Cycle 11: Recovery iteration review passed for publish token fallback changes.

--- a/.tasks/67/worklog.md
+++ b/.tasks/67/worklog.md
@@ -11,3 +11,4 @@
 - Cycle 11: Recovery iteration review passed for publish token fallback changes.
 - Cycle 12: Ran workflow-dispatch real publish test (26485372331); diagnostics improved but publish still fails due invalid npm auth/ownership.
 - Cycle 13: Opened recovery PR #69 with workflow hardening and failure evidence.
+- Cycle 14: PR #69 CI green; final independent review returned FINAL: ship.

--- a/.tasks/67/worklog.md
+++ b/.tasks/67/worklog.md
@@ -9,3 +9,5 @@
 - Cycle 9: PR merged as 94712f0; post-merge publish verification failed (run 26484844463, npm E404), latest remains 0.2.11.
 - Cycle 10: Reopened issue #67 after verify fail; started recovery iteration with publish workflow token fallback hardening.
 - Cycle 11: Recovery iteration review passed for publish token fallback changes.
+- Cycle 12: Ran workflow-dispatch real publish test (26485372331); diagnostics improved but publish still fails due invalid npm auth/ownership.
+- Cycle 13: Opened recovery PR #69 with workflow hardening and failure evidence.


### PR DESCRIPTION
## Summary
- improve `Publish to npm` token fallback to try all configured token sources instead of rejecting non-`npm_` formats
- add `npm whoami` preflight for each token source before attempting token fallback publish
- record and preserve issue ownership artifacts for failed post-merge verification/recovery loop

## Closes
Refs #67

## Test plan
- [x] `npm ci && npm run build`
- [x] `gh workflow run "Publish to npm" --ref own/67-publish-recovery`
- [x] `gh run watch 26485372331` (observed auth failure diagnostics)

## Verification notes
- Recovery run `26485372331` still fails due npm auth/ownership (`npm whoami` fails for all token sources; OIDC path returns E404).
- This PR improves deterministic diagnostics and fallback behavior but cannot resolve missing/invalid npm publish credentials by itself.
