### PR TITLE
fix: keep npm token fallback attempts after whoami failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,11 +128,6 @@ jobs:
             token_values+=("$candidate")
           }
 
-          token_auth_works() {
-            local candidate="$1"
-            NODE_AUTH_TOKEN="$candidate" npm whoami >/dev/null 2>&1
-          }
-
           add_token_candidate "${NODE_AUTH_TOKEN:-}" "NODE_AUTH_TOKEN"
           add_token_candidate "${NPM_TOKEN:-}" "NPM_TOKEN"
           add_token_candidate "${NODE_AUTH_TOKEN_FALLBACK:-}" "NODE_AUTH_TOKEN_FALLBACK"
@@ -156,9 +151,10 @@ jobs:
                 token_value="${token_values[$idx]}"
                 token_source="${token_sources[$idx]}"
 
-                if ! token_auth_works "$token_value"; then
-                  echo "Skipping token from $token_source: npm whoami failed"
-                  continue
+                if NODE_AUTH_TOKEN="$token_value" npm whoami >/dev/null 2>&1; then
+                  echo "Token from $token_source passed npm whoami preflight"
+                else
+                  echo "Token from $token_source failed npm whoami preflight; attempting publish anyway"
                 fi
 
                 echo "Trying token fallback from $token_source for $package_name..."

--- a/.tasks/67/STATE.md
+++ b/.tasks/67/STATE.md
@@ -29,3 +29,11 @@
 - pr: 69
 - phase: 6-ci-green
 - phase: 7-ship-recommended
+- phase: 5-recovery-iteration-2
+- branch: own/67-publish-recovery-2
+- phase: 6-pr-open
+- pr: 70
+- phase: 6-ci-green
+- phase: 7-ship-recommended
+- phase: 5c-recovery2-fail
+- verify-run: 26488104816

--- a/.tasks/67/decisions.md
+++ b/.tasks/67/decisions.md
@@ -53,3 +53,17 @@
 - reasoning: local env tokens and repo token paths all fail `npm whoami`; Bitwarden has no npm credential item to rotate from.
 - alternatives: Keep retrying same publish command without new evidence.
 - evidence: `npm whoami` failed for `.env.d/npm.env` and `vibe/.env` tokens; workflow run 26485372331 shows all three token sources fail auth preflight.
+
+## Decision 9
+- question: Should token fallback keep skipping publish when `npm whoami` fails?
+- decision: No; treat `npm whoami` as diagnostic only and still attempt `npm publish` for each configured token source.
+- reasoning: Existing evidence shows `whoami` alone is insufficient to conclude publish impossibility; skip behavior hides potentially valid token paths and blocks deeper diagnostics.
+- alternatives: Keep skip-on-preflight behavior.
+- evidence: recovery goal in plan requires exercising all token paths; run 26488104816 confirmed behavior change and produced complete source-by-source publish attempts.
+
+## Decision 10
+- question: Is there any local/Bitwarden credential path left to try autonomously?
+- decision: No further autonomous credential sources available; proceed with PR+evidence and request maintainer-side npm publisher credential or scope ownership fix.
+- reasoning: `.env.d/npm.env`, `vibe/.env`, repo secrets rotation attempts, and Bitwarden searches yielded no valid publish-capable credential for `@vibebrowser` scope.
+- alternatives: Continue looping same token set.
+- evidence: runs `26487643493`, `26487677942`, `26488104816` all fail with npm `E404` after token/OIDC attempts; Bitwarden search returned no npm items.

--- a/.tasks/67/review.md
+++ b/.tasks/67/review.md
@@ -5,3 +5,9 @@
 .tasks/67/test-report.md:32: INFO Recovery test correctly proves this PR does not solve external npm ownership/credential failure by itself; it improves failure observability. Keep this limitation explicit in task docs.
 CI(PR #69):1: INFO `build` check is passing and no CI failures are present for this change set. Keep CI green gate before merge.
 FINAL: ship
+
+## PR #70
+.github/workflows/publish.yml:154: INFO `npm whoami` is now diagnostic-only, and fallback still attempts publish per token source; this matches the recovery goal of not discarding potentially valid tokens due to preflight false negatives. Keep this behavior unless npm confirms `whoami` is a strict publish predictor for all token types.
+.github/workflows/publish.yml:157: INFO Logging includes only token source names, not token material, so no new secret exposure is introduced by this change. Keep source-only diagnostics.
+.github/workflows/publish.yml:166: INFO Failure path still exits non-zero after all token sources fail, preserving safe fail-closed behavior for publish automation. Keep explicit error guidance.
+FINAL: ship

--- a/.tasks/67/test-report.md
+++ b/.tasks/67/test-report.md
@@ -43,3 +43,32 @@ RESULT: pass
 
 ## RESULT (Recovery iteration)
 RESULT: fail (external npm credentials/ownership still invalid for publish)
+
+---
+
+## Recovery iteration 2 test (non-blocking token preflight)
+
+## Commands
+- `gh workflow run "Publish to npm" --ref own/67-publish-recovery-2`
+- `gh run watch 26488104816`
+- `gh run view 26488104816 --log-failed`
+
+## Results
+1. Workflow dispatch run `26488104816` - FAIL (expected while npm auth/ownership remains unresolved)
+   - OIDC attempt still fails with:
+     - `npm error 404 Not Found - PUT https://registry.npmjs.org/@vibebrowser%2fmcp - Not found`
+   - Token fallback now attempts publish for each configured source even after `npm whoami` preflight failure:
+     - `Token from NODE_AUTH_TOKEN failed npm whoami preflight; attempting publish anyway`
+     - `Trying token fallback from NODE_AUTH_TOKEN for @vibebrowser/mcp...`
+     - `Token from NPM_TOKEN failed npm whoami preflight; attempting publish anyway`
+     - `Trying token fallback from NPM_TOKEN for @vibebrowser/mcp...`
+     - `Token from NODE_AUTH_TOKEN_FALLBACK failed npm whoami preflight; attempting publish anyway`
+     - `Trying token fallback from NODE_AUTH_TOKEN_FALLBACK for @vibebrowser/mcp...`
+
+## Assertions Verified
+- `npm whoami` no longer gates/skips token publish attempts.
+- Publish fallback executes for all configured token sources.
+- External blocker unchanged: registry still rejects publish with npm `E404`.
+
+## RESULT (Recovery iteration 2)
+RESULT: fail (workflow behavior corrected; publish still blocked by external npm credential/ownership state)

--- a/.tasks/67/verify.md
+++ b/.tasks/67/verify.md
@@ -24,3 +24,18 @@ PROD: fail (release delivery blocked by npm publish auth/ownership mismatch; lat
 - Workflow dispatch run on recovery branch: `26485372331`
 - Outcome unchanged: OIDC publish returns npm `E404`, all token sources fail `npm whoami` preflight.
 - Conclusion unchanged: delivery blocked by external npm credential/ownership configuration.
+
+## Recovery iteration 2 evidence
+- Branch/workflow: `own/67-publish-recovery-2` / run `26488104816`
+- Workflow behavior change confirmed:
+  - Token preflight is diagnostic-only.
+  - Publish fallback attempts now run for `NODE_AUTH_TOKEN`, `NPM_TOKEN`, and `NODE_AUTH_TOKEN_FALLBACK` even when `npm whoami` fails.
+- Runtime outcome unchanged:
+  - OIDC attempt still fails with `404 Not Found - PUT https://registry.npmjs.org/@vibebrowser%2fmcp - Not found`.
+  - Token publish attempts for all three sources also fail with same npm `E404`.
+- Dist-tag check after run:
+  - `npm view @vibebrowser/mcp version` -> `0.2.11`
+  - `npm view @vibebrowser/cli version` -> `0.2.11`
+
+## Result (current)
+PROD: fail (workflow fallback behavior improved and verified; delivery still blocked by external npm publisher auth/ownership)

--- a/.tasks/67/worklog.md
+++ b/.tasks/67/worklog.md
@@ -12,3 +12,6 @@
 - Cycle 12: Ran workflow-dispatch real publish test (26485372331); diagnostics improved but publish still fails due invalid npm auth/ownership.
 - Cycle 13: Opened recovery PR #69 with workflow hardening and failure evidence.
 - Cycle 14: PR #69 CI green; final independent review returned FINAL: ship.
+- Cycle 15: Implemented recovery iteration 2 on branch own/67-publish-recovery-2; changed workflow so token preflight is diagnostic-only and token publish attempts always run.
+- Cycle 16: Opened PR #70, CI green, and independent final review returned FINAL: ship.
+- Cycle 17: Ran real publish workflow on recovery branch (26488104816); confirmed all token sources now attempt publish, but every attempt still fails with npm E404 and npm latest remains 0.2.11.


### PR DESCRIPTION
## Summary
- Keep npm token fallback attempts even when `npm whoami` preflight fails, so each configured token is still exercised against publish endpoint.
- Replace skip-on-preflight behavior with diagnostic-only preflight output that reports source-level pass/fail and still runs `npm publish`.
- Capture evidence that token attempts now run for all configured sources, while publish still fails with npm 404 due to external ownership/auth state.

## Closes
- refs #67

## Verification
- `gh workflow run \"Publish to npm\" --ref own/67-publish-recovery-2`
- `gh run watch 26488104816`
- `gh run view 26488104816 --log-failed`

## Observed
- OIDC attempt still fails with `404 Not Found - PUT https://registry.npmjs.org/@vibebrowser%2fmcp`.
- Token fallback now attempts publish for `NODE_AUTH_TOKEN`, `NPM_TOKEN`, and `NODE_AUTH_TOKEN_FALLBACK` even after preflight failures.

## Task Artifacts
- `.tasks/67/design.md`
- `.tasks/67/plan.md`
- `.tasks/67/review.md`
- `.tasks/67/test-report.md`
- `.tasks/67/verify.md`