### PR TITLE
docs(skill): update installation UI labels to match current extension

### DIFF
--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -20,8 +20,10 @@ metadata:
 
 1. **Get the remote value**:
    - Install the Vibe extension in Chrome
-   - Open extension Settings → MCP External
-   - Enable Remote mode and copy either the extension UUID or full WebSocket relay URL
+   - Open extension Settings → **AI Agent Control**
+   - Toggle **Enable external AI agent control** to ON
+   - Set **Connection mode** to **Remote (internet)**
+   - Copy the relay URL from the **Relay access** section
 
 2. **Provide the remote value** (one of):
    - Pass it directly on every command with `--remote <uuid-or-url>` — no environment variable needed.


### PR DESCRIPTION
## Summary
- Settings section renamed from "MCP External" → "AI Agent Control"
- Updated step labels to match actual extension UI:
  - Toggle: "Enable external AI agent control"
  - Dropdown: "Connection mode" → "Remote (internet)"
  - Copy from: "Relay access" section

## Screenshot reference
User confirmed current UI via screenshot of the extension settings page.