### PR TITLE
ci: reliable npm publishing via OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-token-healthcheck.yml
+++ b/.github/workflows/npm-token-healthcheck.yml
@@ -1,0 +1,112 @@
+name: npm token healthcheck
+
+# Safety net for the emergency NPM_TOKEN fallback used by publish.yml.
+# Primary publishing uses OIDC trusted publishing (no long-lived token), but the
+# NPM_TOKEN secret remains as an emergency fallback. npm automation tokens expire
+# in <= 90 days. This workflow proactively verifies the fallback token is still
+# valid (monthly) so its death is caught BEFORE a release actually needs it.
+
+on:
+  schedule:
+    # 09:00 UTC on the 1st of every month
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  healthcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify npm fallback token (npm whoami)
+        id: whoami
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN secret is not configured." >&2
+            echo "result=missing" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          if user=$(npm whoami --registry=https://registry.npmjs.org 2>/tmp/whoami.err); then
+            echo "npm whoami OK: authenticated as '$user'"
+            echo "result=ok" >> "$GITHUB_OUTPUT"
+            echo "whoami_user=$user" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm whoami FAILED. The fallback NPM_TOKEN is expired or invalid." >&2
+            cat /tmp/whoami.err >&2 || true
+            echo "result=invalid" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Open or update tracking issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'npm publish token expired/invalid';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              '## npm fallback token healthcheck failed',
+              '',
+              'The monthly `npm-token-healthcheck` workflow could not authenticate to',
+              'registry.npmjs.org using the `NPM_TOKEN` secret. This token is the',
+              '**emergency fallback** for `publish.yml` (primary path is OIDC trusted',
+              'publishing).',
+              '',
+              '### Action required',
+              '1. Generate a new npm **automation** token for an account with publish',
+              '   rights to `@vibebrowser/mcp` and `@vibebrowser/cli`.',
+              '2. Update the `NPM_TOKEN` repository secret.',
+              '3. Re-run this workflow (`workflow_dispatch`) to confirm it is green.',
+              '',
+              '> Note: with OIDC trusted publishing enabled on npmjs.com, releases',
+              '> should still succeed without this token. Fixing it restores the',
+              '> emergency fallback.',
+              '',
+              `Failing run: ${runUrl}`,
+              '',
+              `_Last checked: ${new Date().toISOString()}_`,
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'npm-token',
+              per_page: 100,
+            });
+
+            const match = existing.data.find(i => i.title === title);
+
+            if (match) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                state: 'open',
+                body,
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Healthcheck failed again on ${new Date().toISOString()}. See ${runUrl}`,
+              });
+              core.notice(`Updated existing issue #${match.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['npm-token'],
+              });
+              core.notice(`Opened issue #${created.data.number}`);
+            }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,13 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-      
+
+      - name: Upgrade npm (OIDC trusted publishing requires npm >= 11.5.1)
+        run: |
+          npm install -g npm@latest
+          echo "npm version: $(npm --version)"
+          echo "node version: $(node --version)"
+
       - name: Install dependencies
         run: npm ci
       


### PR DESCRIPTION
## Why

npm publishing has been unreliable because it depends on a long-lived `NPM_TOKEN`/`NODE_AUTH_TOKEN` secret that expires every <= 90 days. The workflow already *tries* OIDC trusted publishing first (`id-token: write`, `npm publish --provenance`), but OIDC silently fails because **setup-node@v4 with node 20 ships npm 10.x, and npm Trusted Publishing requires npm >= 11.5.1**. So every release falls back to the expiring token.

## What changed

- **`.github/workflows/publish.yml`**: added a step right after *Setup Node.js* that runs `npm install -g npm@latest` (and echoes npm/node versions), so the OIDC path actually works. Runs before `npm ci`, build, and publish. The token fallback path, `--provenance --access public`, and `id-token: write` / `contents: write` permissions are all kept unchanged — the token now becomes a rarely-used emergency path.
- **`.github/workflows/npm-token-healthcheck.yml`** (new): monthly cron (`0 9 1 * *`) + `workflow_dispatch`. Runs `npm whoami` against registry.npmjs.org using the `NPM_TOKEN` secret. On failure it fails the job AND opens/updates a tracking issue titled "npm publish token expired/invalid" (label `npm-token`) so the fallback token's expiry is caught *before* a release needs it. On success it is a no-op.

No package versions changed. Nothing published. Build verified locally (`npm run build` passes).

## REQUIRED MANUAL STEP (npm web UI — not done by this PR)

Enable Trusted Publishing on npmjs.com for **both** packages so the OIDC path is authorized:

For each of `@vibebrowser/mcp` and `@vibebrowser/cli`:
1. npmjs.com -> package -> **Settings -> Trusted Publishers**
2. Add a **GitHub Actions** publisher with:
   - Repository: `VibeTechnologies/vibe-mcp`
   - Workflow filename: `publish.yml`
   - (Environment: leave blank unless you add one)

Once configured, releases publish via OIDC with provenance and the `NPM_TOKEN` secret becomes a fallback only. The healthcheck workflow keeps that fallback honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)