### PR TITLE
feat(devtools): drive real Chrome over CDP via chrome-use core (#47)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist/
 *.log
 .DS_Store
 tmp/
+
+.claude/
+.tasks/

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Claude Desktop       Cursor          VS Code         OpenCode
 - **Fast & Local** - Automation happens on your machine, no cloud latency
 - **Private** - Your browsing data never leaves your device
 - **Stable** - Content script based, no flaky CDP connections
-- **Chrome DevTools Fallback** - Extension tools stay primary by default; use `--devtools` to force chrome-devtools-only mode
+- **Direct Chrome DevTools mode** - Extension tools stay primary by default; use `--devtools` to drive your real running Chrome directly over the DevTools Protocol (no extension required)
 
 ## Quick Start
 
@@ -232,10 +232,29 @@ If the extension is not connected, `vibebrowser-mcp` can optionally fall back to
 `chrome-devtools-mcp` (started in `--autoConnect` mode) when that package is installed.
 This fallback runs once in the shared local relay daemon (multi-agent safe), so
 both `vibebrowser-mcp` and `vibebrowser-cli` use the same backend instance.
-When extension is connected, extension tools are authoritative. Chrome DevTools
-fallback tools are exposed only when extension is unavailable/disconnected.
-Pass `--devtools` to either CLI to bypass relay/extension routing and use only
-the chrome-devtools backend.
+When extension is connected, extension tools are authoritative.
+
+### `--devtools` mode (drive your real Chrome over CDP)
+
+Pass `--devtools` to either CLI to bypass relay/extension routing entirely and
+drive your **real running Chrome** directly over the Chrome DevTools Protocol.
+This backend (ported from the `chrome-use` skill) reads Chrome's
+`DevToolsActivePort` file and autoConnects to your live profile — no extension,
+no external MCP server, zero extra dependencies. Requires Chrome 144+; the
+permission dialog fires once per profile.
+
+`--devtools` exposes a focused tool set: `navigate`, `snapshot` (accessibility
+tree with `@eN` refs), `click`, `fill`, `type`, `press_key`, `hover`, `scroll`,
+`screenshot`, `eval`, `get_text`, `get_url`, `get_title`, and tab management
+(`list_tabs`, `new_tab`, `select_tab`, `close_tab`). Use `snapshot` to get
+`@eN` element refs, then pass them as selectors to `click`/`fill`/`type`.
+
+Override the Chrome profile/channel with `VIBE_CHROME_USER_DATA_DIR` and
+`VIBE_CHROME_CHANNEL` (`stable` | `canary` | `beta` | `dev`).
+
+Not yet covered by `--devtools` v1 (addable later as more CDP domains are wired):
+network request inspection, console logs, performance traces, Lighthouse, memory
+snapshots, device emulation, dialog handling, file upload, and drag.
 
 ## Available Tools
 
@@ -466,7 +485,7 @@ npx -y @vibebrowser/mcp@latest [start] [options]
   --http-path <path>   Path for streamable HTTP MCP transport (default: /mcp)
   --allow-host <host>  Allowed host header for HTTP transport (repeatable)
   -r, --remote <uuid-or-url>  Extension UUID, or full ws(s) remote URL
-  --devtools           Use only chrome-devtools backend (bypasses extension relay)
+  --devtools           Drive your real running Chrome directly over the DevTools Protocol (bypasses the extension relay)
 
 # MCP server tool
 set_remote { "url": "wss://relay.api.vibebrowser.app/<extension-uuid>" }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dev": "tsc --watch",
     "start": "node dist/cli.js",
     "prepublishOnly": "npm run build",
-    "test": "npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:cli-relay && npm run test:e2e:http && npm run test:e2e:browser-cli",
+    "test": "npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:cli-relay && npm run test:e2e:http && npm run test:e2e:browser-cli && npm run test:e2e:devtools-flag",
     "test:e2e:browser-cli": "node scripts/e2e-browser-cli.mjs",
     "test:e2e:cli-relay": "node scripts/e2e-cli-relay.mjs",
     "test:e2e:http": "node scripts/e2e-http-streamable.mjs",

--- a/scripts/e2e-devtools-flag.mjs
+++ b/scripts/e2e-devtools-flag.mjs
@@ -63,9 +63,13 @@ async function waitForPort(port, timeoutMs = 10_000) {
 // Point Chrome discovery at a directory with no DevToolsActivePort so the
 // chrome-use backend reports unavailable fast — keeps the test hermetic (no
 // live browser), mirroring how the relay tests fake the extension.
+// Isolate the chrome-use proxy on a throwaway socket so the real CLI subprocesses
+// spawned below never start or reuse the user's default gateway daemon.
+const HERMETIC_SOCKET = join(tmpdir(), `vibe-chrome-use-test-${process.pid}.sock`);
 const HERMETIC_ENV = {
   ...process.env,
   VIBE_CHROME_USER_DATA_DIR: join(tmpdir(), `vibe-no-chrome-${process.pid}`),
+  VIBE_CHROME_USE_SOCKET: HERMETIC_SOCKET,
 };
 
 function runJsonCli(scriptPath, args, timeoutMs = 10_000) {
@@ -371,6 +375,15 @@ async function main() {
     if (serverProcess) {
       serverProcess.kill('SIGTERM');
     }
+    // Stop the throwaway proxy the real CLI subprocesses may have started.
+    await new Promise((done) => {
+      const sock = net.createConnection({ path: HERMETIC_SOCKET });
+      const finish = () => { try { sock.destroy(); } catch { /* ignore */ } done(); };
+      sock.on('connect', () => sock.write(JSON.stringify({ id: 1, method: '__stop' }) + '\n'));
+      sock.on('data', finish);
+      sock.on('error', finish);
+      setTimeout(finish, 1500);
+    });
   }
 }
 

--- a/scripts/e2e-devtools-flag.mjs
+++ b/scripts/e2e-devtools-flag.mjs
@@ -2,11 +2,12 @@
 import { spawn } from 'node:child_process';
 import net from 'node:net';
 import process from 'node:process';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { setTimeout as delay } from 'node:timers/promises';
 import { WebSocketServer } from 'ws';
-import { DevtoolsFallbackConnection } from '../dist/devtools-fallback.js';
+import { ChromeUseConnection } from '../dist/chrome-use-connection.js';
 
 const HOST = '127.0.0.1';
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -58,11 +59,20 @@ async function waitForPort(port, timeoutMs = 10_000) {
   throw new Error(`Timed out waiting for port ${port}`);
 }
 
+// Point Chrome discovery at a directory with no DevToolsActivePort so the
+// chrome-use backend reports unavailable fast — keeps the test hermetic (no
+// live browser), mirroring how the relay tests fake the extension.
+const HERMETIC_ENV = {
+  ...process.env,
+  VIBE_CHROME_USER_DATA_DIR: join(tmpdir(), `vibe-no-chrome-${process.pid}`),
+};
+
 function runJsonCli(scriptPath, args, timeoutMs = 10_000) {
   return new Promise((resolveResult, reject) => {
     const child = spawn(process.execPath, [scriptPath, '--json', ...args], {
       cwd: PACKAGE_ROOT,
       stdio: ['ignore', 'pipe', 'pipe'],
+      env: HERMETIC_ENV,
     });
     let stdout = '';
     let stderr = '';
@@ -98,6 +108,7 @@ function runCliText(scriptPath, args, timeoutMs = 10_000) {
     const child = spawn(process.execPath, [scriptPath, ...args], {
       cwd: PACKAGE_ROOT,
       stdio: ['ignore', 'pipe', 'pipe'],
+      env: HERMETIC_ENV,
     });
     let stdout = '';
     let stderr = '';
@@ -122,6 +133,68 @@ function runCliText(scriptPath, args, timeoutMs = 10_000) {
       resolveResult(`${stdout}\n${stderr}`);
     });
   });
+}
+
+/**
+ * A minimal in-memory fake of the CDP client used by ChromeUseConnection. It
+ * answers just enough of the protocol to drive the tool dispatch path (one page
+ * tab, a snapshot with a single button ref, a clickable element) without a real
+ * browser — mirroring how the relay e2e tests fake the extension.
+ */
+function makeFakeCdp() {
+  const state = {
+    connected: true,
+    clicked: false,
+    close() { state.connected = false; },
+    on() { return () => {}; },
+    async send(method, params = {}) {
+      switch (method) {
+        case 'Browser.getVersion':
+          return { product: 'HeadlessChrome/144.0.0' };
+        case 'Target.getTargets':
+          return { targetInfos: [{ targetId: 'T1', type: 'page', url: 'https://example.com/' }] };
+        case 'Target.attachToTarget':
+          return { sessionId: 'S1' };
+        case 'Target.detachFromTarget':
+        case 'Target.closeTarget':
+        case 'Page.navigate':
+        case 'DOM.focus':
+        case 'Input.insertText':
+        case 'Input.dispatchKeyEvent':
+          return {};
+        case 'Target.createTarget':
+          return { targetId: 'T2' };
+        case 'Input.dispatchMouseEvent':
+          if (params.type === 'mousePressed') state.clicked = true;
+          return {};
+        case 'DOM.getBoxModel':
+          return { model: { content: [0, 0, 10, 0, 10, 10, 0, 10] } };
+        case 'Page.captureScreenshot':
+          return { data: 'ZmFrZQ==' };
+        case 'Runtime.callFunctionOn':
+          return { result: { value: 'Example Domain' } };
+        case 'Runtime.evaluate': {
+          const expr = String(params.expression || '');
+          if (expr.includes('document.readyState')) return { result: { value: 'complete' } };
+          if (expr.includes('location.href')) return { result: { value: 'https://example.com/' } };
+          if (expr.includes('document.title')) return { result: { value: 'Example Domain' } };
+          if (expr.includes('document.body.innerText')) return { result: { value: 'Example body text' } };
+          if (expr.includes('window.__chromeUseRefs = []')) {
+            // Snapshot walker IIFE: pretend one interactive button was found.
+            return { result: { value: { nodes: [{ ref: 'e1', role: 'button', name: 'Submit', backendNodeId: 0, depth: 0 }] } } };
+          }
+          if (expr.includes('__chromeUseRefs')) {
+            // Ref resolution: return a remote objectId for @e1.
+            return { result: { type: 'object', objectId: 'OBJ-e1' } };
+          }
+          return { result: { value: null } };
+        }
+        default:
+          return {};
+      }
+    },
+  };
+  return state;
 }
 
 async function main() {
@@ -174,6 +247,7 @@ async function main() {
       {
         cwd: PACKAGE_ROOT,
         stdio: ['ignore', 'pipe', 'pipe'],
+        env: HERMETIC_ENV,
       },
     );
 
@@ -191,29 +265,69 @@ async function main() {
     assert(payload.transport === 'http', `Unexpected health payload: ${JSON.stringify(payload)}`);
     assert(typeof payload.cachedTools === 'number', `Expected cachedTools number: ${JSON.stringify(payload)}`);
 
-    const originalResolveBinaryPath = DevtoolsFallbackConnection.prototype.resolveBinaryPath;
-    // eslint-disable-next-line no-param-reassign
-    DevtoolsFallbackConnection.prototype.resolveBinaryPath = function () {
-      return undefined;
+    // When Chrome cannot be reached, the chrome-use DevTools backend reports
+    // unavailable (it never throws on start) and callTool surfaces that reason.
+    const failingConnector = {
+      connect() {
+        return Promise.reject(new Error('DevToolsActivePort not found'));
+      },
     };
+    const unavailable = new ChromeUseConnection(false, { connector: failingConnector });
+    let sawUnavailable = false;
+    unavailable.on('unavailable', () => { sawUnavailable = true; });
+    await unavailable.start();
+    assert(unavailable.isAvailable() === false, 'Expected backend to be unavailable when Chrome is unreachable');
+    assert(sawUnavailable, 'Expected an "unavailable" event when Chrome is unreachable');
+    assert(unavailable.getTools().length === 0, 'Unavailable backend must expose no tools');
+    assert(
+      /DevToolsActivePort not found/.test(unavailable.getUnavailableReason() ?? ''),
+      `Unexpected unavailable reason: ${unavailable.getUnavailableReason()}`,
+    );
     try {
-      const unavailable = new DevtoolsFallbackConnection(false);
-      await unavailable.start();
-      try {
-        await unavailable.callTool('list_pages', {});
-        throw new Error('Expected callTool to fail when backend is unavailable');
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        assert(
-          message === 'chrome-devtools backend unavailable: chrome-devtools-mcp is not installed',
-          `Unexpected unavailable error message: ${message}`,
-        );
-      } finally {
-        await unavailable.stop();
-      }
+      await unavailable.callTool('navigate', { url: 'https://example.com' });
+      throw new Error('Expected callTool to fail when backend is unavailable');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      assert(
+        message.includes('chrome-use DevTools backend unavailable'),
+        `Unexpected unavailable error message: ${message}`,
+      );
     } finally {
-      DevtoolsFallbackConnection.prototype.resolveBinaryPath = originalResolveBinaryPath;
+      await unavailable.stop();
     }
+
+    // A fake CDP transport lets us exercise the real tool dispatch (navigate →
+    // snapshot → click) without a live browser, the way the relay e2e fakes the
+    // extension. This proves tool wiring end-to-end through ChromeUseConnection.
+    const fakeCdp = makeFakeCdp();
+    const live = new ChromeUseConnection(false, { connector: { connect: async () => fakeCdp } });
+    await live.start();
+    assert(live.isAvailable(), 'Expected fake-CDP backend to be available');
+    const toolNames = live.getTools().map((t) => t.name);
+    for (const required of ['navigate', 'snapshot', 'click', 'fill', 'type', 'screenshot', 'eval', 'get_text', 'get_url', 'get_title']) {
+      assert(toolNames.includes(required), `Missing tool: ${required}`);
+    }
+
+    const nav = await live.callTool('navigate', { url: 'example.com' });
+    assert(!nav.isError, `navigate failed: ${JSON.stringify(nav)}`);
+    assert(/example\.com/.test(nav.content[0].text), `navigate text unexpected: ${JSON.stringify(nav)}`);
+
+    const snap = await live.callTool('snapshot', { interactive: true });
+    assert(!snap.isError, `snapshot failed: ${JSON.stringify(snap)}`);
+    assert(/@e1 \[button\]/.test(snap.content[0].text), `snapshot text unexpected: ${JSON.stringify(snap)}`);
+
+    const click = await live.callTool('click', { selector: '@e1' });
+    assert(!click.isError, `click failed: ${JSON.stringify(click)}`);
+    assert(fakeCdp.clicked, 'Expected a trusted mouse press/release to be dispatched on click');
+
+    const shot = await live.callTool('screenshot', {});
+    assert(shot.content[0].type === 'image', `screenshot should return an image: ${JSON.stringify(shot)}`);
+    assert(shot.content[0].data === 'ZmFrZQ==', 'screenshot should return the fake base64 image data');
+
+    const title = await live.callTool('get_title', {});
+    assert(title.content[0].text === 'Example Domain', `get_title unexpected: ${JSON.stringify(title)}`);
+
+    await live.stop();
 
     console.log('devtools flag e2e ok');
   } finally {

--- a/scripts/e2e-devtools-flag.mjs
+++ b/scripts/e2e-devtools-flag.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { setTimeout as delay } from 'node:timers/promises';
 import { WebSocketServer } from 'ws';
 import { ChromeUseConnection } from '../dist/chrome-use-connection.js';
+import { BrowserCliContext } from '../dist/browser-cli.js';
 
 const HOST = '127.0.0.1';
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -328,6 +329,41 @@ async function main() {
     assert(title.content[0].text === 'Example Domain', `get_title unexpected: ${JSON.stringify(title)}`);
 
     await live.stop();
+
+    // Regression for the chrome-use tool-name mapping: drive the *browser-cli
+    // command layer* (not callTool directly) against the fake CDP. Before the
+    // fix, the candidate name lists only knew chrome-devtools-mcp names
+    // (navigate_page, take_snapshot, evaluate_script), so navigate/snapshot/
+    // evaluate threw "No compatible browser tool found" against the chrome-use
+    // backend (navigate/snapshot/eval). This proves the CLI verb -> tool wiring.
+    const cliCtx = new BrowserCliContext({
+      port: 0,
+      debug: false,
+      devtools: true,
+      profile: 'user',
+      json: true,
+      timeoutMs: 10_000,
+      chromeUseConnector: { connect: async () => makeFakeCdp() },
+    });
+    await cliCtx.connect();
+    try {
+      const navOut = await cliCtx.navigate('example.com');
+      assert(navOut.ok !== false, `cli navigate failed: ${JSON.stringify(navOut)}`);
+
+      const snapOut = await cliCtx.snapshot({
+        format: 'ai',
+        interactive: true,
+        compact: false,
+        efficient: false,
+        labels: false,
+      });
+      assert(snapOut.ok !== false, `cli snapshot failed: ${JSON.stringify(snapOut)}`);
+
+      const evalOut = await cliCtx.evaluate({ fn: 'document.title' });
+      assert(evalOut.ok !== false, `cli evaluate failed: ${JSON.stringify(evalOut)}`);
+    } finally {
+      await cliCtx.shutdown();
+    }
 
     console.log('devtools flag e2e ok');
   } finally {

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -3,7 +3,7 @@ import { basename, extname, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { Command } from 'commander';
 import { ExtensionConnection } from './connection.js';
-import { DevtoolsFallbackConnection } from './devtools-fallback.js';
+import { ChromeUseConnection } from './chrome-use-connection.js';
 import { DEFAULT_WS_PORT, type RelaySessionSummary, type ToolDefinition, type ToolResult } from './types.js';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -116,7 +116,7 @@ function buildBrowserCommand(command: Command): Command {
     .option('--target <target>', 'OpenClaw compatibility target selector (accepted, not used by the Vibe browser CLI)')
     .option('-p, --port <number>', 'WebSocket port for local relay (agent) connection', String(DEFAULT_WS_PORT))
     .option('-d, --debug', 'Enable debug logging', false)
-    .option('--devtools', 'Use only chrome-devtools backend (bypasses extension relay)', false)
+    .option('--devtools', 'Drive your real running Chrome directly over the DevTools Protocol (bypasses the extension relay)', false)
     .option('-r, --remote <uuid-or-url>', 'Connect to a remote extension via relay (provide the extension UUID or full ws(s) relay URL)', DEFAULT_REMOTE)
     .option('-s, --session <id>', 'Target a specific local browser session ID; defaults to the first connected session')
     .option('--json', 'Emit machine-readable JSON output', false)
@@ -498,7 +498,7 @@ async function runBrowserCommand(
 }
 
 class BrowserCliContext {
-  private readonly connection: ExtensionConnection | DevtoolsFallbackConnection;
+  private readonly connection: ExtensionConnection | ChromeUseConnection;
   private readonly profile: string;
   private readonly json: boolean;
   private readonly timeoutMs: number;
@@ -515,7 +515,7 @@ class BrowserCliContext {
   constructor(init: CommandContextInit) {
     this.devtoolsOnly = init.devtools;
     this.connection = init.devtools
-      ? new DevtoolsFallbackConnection(init.debug)
+      ? new ChromeUseConnection(init.debug)
       : new ExtensionConnection(
         init.port,
         init.debug,
@@ -1416,7 +1416,7 @@ class BrowserCliContext {
     if (this.connection instanceof ExtensionConnection) {
       return this.connection.getConnectionErrorMessage();
     }
-    return this.connection.getUnavailableReason() || 'chrome-devtools backend unavailable';
+    return this.connection.getUnavailableReason() || 'chrome-use DevTools backend unavailable';
   }
 
   outputMode(): 'local' | 'remote' | 'devtools' {

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -3,7 +3,7 @@ import { basename, extname, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { Command } from 'commander';
 import { ExtensionConnection } from './connection.js';
-import { ChromeUseConnection } from './chrome-use-connection.js';
+import { ChromeUseConnection, type CdpConnector } from './chrome-use-connection.js';
 import { DEFAULT_WS_PORT, type RelaySessionSummary, type ToolDefinition, type ToolResult } from './types.js';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -90,6 +90,8 @@ interface CommandContextInit {
   timeoutMs: number;
   target?: string;
   pageId?: number;
+  /** Test-only: inject a fake CDP connector for the chrome-use (--devtools) backend. */
+  chromeUseConnector?: CdpConnector;
 }
 
 interface RefTarget {
@@ -497,7 +499,7 @@ async function runBrowserCommand(
   }
 }
 
-class BrowserCliContext {
+export class BrowserCliContext {
   private readonly connection: ExtensionConnection | ChromeUseConnection;
   private readonly profile: string;
   private readonly json: boolean;
@@ -515,7 +517,7 @@ class BrowserCliContext {
   constructor(init: CommandContextInit) {
     this.devtoolsOnly = init.devtools;
     this.connection = init.devtools
-      ? new ChromeUseConnection(init.debug)
+      ? new ChromeUseConnection(init.debug, init.chromeUseConnector ? { connector: init.chromeUseConnector } : undefined)
       : new ExtensionConnection(
         init.port,
         init.debug,

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -652,7 +652,7 @@ class BrowserCliContext {
     const invocation = await this.callTool(
       'tabs',
       [
-        { names: ['list_pages', 'get_tabs'] },
+        { names: ['list_pages', 'get_tabs', 'list_tabs'] },
       ],
       {}
     );
@@ -673,7 +673,7 @@ class BrowserCliContext {
 
   async open(url?: string): Promise<CommandOutput> {
     if (!url) {
-      return this.callGenericCommand('open', [{ names: ['new_page', 'create_new_tab'] }], {});
+      return this.callGenericCommand('open', [{ names: ['new_page', 'create_new_tab', 'new_tab'] }], {});
     }
 
     try {
@@ -681,11 +681,11 @@ class BrowserCliContext {
         'open',
         [
           {
-            names: ['new_page', 'create_new_tab'],
+            names: ['new_page', 'create_new_tab', 'new_tab'],
             buildArgs: (tool) => withOpenArgs(tool, url),
           },
           {
-            names: ['navigate_page', 'navigate_to_url'],
+            names: ['navigate_page', 'navigate_to_url', 'navigate'],
             buildArgs: (tool) => withNavigateArgs(tool, url, this.timeoutMs),
           },
         ],
@@ -709,11 +709,11 @@ class BrowserCliContext {
         'navigate',
         [
           {
-            names: ['navigate_page', 'navigate_to_url'],
+            names: ['navigate_page', 'navigate_to_url', 'navigate'],
             buildArgs: (tool) => withNavigateArgs(tool, url, this.timeoutMs),
           },
           {
-            names: ['new_page', 'create_new_tab'],
+            names: ['new_page', 'create_new_tab', 'new_tab'],
             buildArgs: (tool) => withOpenArgs(tool, url),
           },
         ],
@@ -749,7 +749,7 @@ class BrowserCliContext {
       'focus',
       [
         {
-          names: ['switch_to_page', 'switch_to_tab', 'select_page', 'focus_tab'],
+          names: ['switch_to_page', 'switch_to_tab', 'select_page', 'focus_tab', 'select_tab'],
           buildArgs: (tool) => withPageArgs(tool, id),
         },
       ],
@@ -774,7 +774,7 @@ class BrowserCliContext {
       'snapshot',
       [
         {
-          names: ['take_snapshot'],
+          names: ['take_snapshot', 'snapshot'],
           buildArgs: (tool: ToolDefinition) => withSnapshotArgs(tool, options),
         },
       ],
@@ -1053,7 +1053,7 @@ class BrowserCliContext {
       'evaluate',
       [
         {
-          names: ['evaluate_script'],
+          names: ['evaluate_script', 'eval'],
           buildArgs: (tool) => withEvaluateArgs(tool, options.fn, options.ref, options.argsJson),
         },
       ],
@@ -2088,6 +2088,7 @@ function withSnapshotArgs(
   tool: ToolDefinition,
   options: {
     format: string;
+    interactive?: boolean;
     selector?: string;
     frame?: string;
     compact: boolean;
@@ -2098,6 +2099,8 @@ function withSnapshotArgs(
 ): Record<string, unknown> {
   const args: Record<string, unknown> = {};
   maybeAssign(args, tool, 'format', options.format);
+  // chrome-use `snapshot` tool: interactive-only flag.
+  maybeAssign(args, tool, 'interactive', options.interactive || undefined);
   maybeAssign(args, tool, 'selector', options.selector);
   maybeAssign(args, tool, 'frame', options.frame);
   maybeAssign(args, tool, 'compact', options.compact || undefined);
@@ -2311,6 +2314,8 @@ function withEvaluateArgs(
 ): Record<string, unknown> {
   const args: Record<string, unknown> = {};
   maybeAssign(args, tool, 'function', fn);
+  // chrome-use `eval` tool takes a bare expression rather than a function body.
+  maybeAssign(args, tool, 'expression', fn);
 
   const values: string[] = [];
   if (ref) {

--- a/src/chrome-use-connection.ts
+++ b/src/chrome-use-connection.ts
@@ -1,0 +1,602 @@
+/**
+ * Vibe MCP Server - chrome-use DevTools backend
+ *
+ * Drives the user's REAL running Chrome directly over the Chrome DevTools Protocol
+ * (autoConnect via the DevToolsActivePort file), replacing the old `--devtools`
+ * path that proxied the external, buggy chrome-devtools-mcp server.
+ *
+ * The CDP driver core under `./chrome-use/` is adapted from the `chrome-use` skill
+ * (skills/chrome-use/scripts). This class exposes a fixed catalog of MCP tools and
+ * dispatches each call to that core. It implements the same connection surface as
+ * DevtoolsFallbackConnection so the MCP server (src/server.ts) can use it
+ * interchangeably in `--devtools` mode.
+ */
+import { EventEmitter } from 'node:events';
+import { Cdp, type WebSocketFactory } from './chrome-use/cdp.js';
+import { buildWsEndpoint, type Channel } from './chrome-use/devtools-port.js';
+import { SessionManager } from './chrome-use/session.js';
+import { resolve as resolveSelector } from './chrome-use/selectors.js';
+import { takeSnapshot } from './chrome-use/snapshot.js';
+import {
+  clickElement,
+  fillElement,
+  typeText,
+  pressKey,
+  hoverElement,
+  scrollBy,
+} from './chrome-use/input.js';
+import type { CdpClient, TabSession } from './chrome-use/types.js';
+import type { ToolDefinition, ToolResult, ToolResultContent } from './types.js';
+
+const UNAVAILABLE_PREFIX = 'chrome-use DevTools backend unavailable';
+
+/** How a CDP connection is established. Injectable so tests can supply a fake. */
+export interface CdpConnector {
+  connect(): Promise<CdpClient>;
+}
+
+/**
+ * Default connector: autoConnect to the user's real Chrome via DevToolsActivePort.
+ *
+ * The profile directory and release channel can be overridden via
+ * `VIBE_CHROME_USER_DATA_DIR` / `VIBE_CHROME_CHANNEL` (e.g. to target Chrome
+ * Canary, a custom profile, or — in tests — a path with no DevToolsActivePort so
+ * discovery fails fast and the backend reports unavailable without a live browser).
+ */
+class AutoConnectCdpConnector implements CdpConnector {
+  private readonly channel: Channel;
+  private readonly userDataDir?: string;
+
+  constructor(channel?: Channel, userDataDir?: string, private readonly wsFactory?: WebSocketFactory) {
+    const envChannel = process.env.VIBE_CHROME_CHANNEL as Channel | undefined;
+    this.channel = channel ?? (envChannel || 'stable');
+    this.userDataDir = userDataDir ?? process.env.VIBE_CHROME_USER_DATA_DIR ?? undefined;
+  }
+
+  async connect(): Promise<CdpClient> {
+    const endpoint = buildWsEndpoint(this.channel, this.userDataDir);
+    return Cdp.connect(endpoint, 10_000, this.wsFactory);
+  }
+}
+
+interface ChromeUseConnectionOptions {
+  /** Override the CDP connector (tests inject a fake here). */
+  connector?: CdpConnector;
+  channel?: Channel;
+  userDataDir?: string;
+}
+
+function text(value: string): ToolResultContent {
+  return { type: 'text', text: value };
+}
+
+function ok(value: string): ToolResult {
+  return { success: true, isError: false, content: [text(value)] };
+}
+
+function arg(args: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const v = args[key];
+    if (typeof v === 'string' && v.length > 0) return v;
+    if (typeof v === 'number') return String(v);
+  }
+  return undefined;
+}
+
+/** Sleep helper. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+const TOOLS: ToolDefinition[] = [
+  {
+    name: 'navigate',
+    description: 'Navigate the active tab to a URL (bare domains get https://). Waits for load.',
+    inputSchema: {
+      type: 'object',
+      properties: { url: { type: 'string', description: 'URL or bare domain to open' } },
+      required: ['url'],
+    },
+  },
+  {
+    name: 'snapshot',
+    description:
+      'Accessibility snapshot of the active page as an indented tree of @eN refs. Use these refs as selectors for click/fill/type. Pass interactive=true for interactive elements only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        interactive: { type: 'boolean', description: 'Interactive elements only' },
+        selector: { type: 'string', description: 'Scope the snapshot to a CSS selector' },
+      },
+    },
+  },
+  {
+    name: 'click',
+    description: 'Click an element. Selector may be a @eN snapshot ref, text=…, or a CSS selector.',
+    inputSchema: {
+      type: 'object',
+      properties: { selector: { type: 'string', description: '@eN ref, text=…, or CSS selector' } },
+      required: ['selector'],
+    },
+  },
+  {
+    name: 'fill',
+    description: 'Clear an input/textarea/contenteditable and fill it with text (fires input/change).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        selector: { type: 'string', description: '@eN ref, text=…, or CSS selector' },
+        text: { type: 'string', description: 'Text to fill' },
+      },
+      required: ['selector', 'text'],
+    },
+  },
+  {
+    name: 'type',
+    description: 'Focus an element and type text as trusted input (no clearing).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        selector: { type: 'string', description: '@eN ref, text=…, or CSS selector' },
+        text: { type: 'string', description: 'Text to type' },
+      },
+      required: ['selector', 'text'],
+    },
+  },
+  {
+    name: 'press_key',
+    description: 'Press a key chord on the active page, e.g. Enter, Control+a, Shift+Tab.',
+    inputSchema: {
+      type: 'object',
+      properties: { key: { type: 'string', description: 'Key chord, e.g. Enter or Control+a' } },
+      required: ['key'],
+    },
+  },
+  {
+    name: 'hover',
+    description: 'Move the mouse over an element (hover).',
+    inputSchema: {
+      type: 'object',
+      properties: { selector: { type: 'string', description: '@eN ref, text=…, or CSS selector' } },
+      required: ['selector'],
+    },
+  },
+  {
+    name: 'scroll',
+    description: 'Scroll the active page in a direction by a pixel amount.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        direction: { type: 'string', enum: ['up', 'down', 'left', 'right'], description: 'Scroll direction' },
+        amount: { type: 'number', description: 'Pixels to scroll (default 400)' },
+      },
+    },
+  },
+  {
+    name: 'screenshot',
+    description: 'Capture a PNG screenshot of the active page, returned as a base64 image.',
+    inputSchema: {
+      type: 'object',
+      properties: { fullPage: { type: 'boolean', description: 'Capture beyond the viewport' } },
+    },
+  },
+  {
+    name: 'eval',
+    description: 'Evaluate a JavaScript expression in the active page and return the JSON result.',
+    inputSchema: {
+      type: 'object',
+      properties: { expression: { type: 'string', description: 'JavaScript expression to evaluate' } },
+      required: ['expression'],
+    },
+  },
+  {
+    name: 'get_text',
+    description: 'Get the visible innerText of the active page (or an element when selector is given).',
+    inputSchema: {
+      type: 'object',
+      properties: { selector: { type: 'string', description: 'Optional CSS selector / @eN ref / text=…' } },
+    },
+  },
+  {
+    name: 'get_url',
+    description: 'Get the current URL of the active page.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'get_title',
+    description: 'Get the document title of the active page.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'list_tabs',
+    description: 'List the open browser tabs with their tab id, url, and title.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'new_tab',
+    description: 'Open a new browser tab (optionally at a URL) and make it active.',
+    inputSchema: {
+      type: 'object',
+      properties: { url: { type: 'string', description: 'Optional URL to open' } },
+    },
+  },
+  {
+    name: 'select_tab',
+    description: 'Switch the active tab by tab id (e.g. t2) or index.',
+    inputSchema: {
+      type: 'object',
+      properties: { tab: { type: 'string', description: 'Tab id (t1, t2…) or index' } },
+      required: ['tab'],
+    },
+  },
+  {
+    name: 'close_tab',
+    description: 'Close a browser tab (active tab if none specified).',
+    inputSchema: {
+      type: 'object',
+      properties: { tab: { type: 'string', description: 'Tab id (t1, t2…) or index; defaults to active' } },
+    },
+  },
+];
+
+/** Normalize a tool name for matching (chrome-use exposes snake/lower forms). */
+function normalizeToolName(value: string): string {
+  return value.replace(/[-\s]/g, '_').toLowerCase();
+}
+
+export class ChromeUseConnection extends EventEmitter {
+  private readonly debug: boolean;
+  private readonly connector: CdpConnector;
+  private cdp: CdpClient | null = null;
+  private session: SessionManager | null = null;
+  private available = false;
+  private unavailableReason?: string;
+
+  constructor(debug: boolean, options: ChromeUseConnectionOptions = {}) {
+    super();
+    this.debug = debug;
+    this.connector =
+      options.connector ?? new AutoConnectCdpConnector(options.channel, options.userDataDir);
+  }
+
+  async start(): Promise<void> {
+    try {
+      this.cdp = await this.connector.connect();
+      this.session = new SessionManager(this.cdp);
+      // Probe the connection so we fail fast with a clear reason if Chrome is gone.
+      await this.cdp.send('Browser.getVersion');
+      this.available = true;
+      this.unavailableReason = undefined;
+      this.emit('connected');
+      this.emit('tools_updated', this.getTools());
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.unavailableReason = `${UNAVAILABLE_PREFIX}: ${message}`;
+      this.available = false;
+      this.cdp = null;
+      this.session = null;
+      this.log(this.unavailableReason);
+      this.emit('unavailable', this.unavailableReason);
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.available = false;
+    if (this.session) {
+      try {
+        await this.session.dispose();
+      } catch {
+        /* ignore */
+      }
+      this.session = null;
+    }
+    if (this.cdp) {
+      try {
+        this.cdp.close();
+      } catch {
+        /* ignore */
+      }
+      this.cdp = null;
+    }
+  }
+
+  /** Tool catalog is static; refresh just re-confirms availability. */
+  async refreshTools(_timeoutMs?: number): Promise<ToolDefinition[]> {
+    return this.getTools();
+  }
+
+  getTools(): ToolDefinition[] {
+    return this.available ? TOOLS : [];
+  }
+
+  hasTool(name: string): boolean {
+    const needle = normalizeToolName(name);
+    return this.getTools().some((tool) => normalizeToolName(tool.name) === needle);
+  }
+
+  isAvailable(): boolean {
+    return this.available;
+  }
+
+  getUnavailableReason(): string | undefined {
+    return this.unavailableReason;
+  }
+
+  async callTool(name: string, args: Record<string, unknown>, _timeoutMs?: number): Promise<ToolResult> {
+    if (!this.available || !this.cdp || !this.session) {
+      throw new Error(this.unavailableReason || UNAVAILABLE_PREFIX);
+    }
+    const tool = normalizeToolName(name);
+
+    switch (tool) {
+      case 'navigate':
+        return this.navigate(args);
+      case 'snapshot':
+        return this.snapshot(args);
+      case 'click':
+        return this.actOnElement(args, 'click');
+      case 'fill':
+        return this.fill(args);
+      case 'type':
+        return this.type(args);
+      case 'press_key':
+        return this.pressKey(args);
+      case 'hover':
+        return this.actOnElement(args, 'hover');
+      case 'scroll':
+        return this.scroll(args);
+      case 'screenshot':
+        return this.screenshot(args);
+      case 'eval':
+        return this.evaluate(args);
+      case 'get_text':
+        return this.getText(args);
+      case 'get_url':
+        return this.getUrl();
+      case 'get_title':
+        return this.getTitle();
+      case 'list_tabs':
+        return this.listTabs();
+      case 'new_tab':
+        return this.newTab(args);
+      case 'select_tab':
+        return this.selectTab(args);
+      case 'close_tab':
+        return this.closeTab(args);
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  }
+
+  // ── Tool implementations ───────────────────────────────────────────────────
+
+  private async waitForLoad(tab: TabSession, timeoutMs = 15_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    await sleep(150);
+    while (Date.now() < deadline) {
+      try {
+        const res = await this.cdp!.send<{ result?: { value?: unknown } }>(
+          'Runtime.evaluate',
+          { expression: 'document.readyState', returnByValue: true },
+          tab.sessionId,
+        );
+        if (res?.result?.value === 'complete') return;
+      } catch {
+        /* page may be mid-navigation; keep polling */
+      }
+      await sleep(150);
+    }
+  }
+
+  private normalizeUrl(raw: string): string {
+    if (!raw) return raw;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(raw)) return raw;
+    if (raw.startsWith('//')) return 'https:' + raw;
+    if (raw === 'about:blank') return raw;
+    if (/^localhost(:\d+)?(\/|$)/.test(raw) || /\.[a-z]{2,}/i.test(raw)) {
+      return 'https://' + raw;
+    }
+    return raw;
+  }
+
+  private async navigate(args: Record<string, unknown>): Promise<ToolResult> {
+    const raw = arg(args, 'url');
+    if (!raw) throw new Error('navigate: url is required');
+    const url = this.normalizeUrl(raw);
+    const tab = await this.session!.getActiveTab();
+    await this.cdp!.send('Page.navigate', { url }, tab.sessionId);
+    await this.waitForLoad(tab);
+    try {
+      const res = await this.cdp!.send<{ result?: { value?: unknown } }>(
+        'Runtime.evaluate',
+        { expression: 'location.href', returnByValue: true },
+        tab.sessionId,
+      );
+      if (typeof res?.result?.value === 'string') tab.url = res.result.value;
+    } catch {
+      tab.url = url;
+    }
+    return ok(`Opened ${tab.url}`);
+  }
+
+  private async snapshot(args: Record<string, unknown>): Promise<ToolResult> {
+    const tab = await this.session!.getActiveTab();
+    const r = await takeSnapshot(this.cdp!, tab, {
+      interactive: args.interactive === true,
+      selector: arg(args, 'selector'),
+    });
+    tab.refRegistry = r.refs;
+    return ok(`${r.text}\n${r.refs.size} refs`);
+  }
+
+  private async actOnElement(args: Record<string, unknown>, action: 'click' | 'hover'): Promise<ToolResult> {
+    const selector = arg(args, 'selector');
+    if (!selector) throw new Error(`${action}: selector is required`);
+    const tab = await this.session!.getActiveTab();
+    const el = await resolveSelector(this.cdp!, tab, selector);
+    if (action === 'click') {
+      await clickElement(this.cdp!, tab.sessionId, el);
+      return ok(`Clicked ${selector}`);
+    }
+    await hoverElement(this.cdp!, tab.sessionId, el);
+    return ok(`Hovered ${selector}`);
+  }
+
+  private async fill(args: Record<string, unknown>): Promise<ToolResult> {
+    const selector = arg(args, 'selector');
+    const value = typeof args.text === 'string' ? args.text : '';
+    if (!selector) throw new Error('fill: selector is required');
+    const tab = await this.session!.getActiveTab();
+    const el = await resolveSelector(this.cdp!, tab, selector);
+    await fillElement(this.cdp!, tab.sessionId, el, value);
+    return ok(`Filled ${selector}`);
+  }
+
+  private async type(args: Record<string, unknown>): Promise<ToolResult> {
+    const selector = arg(args, 'selector');
+    const value = typeof args.text === 'string' ? args.text : '';
+    if (!selector) throw new Error('type: selector is required');
+    const tab = await this.session!.getActiveTab();
+    const el = await resolveSelector(this.cdp!, tab, selector);
+    await typeText(this.cdp!, tab.sessionId, el, value);
+    return ok(`Typed into ${selector}`);
+  }
+
+  private async pressKey(args: Record<string, unknown>): Promise<ToolResult> {
+    const key = arg(args, 'key');
+    if (!key) throw new Error('press_key: key is required');
+    const tab = await this.session!.getActiveTab();
+    await pressKey(this.cdp!, tab.sessionId, key);
+    return ok(`Pressed ${key}`);
+  }
+
+  private async scroll(args: Record<string, unknown>): Promise<ToolResult> {
+    const raw = (arg(args, 'direction') ?? 'down').toLowerCase();
+    const dir = (['up', 'down', 'left', 'right'] as const).includes(raw as 'up')
+      ? (raw as 'up' | 'down' | 'left' | 'right')
+      : 'down';
+    const px = typeof args.amount === 'number' ? args.amount : 400;
+    const tab = await this.session!.getActiveTab();
+    await scrollBy(this.cdp!, tab.sessionId, dir, px);
+    return ok(`Scrolled ${dir} ${px}px`);
+  }
+
+  private async screenshot(args: Record<string, unknown>): Promise<ToolResult> {
+    const tab = await this.session!.getActiveTab();
+    const res = await this.cdp!.send<{ data?: string }>(
+      'Page.captureScreenshot',
+      { format: 'png', captureBeyondViewport: args.fullPage === true, fromSurface: true },
+      tab.sessionId,
+    );
+    if (!res?.data) throw new Error('screenshot: no image data returned');
+    return {
+      success: true,
+      isError: false,
+      content: [{ type: 'image', data: res.data, mimeType: 'image/png' }],
+    };
+  }
+
+  private async evaluate(args: Record<string, unknown>): Promise<ToolResult> {
+    const expression = arg(args, 'expression');
+    if (!expression) throw new Error('eval: expression is required');
+    const tab = await this.session!.getActiveTab();
+    const res = await this.cdp!.send<{
+      result?: { value?: unknown };
+      exceptionDetails?: { text?: string };
+    }>(
+      'Runtime.evaluate',
+      { expression, returnByValue: true, awaitPromise: true },
+      tab.sessionId,
+    );
+    if (res?.exceptionDetails) {
+      throw new Error(res.exceptionDetails.text ?? 'eval failed');
+    }
+    return ok(JSON.stringify(res?.result?.value ?? null, null, 2));
+  }
+
+  private async getText(args: Record<string, unknown>): Promise<ToolResult> {
+    const selector = arg(args, 'selector');
+    const tab = await this.session!.getActiveTab();
+    if (!selector) {
+      const res = await this.cdp!.send<{ result?: { value?: unknown } }>(
+        'Runtime.evaluate',
+        { expression: 'document.body ? document.body.innerText : ""', returnByValue: true },
+        tab.sessionId,
+      );
+      return ok(String(res?.result?.value ?? ''));
+    }
+    const el = await resolveSelector(this.cdp!, tab, selector);
+    const res = await this.cdp!.send<{ result?: { value?: unknown } }>(
+      'Runtime.callFunctionOn',
+      { objectId: el.objectId, functionDeclaration: 'function(){ return this.innerText; }', returnByValue: true },
+      tab.sessionId,
+    );
+    return ok(String(res?.result?.value ?? ''));
+  }
+
+  private async getUrl(): Promise<ToolResult> {
+    const tab = await this.session!.getActiveTab();
+    const res = await this.cdp!.send<{ result?: { value?: unknown } }>(
+      'Runtime.evaluate',
+      { expression: 'location.href', returnByValue: true },
+      tab.sessionId,
+    );
+    const url = typeof res?.result?.value === 'string' ? res.result.value : tab.url;
+    return ok(url);
+  }
+
+  private async getTitle(): Promise<ToolResult> {
+    const tab = await this.session!.getActiveTab();
+    const res = await this.cdp!.send<{ result?: { value?: unknown } }>(
+      'Runtime.evaluate',
+      { expression: 'document.title', returnByValue: true },
+      tab.sessionId,
+    );
+    return ok(String(res?.result?.value ?? ''));
+  }
+
+  private async listTabs(): Promise<ToolResult> {
+    await this.session!.syncTabs();
+    const lines: string[] = [];
+    for (const t of this.session!.tabs.values()) {
+      const active = t.targetId === this.session!.activeTargetId;
+      lines.push(`${active ? '*' : ' '} ${t.tabId}  ${t.url}`);
+    }
+    return ok(lines.join('\n') || 'No tabs open');
+  }
+
+  private async newTab(args: Record<string, unknown>): Promise<ToolResult> {
+    const url = arg(args, 'url');
+    const created = await this.session!.newTab(url ? this.normalizeUrl(url) : undefined);
+    return ok(`Opened ${created.tabId}`);
+  }
+
+  private async selectTab(args: Record<string, unknown>): Promise<ToolResult> {
+    const id = arg(args, 'tab');
+    if (!id) throw new Error('select_tab: tab is required');
+    const found = await this.session!.getTab(id);
+    if (!found) throw new Error(`No such tab: ${id}`);
+    this.session!.setActive(found.targetId);
+    return ok(`Switched to ${found.tabId}`);
+  }
+
+  private async closeTab(args: Record<string, unknown>): Promise<ToolResult> {
+    const id = arg(args, 'tab');
+    let victim: TabSession | undefined;
+    if (id) {
+      victim = await this.session!.getTab(id);
+      if (!victim) throw new Error(`No such tab: ${id}`);
+    } else {
+      victim = await this.session!.getActiveTab();
+    }
+    const tabId = victim.tabId;
+    await this.session!.closeTab(victim.targetId);
+    return ok(`Closed tab ${tabId}`);
+  }
+
+  private log(message: string): void {
+    if (this.debug) {
+      console.error(`[vibebrowser-mcp] ${message}`);
+    }
+  }
+}

--- a/src/chrome-use-connection.ts
+++ b/src/chrome-use-connection.ts
@@ -12,8 +12,9 @@
  * interchangeably in `--devtools` mode.
  */
 import { EventEmitter } from 'node:events';
-import { Cdp, type WebSocketFactory } from './chrome-use/cdp.js';
-import { buildWsEndpoint, type Channel } from './chrome-use/devtools-port.js';
+import { type Channel } from './chrome-use/devtools-port.js';
+import { ProxyClient } from './chrome-use/proxy-client.js';
+import { ensureProxy, getSocketPath } from './chrome-use/proxy-launcher.js';
 import { SessionManager } from './chrome-use/session.js';
 import { resolve as resolveSelector } from './chrome-use/selectors.js';
 import { takeSnapshot } from './chrome-use/snapshot.js';
@@ -36,26 +37,35 @@ export interface CdpConnector {
 }
 
 /**
- * Default connector: autoConnect to the user's real Chrome via DevToolsActivePort.
+ * Default connector: route through the long-lived chrome-use proxy (gateway).
+ *
+ * Instead of opening a fresh CDP WebSocket per request (which re-triggers Chrome's
+ * "Allow remote debugging?" dialog every time and starves the single autoConnect
+ * debugger slot), this auto-starts a background proxy that holds ONE approved CDP
+ * connection and relays frames over a Unix socket. The dialog fires once per proxy
+ * lifetime, and the same proxy is shared by the `--devtools` MCP server and every
+ * one-shot `browser --devtools` CLI invocation.
  *
  * The profile directory and release channel can be overridden via
  * `VIBE_CHROME_USER_DATA_DIR` / `VIBE_CHROME_CHANNEL` (e.g. to target Chrome
- * Canary, a custom profile, or — in tests — a path with no DevToolsActivePort so
- * discovery fails fast and the backend reports unavailable without a live browser).
+ * Canary or a custom profile); they are forwarded to the proxy process.
  */
 class AutoConnectCdpConnector implements CdpConnector {
   private readonly channel: Channel;
   private readonly userDataDir?: string;
 
-  constructor(channel?: Channel, userDataDir?: string, private readonly wsFactory?: WebSocketFactory) {
+  constructor(channel?: Channel, userDataDir?: string) {
     const envChannel = process.env.VIBE_CHROME_CHANNEL as Channel | undefined;
     this.channel = channel ?? (envChannel || 'stable');
     this.userDataDir = userDataDir ?? process.env.VIBE_CHROME_USER_DATA_DIR ?? undefined;
   }
 
   async connect(): Promise<CdpClient> {
-    const endpoint = buildWsEndpoint(this.channel, this.userDataDir);
-    return Cdp.connect(endpoint, 10_000, this.wsFactory);
+    const socketPath = getSocketPath();
+    const extraEnv: Record<string, string> = { VIBE_CHROME_CHANNEL: this.channel };
+    if (this.userDataDir) extraEnv.VIBE_CHROME_USER_DATA_DIR = this.userDataDir;
+    await ensureProxy(socketPath, undefined, extraEnv);
+    return ProxyClient.open(socketPath, 320_000);
   }
 }
 
@@ -264,7 +274,11 @@ export class ChromeUseConnection extends EventEmitter {
       this.cdp = await this.connector.connect();
       this.session = new SessionManager(this.cdp);
       // Probe the connection so we fail fast with a clear reason if Chrome is gone.
-      await this.cdp.send('Browser.getVersion');
+      // But do NOT block startup on the one-time "Allow remote debugging?" approval:
+      // if the probe is still pending after a short window, the proxy is up and the
+      // dialog is showing — mark available now and let the first real command await
+      // approval. This keeps MCP tools/list responsive (no startup hang).
+      await this.probeConnection();
       this.available = true;
       this.unavailableReason = undefined;
       this.emit('connected');
@@ -273,10 +287,42 @@ export class ChromeUseConnection extends EventEmitter {
       const message = error instanceof Error ? error.message : String(error);
       this.unavailableReason = `${UNAVAILABLE_PREFIX}: ${message}`;
       this.available = false;
+      // Close the client transport (proxy socket / WS) so it doesn't keep the
+      // Node event loop alive and hang a one-shot CLI after it prints output.
+      if (this.cdp) {
+        try {
+          this.cdp.close();
+        } catch {
+          /* ignore */
+        }
+      }
       this.cdp = null;
       this.session = null;
       this.log(this.unavailableReason);
       this.emit('unavailable', this.unavailableReason);
+    }
+  }
+
+  /**
+   * Probe Browser.getVersion to detect a dead/absent Chrome, but cap the wait so a
+   * pending approval dialog never blocks startup. Resolves on success; rethrows if
+   * the probe fails fast (Chrome gone); resolves as "deferred" if still pending.
+   */
+  private async probeConnection(timeoutMs = 4000): Promise<void> {
+    const probe = (this.cdp as CdpClient).send('Browser.getVersion');
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const pending = new Promise<'pending'>((resolveRace) => {
+      timer = setTimeout(() => resolveRace('pending'), timeoutMs);
+    });
+    try {
+      const outcome = await Promise.race([probe.then(() => 'ok' as const), pending]);
+      if (outcome === 'pending') {
+        // Approval likely in progress: don't fail, don't await it here. Swallow the
+        // probe's eventual settling so it can't raise an unhandled rejection.
+        probe.catch(() => {});
+      }
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
 

--- a/src/chrome-use/cdp.ts
+++ b/src/chrome-use/cdp.ts
@@ -58,7 +58,14 @@ export class Cdp implements CdpClient {
     const make = wsFactory ?? ((url: string) => new WebSocket(url) as unknown as WebSocketLike);
     const ws = make(wsEndpoint);
     const client = new Cdp(ws);
-    await withTimeout(client.openPromise, timeoutMs, `CDP connect timed out after ${timeoutMs}ms`);
+    try {
+      await withTimeout(client.openPromise, timeoutMs, `CDP connect timed out after ${timeoutMs}ms`);
+    } catch (err) {
+      // Close the dangling socket so it stops keeping the Node event loop alive
+      // (otherwise the one-shot CLI hangs after printing the error).
+      client.close();
+      throw err;
+    }
     return client;
   }
 

--- a/src/chrome-use/cdp.ts
+++ b/src/chrome-use/cdp.ts
@@ -1,0 +1,155 @@
+/**
+ * Zero-dependency Chrome DevTools Protocol client over Node's global WebSocket.
+ *
+ * Connects to the browser-level endpoint (ws://127.0.0.1:<port>/devtools/browser/<id>)
+ * and uses flattened sessions: page-level commands carry a `sessionId` obtained via
+ * Target.attachToTarget({ flatten: true }). No Puppeteer, no npm deps.
+ *
+ * Adapted from the `chrome-use` skill (skills/chrome-use/scripts/lib/cdp.ts).
+ */
+import type { CdpClient } from './types.js';
+
+interface Pending {
+  resolve: (v: unknown) => void;
+  reject: (e: Error) => void;
+}
+
+/** Subset of the WHATWG WebSocket the CDP client relies on. */
+interface WebSocketLike {
+  readyState: number;
+  send(data: string): void;
+  close(): void;
+  addEventListener(type: string, listener: (ev: unknown) => void, opts?: { once?: boolean }): void;
+}
+
+/** Factory for a WebSocket; injectable for tests. Defaults to global WebSocket. */
+export type WebSocketFactory = (url: string) => WebSocketLike;
+
+const WS_OPEN = 1;
+
+export class Cdp implements CdpClient {
+  private readonly ws: WebSocketLike;
+  private nextId = 1;
+  private readonly pending = new Map<number, Pending>();
+  private readonly listeners = new Map<string, Set<(params: unknown, sessionId?: string) => void>>();
+  private readonly openPromise: Promise<void>;
+  private isClosed = false;
+
+  private constructor(ws: WebSocketLike) {
+    this.ws = ws;
+    this.openPromise = new Promise<void>((resolve, reject) => {
+      ws.addEventListener('open', () => resolve(), { once: true });
+      ws.addEventListener('error', () => reject(new Error('WebSocket connection error')), { once: true });
+    });
+    ws.addEventListener('message', (ev) => this.onMessage(String((ev as { data: unknown }).data)));
+    ws.addEventListener('close', () => {
+      this.isClosed = true;
+      for (const { reject } of this.pending.values()) reject(new Error('CDP connection closed'));
+      this.pending.clear();
+    });
+  }
+
+  /** Connect to a browser-level ws endpoint and resolve once the socket is open. */
+  static async connect(
+    wsEndpoint: string,
+    timeoutMs = 10_000,
+    wsFactory?: WebSocketFactory,
+  ): Promise<Cdp> {
+    const make = wsFactory ?? ((url: string) => new WebSocket(url) as unknown as WebSocketLike);
+    const ws = make(wsEndpoint);
+    const client = new Cdp(ws);
+    await withTimeout(client.openPromise, timeoutMs, `CDP connect timed out after ${timeoutMs}ms`);
+    return client;
+  }
+
+  get connected(): boolean {
+    return !this.isClosed && this.ws.readyState === WS_OPEN;
+  }
+
+  private onMessage(raw: string): void {
+    let msg: {
+      id?: number;
+      method?: string;
+      params?: unknown;
+      sessionId?: string;
+      result?: unknown;
+      error?: { message?: string; code?: number };
+    };
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (typeof msg.id === 'number') {
+      const p = this.pending.get(msg.id);
+      if (!p) return;
+      this.pending.delete(msg.id);
+      if (msg.error) p.reject(new Error(`${msg.error.message ?? 'CDP error'} (code ${msg.error.code ?? '?'})`));
+      else p.resolve(msg.result);
+      return;
+    }
+    if (typeof msg.method === 'string') {
+      const set = this.listeners.get(msg.method);
+      if (set) {
+        for (const fn of set) {
+          try {
+            fn(msg.params, msg.sessionId);
+          } catch {
+            /* listener errors are non-fatal */
+          }
+        }
+      }
+    }
+  }
+
+  send<T = unknown>(method: string, params: Record<string, unknown> = {}, sessionId?: string): Promise<T> {
+    if (this.isClosed) return Promise.reject(new Error('CDP connection closed'));
+    const id = this.nextId++;
+    const payload: Record<string, unknown> = { id, method, params };
+    if (sessionId) payload.sessionId = sessionId;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject });
+      try {
+        this.ws.send(JSON.stringify(payload));
+      } catch (e) {
+        this.pending.delete(id);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+  }
+
+  on(method: string, handler: (params: unknown, sessionId?: string) => void): () => void {
+    let set = this.listeners.get(method);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(method, set);
+    }
+    set.add(handler);
+    return () => set!.delete(handler);
+  }
+
+  close(): void {
+    this.isClosed = true;
+    try {
+      this.ws.close();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}

--- a/src/chrome-use/devtools-port.ts
+++ b/src/chrome-use/devtools-port.ts
@@ -1,0 +1,71 @@
+/**
+ * Locate and parse Chrome's DevToolsActivePort file and build the browser-level
+ * WebSocket endpoint for autoConnect. No HTTP /json/version endpoint exists in
+ * autoConnect mode — we read the port file and connect to the WS path directly.
+ *
+ * Adapted from the `chrome-use` skill (skills/chrome-use/scripts/lib/devtools-port.ts).
+ * Connects to the user's real Chrome profile (Chrome 144+). The permission dialog
+ * fires once per profile.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+export type Channel = 'stable' | 'canary' | 'beta' | 'dev';
+
+/** Absolute path to the DevToolsActivePort file for a channel / explicit profile dir. */
+export function getPortPath(channel: Channel = 'stable', userDataDir?: string): string {
+  if (userDataDir) return path.join(userDataDir, 'DevToolsActivePort');
+  const h = os.homedir();
+  if (os.platform() === 'darwin') {
+    const d: Record<string, string> = {
+      stable: 'Google/Chrome',
+      canary: 'Google/Chrome Canary',
+      beta: 'Google/Chrome Beta',
+      dev: 'Google/Chrome Dev',
+    };
+    return path.join(h, 'Library/Application Support', d[channel] ?? d.stable, 'DevToolsActivePort');
+  }
+  if (os.platform() === 'linux') {
+    const d: Record<string, string> = {
+      stable: '.config/google-chrome',
+      canary: '.config/google-chrome-unstable',
+      beta: '.config/google-chrome-beta',
+      dev: '.config/google-chrome-unstable',
+    };
+    return path.join(h, d[channel] ?? d.stable, 'DevToolsActivePort');
+  }
+  return path.join(process.env.LOCALAPPDATA ?? '', 'Google/Chrome/User Data/DevToolsActivePort');
+}
+
+/**
+ * Parse a DevToolsActivePort file body. Format is two lines:
+ *   <port>
+ *   <ws-path>   e.g. /devtools/browser/4fd90b22-...
+ * Returns the browser-level ws:// endpoint.
+ * @throws if the body is malformed.
+ */
+export function parsePortFile(content: string): string {
+  const [rawPort, rawPath] = content.split('\n').map((l) => l.trim()).filter(Boolean);
+  if (!rawPort || !rawPath) throw new Error(`Invalid DevToolsActivePort: ${JSON.stringify(content)}`);
+  const port = parseInt(rawPort, 10);
+  if (!port || port < 1 || port > 65535) throw new Error(`Bad port in DevToolsActivePort: ${rawPort}`);
+  return `ws://127.0.0.1:${port}${rawPath}`;
+}
+
+/** Read the port file and build the ws:// browser endpoint, with a helpful error. */
+export function buildWsEndpoint(channel: Channel = 'stable', userDataDir?: string): string {
+  const portPath = getPortPath(channel, userDataDir);
+  let content: string;
+  try {
+    content = fs.readFileSync(portPath, 'utf8');
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `DevToolsActivePort not found at ${portPath}.\n` +
+        `Make sure Chrome (144+) is running and remote debugging is allowed at ` +
+        `chrome://inspect/#remote-debugging.\n${message}`,
+    );
+  }
+  return parsePortFile(content);
+}

--- a/src/chrome-use/input.ts
+++ b/src/chrome-use/input.ts
@@ -1,0 +1,337 @@
+/**
+ * Trusted input helpers built on the CDP Input domain. Unlike synthetic
+ * dispatchEvent, Input.* produces trusted events that pass on sites which reject
+ * scripted interaction. Elements are addressed by a resolved {@link ResolvedElement}.
+ *
+ * Adapted from the `chrome-use` skill (skills/chrome-use/scripts/lib/input.ts).
+ */
+import type { CdpClient, ResolvedElement } from './types.js';
+
+/** Modifier bitmask values used by Input.dispatchKeyEvent. */
+const MOD = { Alt: 1, Control: 2, Ctrl: 2, Meta: 4, Shift: 8 } as const;
+
+interface KeyDef {
+  key: string;
+  code: string;
+  keyCode: number;
+  text?: string;
+}
+
+/** Named (non-printable) keys recognized by `pressKey`. */
+const NAMED_KEYS: Record<string, KeyDef> = {
+  Enter: { key: 'Enter', code: 'Enter', keyCode: 13, text: '\r' },
+  Tab: { key: 'Tab', code: 'Tab', keyCode: 9 },
+  Escape: { key: 'Escape', code: 'Escape', keyCode: 27 },
+  Backspace: { key: 'Backspace', code: 'Backspace', keyCode: 8 },
+  Delete: { key: 'Delete', code: 'Delete', keyCode: 46 },
+  ArrowUp: { key: 'ArrowUp', code: 'ArrowUp', keyCode: 38 },
+  ArrowDown: { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 },
+  ArrowLeft: { key: 'ArrowLeft', code: 'ArrowLeft', keyCode: 37 },
+  ArrowRight: { key: 'ArrowRight', code: 'ArrowRight', keyCode: 39 },
+  Home: { key: 'Home', code: 'Home', keyCode: 36 },
+  End: { key: 'End', code: 'End', keyCode: 35 },
+  PageUp: { key: 'PageUp', code: 'PageUp', keyCode: 33 },
+  PageDown: { key: 'PageDown', code: 'PageDown', keyCode: 34 },
+  Space: { key: ' ', code: 'Space', keyCode: 32, text: ' ' },
+};
+
+/** Build the {objectId} | {backendNodeId} addressing object for CDP DOM/Input. */
+function nodeAddr(el: ResolvedElement): Record<string, unknown> {
+  if (el.objectId) return { objectId: el.objectId };
+  if (el.backendNodeId != null) return { backendNodeId: el.backendNodeId };
+  throw new Error('ResolvedElement has neither objectId nor backendNodeId');
+}
+
+/** Scroll the element into view (centered) so it has a renderable box. */
+async function scrollIntoView(cdp: CdpClient, sessionId: string, el: ResolvedElement): Promise<void> {
+  if (el.objectId) {
+    await cdp.send(
+      'Runtime.callFunctionOn',
+      {
+        objectId: el.objectId,
+        functionDeclaration: "function(){ this.scrollIntoView({block:'center', inline:'center'}); }",
+      },
+      sessionId,
+    );
+    return;
+  }
+  const resolved = await cdp.send<{ object?: { objectId?: string } }>(
+    'DOM.resolveNode',
+    { backendNodeId: el.backendNodeId },
+    sessionId,
+  );
+  if (resolved?.object?.objectId) {
+    await cdp.send(
+      'Runtime.callFunctionOn',
+      {
+        objectId: resolved.object.objectId,
+        functionDeclaration: "function(){ this.scrollIntoView({block:'center', inline:'center'}); }",
+      },
+      sessionId,
+    );
+  }
+}
+
+/**
+ * Compute the viewport center point of an element. Falls back to scrolling it into
+ * view and retrying once if the box model is initially unavailable.
+ */
+async function centerOf(
+  cdp: CdpClient,
+  sessionId: string,
+  el: ResolvedElement,
+): Promise<{ x: number; y: number }> {
+  const getBox = async (): Promise<{ x: number; y: number } | null> => {
+    const res = await cdp.send<{ model?: { content?: number[] } }>('DOM.getBoxModel', nodeAddr(el), sessionId);
+    const quad = res?.model?.content;
+    if (!quad || quad.length < 8) return null;
+    return { x: (quad[0] + quad[4]) / 2, y: (quad[1] + quad[5]) / 2 };
+  };
+
+  try {
+    const c = await getBox();
+    if (c) return c;
+  } catch {
+    /* fall through to scroll + retry */
+  }
+
+  await scrollIntoView(cdp, sessionId, el);
+  const c2 = await getBox();
+  if (c2) return c2;
+  throw new Error('Element is not rendered (no box model)');
+}
+
+/** Click an element with a trusted left mouse press/release at its center. */
+export async function clickElement(
+  cdp: CdpClient,
+  sessionId: string,
+  el: ResolvedElement,
+): Promise<void> {
+  await scrollIntoView(cdp, sessionId, el);
+  const { x, y } = await centerOf(cdp, sessionId, el);
+  await cdp.send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y }, sessionId);
+  await cdp.send(
+    'Input.dispatchMouseEvent',
+    { type: 'mousePressed', x, y, button: 'left', clickCount: 1, buttons: 1 },
+    sessionId,
+  );
+  await cdp.send(
+    'Input.dispatchMouseEvent',
+    { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, buttons: 1 },
+    sessionId,
+  );
+}
+
+/** Move the mouse to the element center (hover). */
+export async function hoverElement(
+  cdp: CdpClient,
+  sessionId: string,
+  el: ResolvedElement,
+): Promise<void> {
+  const { x, y } = await centerOf(cdp, sessionId, el);
+  await cdp.send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y }, sessionId);
+}
+
+/** Focus an element via DOM.focus. */
+export async function focusElement(
+  cdp: CdpClient,
+  sessionId: string,
+  el: ResolvedElement,
+): Promise<void> {
+  await cdp.send('DOM.focus', nodeAddr(el), sessionId);
+}
+
+/**
+ * Clear an element and insert `text`. Clears any existing value first (for
+ * inputs/textareas/contenteditable) then inserts as trusted text and fires an
+ * input event so frameworks (React, Vue, …) observe the change.
+ */
+export async function fillElement(
+  cdp: CdpClient,
+  sessionId: string,
+  el: ResolvedElement,
+  text: string,
+): Promise<void> {
+  await focusElement(cdp, sessionId, el);
+  if (el.objectId) {
+    await cdp.send(
+      'Runtime.callFunctionOn',
+      {
+        objectId: el.objectId,
+        functionDeclaration:
+          "function(){ if ('value' in this) { this.value=''; } else if (this.isContentEditable) { this.textContent=''; } }",
+      },
+      sessionId,
+    );
+  }
+  await cdp.send('Input.insertText', { text }, sessionId);
+  if (el.objectId) {
+    await cdp.send(
+      'Runtime.callFunctionOn',
+      {
+        objectId: el.objectId,
+        functionDeclaration:
+          "function(){ this.dispatchEvent(new Event('input', {bubbles:true})); this.dispatchEvent(new Event('change', {bubbles:true})); }",
+      },
+      sessionId,
+    );
+  }
+}
+
+/** Focus an element and insert `text` as trusted input (fast path, no per-key events). */
+export async function typeText(
+  cdp: CdpClient,
+  sessionId: string,
+  el: ResolvedElement,
+  text: string,
+): Promise<void> {
+  await focusElement(cdp, sessionId, el);
+  await cdp.send('Input.insertText', { text }, sessionId);
+}
+
+/**
+ * Press a key chord like `Enter`, `Control+a`, `Meta+Enter`, or `Shift+Tab`.
+ * Modifiers are held (keyDown) before the main key and released (keyUp) after.
+ */
+export async function pressKey(cdp: CdpClient, sessionId: string, key: string): Promise<void> {
+  const parts = key.split('+').map((p) => p.trim()).filter(Boolean);
+  const main = parts.pop() ?? '';
+  const modifiers = parts;
+
+  let mask = 0;
+  for (const m of modifiers) {
+    const v = (MOD as Record<string, number>)[normalizeMod(m)];
+    if (v) mask |= v;
+  }
+
+  const def = resolveKeyDef(main);
+
+  for (const m of modifiers) {
+    const md = modifierKeyDef(normalizeMod(m));
+    if (md) await sendKey(cdp, sessionId, 'keyDown', md, mask);
+  }
+
+  const commands = editingCommands(mask, main);
+  await sendKey(cdp, sessionId, 'keyDown', def, mask, commands);
+  await sendKey(cdp, sessionId, 'keyUp', def, mask);
+
+  for (const m of [...modifiers].reverse()) {
+    const md = modifierKeyDef(normalizeMod(m));
+    if (md) await sendKey(cdp, sessionId, 'keyUp', md, mask);
+  }
+}
+
+/** Normalize modifier spellings to the canonical MOD keys. */
+function normalizeMod(m: string): string {
+  const lower = m.toLowerCase();
+  if (lower === 'ctrl' || lower === 'control') return 'Control';
+  if (lower === 'alt' || lower === 'option') return 'Alt';
+  if (lower === 'meta' || lower === 'cmd' || lower === 'command' || lower === 'super') return 'Meta';
+  if (lower === 'shift') return 'Shift';
+  return m;
+}
+
+/** KeyDef for a held modifier key (so it generates its own key events). */
+function modifierKeyDef(mod: string): KeyDef | null {
+  switch (mod) {
+    case 'Control':
+      return { key: 'Control', code: 'ControlLeft', keyCode: 17 };
+    case 'Alt':
+      return { key: 'Alt', code: 'AltLeft', keyCode: 18 };
+    case 'Meta':
+      return { key: 'Meta', code: 'MetaLeft', keyCode: 91 };
+    case 'Shift':
+      return { key: 'Shift', code: 'ShiftLeft', keyCode: 16 };
+    default:
+      return null;
+  }
+}
+
+/** Resolve a key token to a KeyDef (named key, or a single printable char). */
+function resolveKeyDef(token: string): KeyDef {
+  if (NAMED_KEYS[token]) return NAMED_KEYS[token];
+  const found = Object.keys(NAMED_KEYS).find((k) => k.toLowerCase() === token.toLowerCase());
+  if (found) return NAMED_KEYS[found];
+
+  if (token.length === 1) {
+    const ch = token;
+    const upper = ch.toUpperCase();
+    const code = /[a-zA-Z]/.test(ch) ? `Key${upper}` : /[0-9]/.test(ch) ? `Digit${ch}` : '';
+    return { key: ch, code, keyCode: upper.charCodeAt(0), text: ch };
+  }
+  return { key: token, code: token, keyCode: 0 };
+}
+
+/**
+ * Map an editing chord (Ctrl/Cmd + key, optionally Shift) to the CDP editing
+ * command(s) Chrome's editor expects. Empty when the chord isn't an editor action.
+ */
+function editingCommands(mask: number, key: string): string[] {
+  if (!(mask & (MOD.Control | MOD.Meta))) return [];
+  const k = key.toLowerCase();
+  const shift = mask & MOD.Shift;
+  switch (k) {
+    case 'a':
+      return ['selectAll'];
+    case 'c':
+      return ['copy'];
+    case 'v':
+      return ['paste'];
+    case 'x':
+      return ['cut'];
+    case 'z':
+      return shift ? ['redo'] : ['undo'];
+    case 'y':
+      return ['redo'];
+    default:
+      return [];
+  }
+}
+
+/** Dispatch a single key event with the given modifier mask and optional editor commands. */
+async function sendKey(
+  cdp: CdpClient,
+  sessionId: string,
+  type: 'keyDown' | 'keyUp',
+  def: KeyDef,
+  modifiers: number,
+  commands: string[] = [],
+): Promise<void> {
+  const params: Record<string, unknown> = {
+    type,
+    key: def.key,
+    code: def.code,
+    windowsVirtualKeyCode: def.keyCode,
+    nativeVirtualKeyCode: def.keyCode,
+    modifiers,
+  };
+  if (type === 'keyDown' && def.text && !(modifiers & (MOD.Control | MOD.Meta))) {
+    params.text = def.text;
+  }
+  if (type === 'keyDown' && commands.length) {
+    params.commands = commands;
+  }
+  await cdp.send('Input.dispatchKeyEvent', params, sessionId);
+}
+
+/** Scroll the page by `px` pixels in the given direction via a wheel event. */
+export async function scrollBy(
+  cdp: CdpClient,
+  sessionId: string,
+  dir: 'up' | 'down' | 'left' | 'right',
+  px: number,
+): Promise<void> {
+  const amount = px || 400;
+  let deltaX = 0;
+  let deltaY = 0;
+  if (dir === 'down') deltaY = amount;
+  else if (dir === 'up') deltaY = -amount;
+  else if (dir === 'right') deltaX = amount;
+  else if (dir === 'left') deltaX = -amount;
+
+  await cdp.send(
+    'Input.dispatchMouseEvent',
+    { type: 'mouseWheel', x: 0, y: 0, deltaX, deltaY },
+    sessionId,
+  );
+}

--- a/src/chrome-use/proxy-client.ts
+++ b/src/chrome-use/proxy-client.ts
@@ -1,0 +1,129 @@
+/**
+ * CdpClient implementation that forwards raw CDP commands over a Unix socket to
+ * the long-lived transparent proxy (proxy.ts). All command payloads are built on
+ * the client side (in chrome-use-connection.ts); the proxy just relays them to
+ * Chrome on its single approved connection. Because the proxy outlives individual
+ * requests, Chrome's "Allow remote debugging?" dialog fires once per proxy
+ * lifetime instead of once per request.
+ *
+ * Wire protocol: newline-delimited JSON. Request `{ id, method, params, sessionId? }`,
+ * response `{ id, result }` or `{ id, error }`. Control methods are prefixed `__`
+ * (e.g. `__status`, `__stop`) and are answered by the proxy without touching Chrome.
+ *
+ * Adapted from the chrome-use skill (scripts/lib/proxy-client.ts).
+ */
+import net from 'node:net';
+import type { CdpClient } from './types.js';
+
+interface Pending {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class ProxyClient implements CdpClient {
+  private readonly socket: net.Socket;
+  private buf = '';
+  private nextId = 1;
+  private readonly pending = new Map<number, Pending>();
+  private readonly ready: Promise<void>;
+  private isClosed = false;
+  private readonly defaultTimeout: number;
+
+  private constructor(socket: net.Socket, defaultTimeout: number) {
+    this.socket = socket;
+    this.defaultTimeout = defaultTimeout;
+    socket.setEncoding('utf8');
+    this.ready = new Promise<void>((resolve, reject) => {
+      socket.once('connect', () => resolve());
+      socket.once('error', (e) => reject(e));
+    });
+    socket.on('data', (chunk) => this.onData(String(chunk)));
+    socket.on('close', () => {
+      this.isClosed = true;
+      for (const { reject, timer } of this.pending.values()) {
+        clearTimeout(timer);
+        reject(new Error('Proxy connection closed'));
+      }
+      this.pending.clear();
+    });
+    socket.on('error', () => {
+      /* surfaced via the ready promise / pending rejections */
+    });
+  }
+
+  /** Open a client connection to the proxy socket and wait until connected. */
+  static async open(socketPath: string, defaultTimeout = 320_000): Promise<ProxyClient> {
+    const socket = net.createConnection({ path: socketPath });
+    const client = new ProxyClient(socket, defaultTimeout);
+    await client.ready;
+    return client;
+  }
+
+  get connected(): boolean {
+    return !this.isClosed;
+  }
+
+  /** The proxy relays request/response only; no CDP events are delivered. Nothing
+   * in the chrome-use backend subscribes to events, so this is a no-op. */
+  on(): () => void {
+    return () => {};
+  }
+
+  private onData(chunk: string): void {
+    this.buf += chunk;
+    let nl: number;
+    while ((nl = this.buf.indexOf('\n')) !== -1) {
+      const line = this.buf.slice(0, nl);
+      this.buf = this.buf.slice(nl + 1);
+      if (!line.trim()) continue;
+      let msg: { id?: number; result?: unknown; error?: unknown };
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (typeof msg.id !== 'number') continue;
+      const p = this.pending.get(msg.id);
+      if (!p) continue;
+      this.pending.delete(msg.id);
+      clearTimeout(p.timer);
+      if (msg.error !== undefined) {
+        p.reject(new Error(typeof msg.error === 'string' ? msg.error : JSON.stringify(msg.error)));
+      } else {
+        p.resolve(msg.result);
+      }
+    }
+  }
+
+  send<T = unknown>(method: string, params: Record<string, unknown> = {}, sessionId?: string): Promise<T> {
+    if (this.isClosed) return Promise.reject(new Error('Proxy connection closed'));
+    const id = this.nextId++;
+    const frame: Record<string, unknown> = { id, method, params };
+    if (sessionId) frame.sessionId = sessionId;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`CDP request timed out: ${method}`));
+      }, this.defaultTimeout);
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timer });
+      try {
+        this.socket.write(JSON.stringify(frame) + '\n');
+      } catch (err) {
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  close(): void {
+    this.isClosed = true;
+    try {
+      this.socket.end();
+      this.socket.destroy();
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/src/chrome-use/proxy-client.ts
+++ b/src/chrome-use/proxy-client.ts
@@ -119,8 +119,11 @@ export class ProxyClient implements CdpClient {
 
   close(): void {
     this.isClosed = true;
+    // Clear any pending request timers so they can't keep a one-shot CLI's event
+    // loop alive after the socket is torn down.
+    for (const { timer } of this.pending.values()) clearTimeout(timer);
+    this.pending.clear();
     try {
-      this.socket.end();
       this.socket.destroy();
     } catch {
       /* ignore */

--- a/src/chrome-use/proxy-launcher.ts
+++ b/src/chrome-use/proxy-launcher.ts
@@ -1,0 +1,75 @@
+/**
+ * Lifecycle helpers for the long-lived chrome-use CDP proxy.
+ *
+ * The proxy (proxy.ts) is a background daemon that holds the single approved CDP
+ * connection to Chrome and relays frames over a Unix socket. Both the `--devtools`
+ * MCP server and the one-shot `browser --devtools` CLI connect to the SAME socket,
+ * so Chrome's "Allow remote debugging?" dialog fires once per proxy lifetime and
+ * is shared across every client — never once per request.
+ *
+ * Adapted from the chrome-use skill (scripts/cli.ts ensureProxy/proxyAlive).
+ */
+import os from 'node:os';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { ProxyClient } from './proxy-client.js';
+
+/** Unix socket the proxy listens on. Namespaced to vibe so it never collides with
+ * the standalone chrome-use skill's own proxy. Overridable for tests. */
+export function getSocketPath(): string {
+  return process.env.VIBE_CHROME_USE_SOCKET ?? `/tmp/vibe-chrome-use-${os.userInfo().uid}.sock`;
+}
+
+/** Absolute path to the compiled proxy entry (dist/chrome-use/proxy.js). */
+export function getProxyPath(): string {
+  return fileURLToPath(new URL('./proxy.js', import.meta.url));
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Probe whether a proxy answers a control `__status` within `timeoutMs`. */
+export async function proxyAlive(socketPath: string, timeoutMs = 2000): Promise<boolean> {
+  let client: ProxyClient | null = null;
+  try {
+    client = await ProxyClient.open(socketPath, timeoutMs);
+    const status = await client.send<{ socketPath?: string }>('__status');
+    return Boolean(status);
+  } catch {
+    return false;
+  } finally {
+    client?.close();
+  }
+}
+
+/**
+ * Ensure the proxy is running, starting it (detached double-fork) if not. Polls
+ * until it answers `__status` or the attempt budget is exhausted.
+ * @throws if the proxy does not come up in time.
+ */
+export async function ensureProxy(
+  socketPath = getSocketPath(),
+  proxyPath = getProxyPath(),
+  extraEnv: Record<string, string> = {},
+): Promise<void> {
+  if (await proxyAlive(socketPath, 2000)) return;
+
+  const child = spawn(process.execPath, [proxyPath], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env, ...extraEnv, VIBE_CHROME_USE_SOCKET: socketPath },
+  });
+  child.unref();
+
+  // The proxy connects to Chrome eagerly and waits up to 5 min for the one-time
+  // approval dialog. We only need it to be LISTENING here; the first CDP command
+  // through ProxyClient blocks on the approval. Poll the socket for ~10s.
+  for (let i = 0; i < 50; i++) {
+    await sleep(200);
+    if (await proxyAlive(socketPath, 2000)) return;
+  }
+  throw new Error(
+    `chrome-use proxy did not start in time (socket ${socketPath}).\n` +
+      'Make sure Chrome 144+ is running and remote debugging is allowed at chrome://inspect/#remote-debugging.',
+  );
+}

--- a/src/chrome-use/proxy.ts
+++ b/src/chrome-use/proxy.ts
@@ -1,0 +1,212 @@
+/**
+ * vibe-mcp chrome-use transparent CDP proxy (gateway).
+ *
+ * Holds ONE approved CDP connection to the user's real Chrome (via DevToolsActivePort
+ * autoConnect — the "Allow remote debugging?" dialog fires once per proxy lifetime)
+ * and relays raw CDP commands between clients and Chrome. It contains NO command
+ * logic: all request payloads (snapshot walkers, selector queries, input events, …)
+ * are built client-side in chrome-use-connection.ts. Because the logic lives in the
+ * client, command behavior can change without restarting this proxy — so no repeated
+ * approval prompts.
+ *
+ * Wire protocol over the Unix socket (newline-delimited JSON):
+ *   request  { id, method, params, sessionId? }
+ *   response { id, result } | { id, error }
+ * Control methods (answered without touching Chrome): `__status`, `__stop`.
+ *
+ * Daemonizes (double-fork) unless VIBE_CHROME_USE_DAEMON=1. Exits 0 if another proxy
+ * already owns the socket. Socket path comes from VIBE_CHROME_USE_SOCKET (set by the
+ * launcher) or the per-uid default.
+ *
+ * Adapted from the chrome-use skill (scripts/proxy.ts).
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+
+import { Cdp } from './cdp.js';
+import { buildWsEndpoint, type Channel } from './devtools-port.js';
+
+const SOCKET_PATH = process.env.VIBE_CHROME_USE_SOCKET ?? `/tmp/vibe-chrome-use-${os.userInfo().uid}.sock`;
+
+function log(...a: unknown[]): void {
+  process.stderr.write('[vibe chrome-use proxy] ' + a.join(' ') + '\n');
+}
+
+// ── Singleton check ─────────────────────────────────────────────────────────────
+
+function checkAlreadyRunning(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ path: SOCKET_PATH });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, 1000);
+    socket.on('connect', () => socket.write(JSON.stringify({ id: 0, method: '__status' }) + '\n'));
+    socket.on('data', (chunk) => {
+      clearTimeout(timer);
+      socket.destroy();
+      try {
+        resolve(JSON.parse(String(chunk).split('\n')[0]).id === 0);
+      } catch {
+        resolve(false);
+      }
+    });
+    socket.on('error', () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+// ── Single approved connection (memoized, approval-aware) ─────────────────────────
+
+let cdp: Cdp | null = null;
+let connecting: Promise<void> | null = null;
+let server: net.Server | null = null;
+
+function ensureConnected(): Promise<void> {
+  if (cdp?.connected) return Promise.resolve();
+  if (connecting) return connecting;
+  connecting = (async () => {
+    const channel = ((process.env.VIBE_CHROME_CHANNEL as Channel | undefined) || 'stable') as Channel;
+    const userDataDir = process.env.VIBE_CHROME_USER_DATA_DIR || undefined;
+    const ws = buildWsEndpoint(channel, userDataDir);
+    log(`Connecting to ${ws}`);
+    log('Chrome shows a one-time "Allow remote debugging?" dialog — click Allow (waits up to 5 min).');
+    cdp = await Cdp.connect(ws, 300_000);
+    const v = await cdp.send<{ product?: string }>('Browser.getVersion');
+    log(`Connected. ${v?.product ?? 'Chrome'}`);
+  })().catch((err) => {
+    connecting = null;
+    cdp = null;
+    throw err;
+  });
+  return connecting;
+}
+
+// ── Per-request relay ─────────────────────────────────────────────────────────────
+
+async function handle(msg: {
+  id?: unknown;
+  method?: string;
+  params?: Record<string, unknown>;
+  sessionId?: string;
+}): Promise<{ id: unknown; result?: unknown; error?: string }> {
+  const { id, method, params, sessionId } = msg ?? {};
+
+  if (method === '__status') {
+    return { id, result: { connected: !!cdp?.connected, socketPath: SOCKET_PATH } };
+  }
+  if (method === '__stop') {
+    setImmediate(() => {
+      try {
+        server?.close();
+      } catch {
+        /* ignore */
+      }
+      try {
+        cdp?.close();
+      } catch {
+        /* ignore */
+      }
+      process.exit(0);
+    });
+    return { id, result: { stopping: true } };
+  }
+
+  try {
+    await ensureConnected();
+    const result = await cdp!.send(method as string, params ?? {}, sessionId);
+    return { id, result };
+  } catch (err) {
+    return { id, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ── Unix socket server ────────────────────────────────────────────────────────────
+
+function startServer(): void {
+  try {
+    fs.unlinkSync(SOCKET_PATH);
+  } catch {
+    /* no stale socket */
+  }
+
+  server = net.createServer((socket) => {
+    let buf = '';
+    socket.setEncoding('utf8');
+    socket.on('data', (chunk) => {
+      buf += chunk;
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        let msg: { id?: unknown };
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          socket.write(JSON.stringify({ id: null, error: `Invalid JSON: ${line}` }) + '\n');
+          continue;
+        }
+        handle(msg)
+          .then((res) => socket.write(JSON.stringify(res) + '\n'))
+          .catch((err) =>
+            socket.write(JSON.stringify({ id: msg?.id ?? null, error: String(err?.message ?? err) }) + '\n'),
+          );
+      }
+    });
+    socket.on('error', () => {});
+  });
+
+  server.listen(SOCKET_PATH, () => log(`Listening on ${SOCKET_PATH}`));
+  server.on('error', (err) => {
+    log('Server error:', err.message);
+    process.exit(1);
+  });
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  if (await checkAlreadyRunning()) process.exit(0);
+
+  const isDaemon = process.env.VIBE_CHROME_USE_DAEMON === '1';
+  if (!isDaemon) {
+    const child = spawn(process.execPath, [process.argv[1]], {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env, VIBE_CHROME_USE_DAEMON: '1', VIBE_CHROME_USE_SOCKET: SOCKET_PATH },
+    });
+    child.unref();
+    await new Promise((r) => setTimeout(r, 100));
+    process.exit(0);
+  }
+
+  startServer();
+  // Connect eagerly so the approval dialog appears at startup, not on first command.
+  ensureConnected().catch((err) => log('Initial connection failed (will retry on next command):', err.message));
+
+  for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP'] as const) {
+    process.on(sig, () => {
+      try {
+        server?.close();
+      } catch {
+        /* ignore */
+      }
+      try {
+        cdp?.close();
+      } catch {
+        /* ignore */
+      }
+      process.exit(0);
+    });
+  }
+  process.on('uncaughtException', (err) => log('Uncaught:', err.message));
+}
+
+if (process.argv[1] && process.argv[1].endsWith('proxy.js')) {
+  void main();
+}

--- a/src/chrome-use/proxy.ts
+++ b/src/chrome-use/proxy.ts
@@ -42,7 +42,8 @@ function checkAlreadyRunning(): Promise<boolean> {
     const timer = setTimeout(() => {
       socket.destroy();
       resolve(false);
-    }, 1000);
+    }, 3000); // generous: a busy proxy mid Chrome-connect must still be detected so
+    // we don't unlink its socket and start a second instance.
     socket.on('connect', () => socket.write(JSON.stringify({ id: 0, method: '__status' }) + '\n'));
     socket.on('data', (chunk) => {
       clearTimeout(timer);
@@ -78,11 +79,17 @@ function ensureConnected(): Promise<void> {
     cdp = await Cdp.connect(ws, 300_000);
     const v = await cdp.send<{ product?: string }>('Browser.getVersion');
     log(`Connected. ${v?.product ?? 'Chrome'}`);
-  })().catch((err) => {
-    connecting = null;
-    cdp = null;
-    throw err;
-  });
+  })()
+    .then(() => {
+      // Clear the in-flight lock so a later Chrome drop (cdp.connected → false)
+      // triggers a fresh reconnect instead of returning this stale resolved promise.
+      connecting = null;
+    })
+    .catch((err) => {
+      connecting = null;
+      cdp = null;
+      throw err;
+    });
   return connecting;
 }
 
@@ -161,7 +168,17 @@ function startServer(): void {
     socket.on('error', () => {});
   });
 
-  server.listen(SOCKET_PATH, () => log(`Listening on ${SOCKET_PATH}`));
+  server.listen(SOCKET_PATH, () => {
+    // Restrict the socket to the owner so another local UID can't connect and drive
+    // the victim's Chrome (the relay grants full CDP control). Defends against a
+    // permissive umask making the socket group/world-accessible.
+    try {
+      fs.chmodSync(SOCKET_PATH, 0o600);
+    } catch {
+      /* best effort */
+    }
+    log(`Listening on ${SOCKET_PATH}`);
+  });
   server.on('error', (err) => {
     log('Server error:', err.message);
     process.exit(1);

--- a/src/chrome-use/selectors.ts
+++ b/src/chrome-use/selectors.ts
@@ -1,0 +1,116 @@
+/**
+ * Selector resolution: turn a user-supplied selector string into a
+ * {@link ResolvedElement} (an `objectId`) usable with the CDP DOM/Input domains.
+ *
+ * Three forms are supported:
+ *   - `@eN`     — a snapshot element ref (looked up in window.__chromeUseRefs).
+ *   - `text=…`  — first visible element whose trimmed text contains the substring.
+ *   - anything else — a CSS selector passed to document.querySelector.
+ *
+ * Adapted from the `chrome-use` skill (skills/chrome-use/scripts/lib/selectors.ts).
+ */
+import type { CdpClient, TabSession, ResolvedElement } from './types.js';
+
+interface EvalResult {
+  result?: {
+    type?: string;
+    subtype?: string;
+    value?: unknown;
+    objectId?: string;
+  };
+}
+
+/** True when `selector` is a snapshot element ref like "@e1". */
+export function isRef(selector: string): boolean {
+  return /^@e\d+$/.test(selector);
+}
+
+/** Resolve a selector against a tab, returning a remote {@link ResolvedElement}. */
+export async function resolve(
+  cdp: CdpClient,
+  tab: TabSession,
+  selector: string,
+): Promise<ResolvedElement> {
+  if (isRef(selector)) return resolveRef(cdp, tab, selector);
+  if (selector.startsWith('text=')) return resolveText(cdp, tab, selector.slice('text='.length));
+  return resolveCss(cdp, tab, selector);
+}
+
+/** Resolve a `@eN` ref via the page-side ref registry installed by snapshot. */
+async function resolveRef(
+  cdp: CdpClient,
+  tab: TabSession,
+  selector: string,
+): Promise<ResolvedElement> {
+  const index = parseInt(selector.slice(2), 10) - 1; // "@e1" → index 0
+  const expression = `(window.__chromeUseRefs ? window.__chromeUseRefs[${index}] : '__NO_SNAPSHOT__')`;
+  const res = await cdp.send<EvalResult>(
+    'Runtime.evaluate',
+    { expression, returnByValue: false, objectGroup: 'chrome-use' },
+    tab.sessionId,
+  );
+  const result = res?.result;
+  if (result?.type === 'string' && result.value === '__NO_SNAPSHOT__') {
+    throw new Error('No snapshot for this page — run snapshot first');
+  }
+  if (!result || result.subtype === 'null' || result.type === 'undefined' || !result.objectId) {
+    throw new Error(`Stale ref ${selector} — the page changed; re-run snapshot`);
+  }
+  return { objectId: result.objectId };
+}
+
+/** Resolve `text=…` to the deepest visible element containing the substring. */
+async function resolveText(
+  cdp: CdpClient,
+  tab: TabSession,
+  needle: string,
+): Promise<ResolvedElement> {
+  const expression = `(() => {
+    const needle = ${JSON.stringify(needle)};
+    const isVisible = (el) => {
+      if (!(el instanceof Element)) return false;
+      const cs = getComputedStyle(el);
+      if (cs.display === 'none' || cs.visibility === 'hidden') return false;
+      if (el.offsetParent === null && cs.position !== 'fixed') return false;
+      return true;
+    };
+    let best = null;
+    let bestDepth = -1;
+    const walk = (el, depth) => {
+      const tag = el.tagName ? el.tagName.toLowerCase() : '';
+      if (tag === 'script' || tag === 'style') return;
+      const text = (el.textContent || '').trim();
+      if (text.includes(needle) && isVisible(el) && depth > bestDepth) {
+        best = el; bestDepth = depth;
+      }
+      for (const child of el.children) walk(child, depth + 1);
+    };
+    walk(document.body, 0);
+    return best;
+  })()`;
+  const res = await cdp.send<EvalResult>(
+    'Runtime.evaluate',
+    { expression, returnByValue: false, objectGroup: 'chrome-use' },
+    tab.sessionId,
+  );
+  const objectId = res?.result?.objectId;
+  if (!objectId) throw new Error(`No element matching text=${needle}`);
+  return { objectId };
+}
+
+/** Resolve a CSS selector via document.querySelector. */
+async function resolveCss(
+  cdp: CdpClient,
+  tab: TabSession,
+  selector: string,
+): Promise<ResolvedElement> {
+  const expression = `document.querySelector(${JSON.stringify(selector)})`;
+  const res = await cdp.send<EvalResult>(
+    'Runtime.evaluate',
+    { expression, returnByValue: false, objectGroup: 'chrome-use' },
+    tab.sessionId,
+  );
+  const objectId = res?.result?.objectId;
+  if (!objectId) throw new Error(`No element matching selector: ${selector}`);
+  return { objectId };
+}

--- a/src/chrome-use/session.ts
+++ b/src/chrome-use/session.ts
@@ -1,0 +1,135 @@
+/**
+ * Browser/tab state for the long-lived MCP server process. Owns the single CDP
+ * connection plus all attached page tabs and the active-tab pointer.
+ *
+ * Adapted from the `chrome-use` skill (skills/chrome-use/scripts/lib/session.ts),
+ * with the cross-invocation /tmp active-file removed: the MCP server is a
+ * long-lived process, so the active-tab pointer lives in memory here.
+ */
+import type { CdpClient, TabSession } from './types.js';
+
+interface TargetInfo {
+  targetId: string;
+  type: string;
+  url: string;
+}
+
+/** A page target we are willing to drive (skip devtools/extension surfaces). */
+function drivable(t: TargetInfo): boolean {
+  return (
+    t.type === 'page' &&
+    !t.url.startsWith('devtools://') &&
+    !t.url.startsWith('chrome-extension://')
+  );
+}
+
+export class SessionManager {
+  readonly cdp: CdpClient;
+  readonly tabs = new Map<string, TabSession>();
+  activeTargetId: string | null = null;
+  /** Sessions attached this connection, detached on dispose() to keep Chrome clean. */
+  private readonly attached = new Set<string>();
+
+  constructor(cdp: CdpClient) {
+    this.cdp = cdp;
+  }
+
+  private async pages(): Promise<TargetInfo[]> {
+    const { targetInfos } = await this.cdp.send<{ targetInfos: TargetInfo[] }>('Target.getTargets');
+    return targetInfos.filter(drivable);
+  }
+
+  private async attach(targetId: string): Promise<string> {
+    const { sessionId } = await this.cdp.send<{ sessionId: string }>('Target.attachToTarget', {
+      targetId,
+      flatten: true,
+    });
+    this.attached.add(sessionId);
+    return sessionId;
+  }
+
+  /** Detach every session this connection created (best-effort). */
+  async dispose(): Promise<void> {
+    for (const sessionId of this.attached) {
+      try {
+        await this.cdp.send('Target.detachFromTarget', { sessionId });
+      } catch {
+        /* ignore */
+      }
+    }
+    this.attached.clear();
+    this.tabs.clear();
+  }
+
+  async syncTabs(): Promise<void> {
+    const pages = await this.pages();
+    const seen = new Set<string>();
+    let i = 0;
+    for (const p of pages) {
+      i++;
+      seen.add(p.targetId);
+      const existing = this.tabs.get(p.targetId);
+      if (existing) {
+        existing.url = p.url;
+        existing.tabId = 't' + i;
+        continue;
+      }
+      const sessionId = await this.attach(p.targetId);
+      this.tabs.set(p.targetId, {
+        targetId: p.targetId,
+        sessionId,
+        url: p.url,
+        tabId: 't' + i,
+        refRegistry: new Map(),
+      });
+    }
+    for (const targetId of [...this.tabs.keys()]) {
+      if (!seen.has(targetId)) this.tabs.delete(targetId);
+    }
+    if (this.activeTargetId && !this.tabs.has(this.activeTargetId)) this.activeTargetId = null;
+  }
+
+  async getActiveTab(): Promise<TabSession> {
+    await this.syncTabs();
+    if (!this.tabs.size) throw new Error('No page open in Chrome');
+    if (!this.activeTargetId || !this.tabs.has(this.activeTargetId)) {
+      this.activeTargetId = [...this.tabs.keys()][0];
+    }
+    return this.tabs.get(this.activeTargetId)!;
+  }
+
+  async getTab(idOrIndex: string): Promise<TabSession | undefined> {
+    if (!this.tabs.size) await this.syncTabs();
+    for (const t of this.tabs.values()) if (t.tabId === idOrIndex) return t;
+    const n = Number(idOrIndex);
+    if (!Number.isNaN(n)) return [...this.tabs.values()][n];
+    return undefined;
+  }
+
+  setActive(targetId: string): void {
+    this.activeTargetId = targetId;
+  }
+
+  async newTab(url?: string): Promise<TabSession> {
+    const { targetId } = await this.cdp.send<{ targetId: string }>('Target.createTarget', {
+      url: url || 'about:blank',
+    });
+    const sessionId = await this.attach(targetId);
+    this.setActive(targetId);
+    const tab: TabSession = {
+      targetId,
+      sessionId,
+      url: url || 'about:blank',
+      tabId: 't' + (this.tabs.size + 1),
+      refRegistry: new Map(),
+    };
+    this.tabs.set(targetId, tab);
+    return tab;
+  }
+
+  async closeTab(targetId: string): Promise<void> {
+    await this.cdp.send('Target.closeTarget', { targetId });
+    this.tabs.delete(targetId);
+    if (this.activeTargetId === targetId) this.activeTargetId = null;
+  }
+}

--- a/src/chrome-use/snapshot.ts
+++ b/src/chrome-use/snapshot.ts
@@ -1,0 +1,183 @@
+/**
+ * Accessibility-flavoured DOM snapshot: walk the page, assign `@eN` refs to
+ * interactive (and, in full mode, structural) elements, and produce an indented
+ * ref tree the model can read plus a structured node list.
+ *
+ * The walk runs entirely in-page as a single Runtime.evaluate IIFE. It installs
+ * window.__chromeUseRefs as an array of the ref'd elements so later selector
+ * resolution can map `@eN` → element[N-1].
+ *
+ * Adapted from the `chrome-use` skill (skills/chrome-use/scripts/lib/snapshot.ts).
+ */
+import type {
+  CdpClient,
+  TabSession,
+  SnapshotOptions,
+  SnapshotResult,
+  SnapshotNode,
+} from './types.js';
+
+interface EvalValueResult {
+  result?: { value?: { nodes?: SnapshotNode[] } };
+}
+
+/** Take a snapshot of the tab, returning the ref tree, ref map, and node list. */
+export async function takeSnapshot(
+  cdp: CdpClient,
+  tab: TabSession,
+  opts: SnapshotOptions,
+): Promise<SnapshotResult> {
+  const expression = buildWalkerExpression(opts);
+  const res = await cdp.send<EvalValueResult>(
+    'Runtime.evaluate',
+    { expression, returnByValue: true },
+    tab.sessionId,
+  );
+  const nodes: SnapshotNode[] = res?.result?.value?.nodes ?? [];
+
+  const lines: string[] = [];
+  const refs = new Map<string, number>();
+  let refIndex = 0;
+  for (const node of nodes) {
+    let line = '  '.repeat(node.depth) + '@' + node.ref + ' [' + node.role + '] ' + JSON.stringify(node.name);
+    if (node.url) line += ' ' + node.url;
+    lines.push(line);
+    refs.set(node.ref, refIndex++);
+  }
+
+  return { text: lines.join('\n'), refs, nodes };
+}
+
+/**
+ * Build the self-contained, defensive in-page walker expression. The returned
+ * string is a complete IIFE evaluated in the page; per-element work is wrapped so
+ * a single bad node cannot abort the snapshot.
+ */
+function buildWalkerExpression(opts: SnapshotOptions): string {
+  const interactiveOnly = opts.interactive === true;
+  const rootExpr = opts.selector
+    ? `document.querySelector(${JSON.stringify(opts.selector)})`
+    : 'document.body';
+
+  return `(() => {
+    window.__chromeUseRefs = [];
+    const root = ${rootExpr};
+    if (!root) return { nodes: [] };
+
+    const nodes = [];
+
+    const isHidden = (el) => {
+      try {
+        const cs = getComputedStyle(el);
+        if (cs.display === 'none' || cs.visibility === 'hidden' || cs.visibility === 'collapse') return true;
+        const rect = el.getBoundingClientRect();
+        if (rect.width <= 0 && rect.height <= 0 && el.getClientRects().length === 0) return true;
+        return false;
+      } catch { return true; }
+    };
+
+    const roleOf = (el, tag) => {
+      const explicit = (el.getAttribute && el.getAttribute('role') || '').toLowerCase();
+      if (explicit) {
+        if (explicit === 'button') return 'button';
+        if (explicit === 'link') return 'link';
+        if (explicit === 'checkbox') return 'checkbox';
+        if (explicit === 'radio') return 'radio';
+        if (explicit === 'textbox') return 'textbox';
+        if (explicit === 'combobox') return 'combobox';
+        return explicit;
+      }
+      if (tag === 'a') return 'link';
+      if (tag === 'button') return 'button';
+      if (tag === 'textarea') return 'textbox';
+      if (tag === 'select') return 'combobox';
+      if (tag === 'img') return 'image';
+      if (/^h[1-6]$/.test(tag)) return 'heading';
+      if (tag === 'nav' || tag === 'main' || tag === 'header' || tag === 'footer' || tag === 'section') return 'region';
+      if (tag === 'input') {
+        const t = (el.getAttribute('type') || 'text').toLowerCase();
+        if (t === 'checkbox') return 'checkbox';
+        if (t === 'radio') return 'radio';
+        if (t === 'button' || t === 'submit' || t === 'reset' || t === 'image') return 'button';
+        return 'textbox';
+      }
+      return 'generic';
+    };
+
+    const ownText = (el) => {
+      let t = '';
+      for (const node of el.childNodes) {
+        if (node.nodeType === 3) t += node.textContent;
+      }
+      return t.trim();
+    };
+
+    const nameOf = (el) => {
+      try {
+        const aria = el.getAttribute && el.getAttribute('aria-label');
+        if (aria) return aria.trim().slice(0, 120);
+        const alt = el.getAttribute && el.getAttribute('alt');
+        if (alt) return alt.trim().slice(0, 120);
+        const ph = el.getAttribute && el.getAttribute('placeholder');
+        if (ph) return ph.trim().slice(0, 120);
+        const own = ownText(el);
+        if (own) return own.slice(0, 120);
+        const full = (el.textContent || '').trim();
+        return full.slice(0, 120);
+      } catch { return ''; }
+    };
+
+    const isInteractive = (el, tag, role) => {
+      if (tag === 'a' || tag === 'button' || tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+      if (role === 'button' || role === 'link' || role === 'checkbox' || role === 'textbox' || role === 'combobox') return true;
+      if (el.hasAttribute && el.hasAttribute('onclick')) return true;
+      const ti = el.getAttribute && el.getAttribute('tabindex');
+      if (ti != null && parseInt(ti, 10) >= 0) return true;
+      return false;
+    };
+
+    const interactiveOnly = ${interactiveOnly ? 'true' : 'false'};
+
+    const walk = (el, depth) => {
+      try {
+        if (!(el instanceof Element)) return;
+        const tag = el.tagName.toLowerCase();
+        if (tag === 'script' || tag === 'style' || tag === 'noscript') return;
+        if (isHidden(el)) return;
+
+        const role = roleOf(el, tag);
+        const interactive = isInteractive(el, tag, role);
+        const heading = role === 'heading';
+        const name = nameOf(el);
+
+        let include = false;
+        if (interactiveOnly) {
+          include = interactive;
+        } else {
+          const ownTrivial = ownText(el);
+          include = interactive || heading || (ownTrivial.length > 1 && role !== 'generic');
+          if (!include && !interactive && !heading) {
+            if (ownTrivial.length > 1) include = true;
+          }
+        }
+
+        if (include) {
+          const idx = window.__chromeUseRefs.length;
+          window.__chromeUseRefs.push(el);
+          const ref = 'e' + (idx + 1);
+          const node = { ref: ref, role: role, name: name, backendNodeId: 0, depth: depth };
+          if (tag === 'a') {
+            const href = el.getAttribute('href');
+            if (href) node.url = el.href || href;
+          }
+          nodes.push(node);
+        }
+
+        for (const child of el.children) walk(child, depth + 1);
+      } catch { /* skip this element, keep walking siblings */ }
+    };
+
+    walk(root, 0);
+    return { nodes: nodes };
+  })()`;
+}

--- a/src/chrome-use/types.ts
+++ b/src/chrome-use/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Internal type contracts for the chrome-use CDP driver.
+ *
+ * Adapted from the `chrome-use` skill (skills/chrome-use/scripts/lib/types.ts),
+ * a zero-dependency Chrome DevTools Protocol browser driver. Ported into vibe-mcp
+ * so the `--devtools` MCP mode can drive the user's real running Chrome directly
+ * over CDP instead of proxying the external chrome-devtools-mcp server.
+ */
+
+/** A minimal Chrome DevTools Protocol client over a raw WebSocket. */
+export interface CdpClient {
+  /**
+   * Send a CDP command and await its result. If `sessionId` is given the command
+   * is routed to that flattened target session (page-level domains); otherwise it
+   * runs at the browser level.
+   */
+  send<T = unknown>(method: string, params?: Record<string, unknown>, sessionId?: string): Promise<T>;
+  /** Subscribe to a CDP event. Returns an unsubscribe function. */
+  on(method: string, handler: (params: unknown, sessionId?: string) => void): () => void;
+  /** True while the underlying socket is open. */
+  readonly connected: boolean;
+  /** Close the socket. */
+  close(): void;
+}
+
+/** Per-tab (per CDP target) session. */
+export interface TabSession {
+  /** CDP target id of the page. */
+  targetId: string;
+  /** Flattened CDP session id used for page-level domains (DOM, Input, Runtime…). */
+  sessionId: string;
+  /** Snapshot ref registry: ref key without the leading "@" (e.g. "e1") → list index. */
+  refRegistry: Map<string, number>;
+  /** Last known URL (updated on navigation). */
+  url: string;
+  /** Stable short tab id exposed to the user, e.g. "t1". */
+  tabId: string;
+}
+
+/** A resolved DOM element reference usable with CDP DOM/Runtime/Input. */
+export interface ResolvedElement {
+  backendNodeId?: number;
+  objectId?: string;
+}
+
+export interface SnapshotOptions {
+  /** Interactive elements only (buttons, links, inputs, …). */
+  interactive?: boolean;
+  /** Scope the snapshot to a CSS selector. */
+  selector?: string;
+}
+
+export interface SnapshotResult {
+  /** Indented ref tree, e.g. `@e1 [button] "Submit"`. */
+  text: string;
+  /** ref key (without "@") → list index, to install into the tab registry. */
+  refs: Map<string, number>;
+  /** Structured node list. */
+  nodes: SnapshotNode[];
+}
+
+export interface SnapshotNode {
+  ref: string; // "e1"
+  role: string; // "button", "textbox", "link", "heading", "text", …
+  name: string; // accessible name / text content
+  backendNodeId: number;
+  depth: number;
+  url?: string; // for links
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ program
   .description('Start the MCP server (default)')
   .option('-p, --port <number>', 'WebSocket port for local relay (agent) connection', String(DEFAULT_WS_PORT))
   .option('-d, --debug', 'Enable debug logging', false)
-  .option('--devtools', 'Use only chrome-devtools backend (bypasses extension relay)', false)
+  .option('--devtools', 'Drive your real running Chrome directly over the DevTools Protocol (bypasses the extension relay)', false)
   .option('-r, --remote <uuid-or-url>', 'Connect to a remote extension via relay (provide the extension UUID or full ws(s) relay URL)')
   .option('-s, --session <id>', 'Target a specific local browser session ID; defaults to the first connected session')
   .option('--transport <mode>', 'MCP transport to expose: stdio or http', 'stdio')

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { ExtensionConnection, type RemoteConfig } from './connection.js';
-import { DevtoolsFallbackConnection } from './devtools-fallback.js';
+import { ChromeUseConnection } from './chrome-use-connection.js';
 import {
   DEFAULT_HTTP_PATH,
   DEFAULT_HTTP_PORT,
@@ -69,7 +69,7 @@ interface SessionState {
  * Exposes Vibe browser tools to MCP clients via stdio or streamable HTTP transport.
  */
 export class VibeMcpServer {
-  private readonly connection: ExtensionConnection | DevtoolsFallbackConnection;
+  private readonly connection: ExtensionConnection | ChromeUseConnection;
   private readonly config: ServerConfig;
   private readonly sessions = new Map<string, SessionState>();
   private stdioServer: Server | null = null;
@@ -93,7 +93,7 @@ export class VibeMcpServer {
     };
 
     if (this.config.devtools) {
-      this.connection = new DevtoolsFallbackConnection(this.config.debug);
+      this.connection = new ChromeUseConnection(this.config.debug);
     } else {
       const remoteConfig: RemoteConfig | undefined = this.config.remoteUuid
         ? { uuid: this.config.remoteUuid, relayUrl: this.config.remoteRelayUrl }
@@ -126,10 +126,10 @@ export class VibeMcpServer {
     }
 
     if (this.config.devtools) {
-      if (this.connection instanceof DevtoolsFallbackConnection && this.connection.isAvailable()) {
-        this.log('Connected to chrome-devtools backend');
+      if (this.connection instanceof ChromeUseConnection && this.connection.isAvailable()) {
+        this.log('Connected to Chrome via DevTools Protocol (chrome-use backend)');
       } else {
-        this.log('chrome-devtools backend unavailable; server started without tools');
+        this.log('chrome-use DevTools backend unavailable; server started without tools');
       }
     } else if (this.config.remoteUuid) {
       this.log(`Connected to remote relay for UUID ${this.config.remoteUuid}`);
@@ -216,16 +216,16 @@ export class VibeMcpServer {
    * Set up extension connection events
    */
   private setupConnectionEvents(): void {
-    if (this.connection instanceof DevtoolsFallbackConnection) {
+    if (this.connection instanceof ChromeUseConnection) {
       this.connection.on('connected', () => {
-        this.log('chrome-devtools backend connected');
+        this.log('chrome-use DevTools backend connected');
       });
       this.connection.on('unavailable', (reason: string) => {
         this.log(reason);
         this.notifyToolListChanged();
       });
       this.connection.on('tools_updated', (tools: ToolDefinition[]) => {
-        this.log(`Received ${tools.length} tools from chrome-devtools backend`);
+        this.log(`Received ${tools.length} tools from chrome-use DevTools backend`);
         this.notifyToolListChanged();
       });
       return;
@@ -336,7 +336,7 @@ export class VibeMcpServer {
   private async handleSetRemoteTool(args: Record<string, unknown>): Promise<{ content: ToolResult['content']; isError?: boolean }> {
     if (!(this.connection instanceof ExtensionConnection)) {
       return {
-        content: [{ type: 'text', text: 'Error: set_remote is not supported when using the chrome-devtools fallback backend' }],
+        content: [{ type: 'text', text: 'Error: set_remote is not supported when using the chrome-use DevTools backend' }],
         isError: true,
       };
     }
@@ -495,7 +495,7 @@ export class VibeMcpServer {
         version: SERVER_VERSION,
         transport: 'http',
         mcpPath: this.config.httpPath,
-        extensionConnected: this.connection instanceof DevtoolsFallbackConnection
+        extensionConnected: this.connection instanceof ChromeUseConnection
           ? this.connection.isAvailable()
           : this.connection.isExtensionConnected(),
         cachedTools: this.connection.getTools().length,

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,7 +120,7 @@ export interface ServerConfig {
   port: number;
   host: string;
   debug: boolean;
-  /** Use chrome-devtools-mcp directly and bypass relay/extension routing. */
+  /** Drive the real Chrome directly over CDP (chrome-use backend), bypassing relay/extension routing. */
   devtools?: boolean;
   transport: ServerTransportMode;
   httpPort: number;


### PR DESCRIPTION
## What

Replace the buggy, non-functional `--devtools` mode (issue #47) — which proxied the external `chrome-devtools-mcp` server — with a self-contained driver for the user's **real running Chrome** over the Chrome DevTools Protocol, adapted from the `chrome-use` skill.

## Architecture: long-lived gateway proxy (not per-request connect)

The `--devtools` backend talks to Chrome through a **background gateway daemon** that holds a single approved CDP connection and relays raw frames over a per-uid Unix socket. Both the long-lived `start --devtools` MCP server and every one-shot `browser --devtools` CLI call share that one proxy.

Why it matters: Chrome's autoConnect fires an **"Allow remote debugging?" trust dialog on every new debugger client** and serializes the single debugger slot. Connecting directly per request (the first cut of this PR) re-prompted on every command and starved itself. The gateway makes the dialog fire **once per proxy lifetime**, shared across all clients — the whole point of the chrome-use design.

- `src/chrome-use/proxy.ts` — daemon: single approved `Cdp` connection, newline-JSON relay, `__status`/`__stop`, singleton guard, socket chmod 0600, reconnect on Chrome drop.
- `src/chrome-use/proxy-client.ts` — `ProxyClient implements CdpClient` over the socket.
- `src/chrome-use/proxy-launcher.ts` — `ensureProxy` auto-start (double-fork) + poll.
- `src/chrome-use-connection.ts` — connector routes through the proxy; `start()` probe is bounded so a pending approval never hangs MCP startup; failure paths close the transport so one-shot CLIs always exit.
- `src/browser-cli.ts` — map CLI verbs to the chrome-use tool names (navigate/snapshot/new_tab/select_tab/list_tabs/eval) and their args.

## Verification (R1, real channel)

`node dist/cli.js browser --devtools …` against real Chrome, all `ok:true`:
- `navigate` → `Opened https://example.com/`
- `snapshot --interactive` → real `@eN` ref tree (`@e1 [link] "Learn more" …`)
- `screenshot --output` → real PNG 2880×1468
- `evaluate --fn document.title` → `tool: eval`, success
- One approval reused across all commands; CLIs exit cleanly (no hang); proxy persists.

Hermetic (CI, no Chrome): `scripts/e2e-devtools-flag.mjs` drives the real browser-cli verb→tool layer and the connection dispatch against a fake CDP, isolated on a throwaway socket. Regression has teeth (removing a tool-name alias fails it).

## Follow-ups
#76, #77 (behavioral), #78 (`--timeout` plumbing), #79 (approval-pending UX), #80 (per-profile proxy).

Closes #47.