### PR TITLE
fix(devtools): stable tab ids, surface incomplete loads, honor --timeout (#76 #77 #78)

### DIFF
--- a/src/chrome-use-connection.ts
+++ b/src/chrome-use-connection.ts
@@ -31,6 +31,11 @@ import type { ToolDefinition, ToolResult, ToolResultContent } from './types.js';
 
 const UNAVAILABLE_PREFIX = 'chrome-use DevTools backend unavailable';
 
+/** Default per-request CDP timeout. Generous because the first request through a
+ * fresh proxy may block on the one-time Chrome approval dialog. Overridable per
+ * call via callTool(..., timeoutMs) (e.g. the CLI --timeout flag). */
+const DEFAULT_CDP_TIMEOUT_MS = 320_000;
+
 /** How a CDP connection is established. Injectable so tests can supply a fake. */
 export interface CdpConnector {
   connect(): Promise<CdpClient>;
@@ -65,7 +70,7 @@ class AutoConnectCdpConnector implements CdpConnector {
     const extraEnv: Record<string, string> = { VIBE_CHROME_CHANNEL: this.channel };
     if (this.userDataDir) extraEnv.VIBE_CHROME_USER_DATA_DIR = this.userDataDir;
     await ensureProxy(socketPath, undefined, extraEnv);
-    return ProxyClient.open(socketPath, 320_000);
+    return ProxyClient.open(socketPath, DEFAULT_CDP_TIMEOUT_MS);
   }
 }
 
@@ -368,10 +373,27 @@ export class ChromeUseConnection extends EventEmitter {
     return this.unavailableReason;
   }
 
-  async callTool(name: string, args: Record<string, unknown>, _timeoutMs?: number): Promise<ToolResult> {
+  async callTool(name: string, args: Record<string, unknown>, timeoutMs?: number): Promise<ToolResult> {
     if (!this.available || !this.cdp || !this.session) {
       throw new Error(this.unavailableReason || UNAVAILABLE_PREFIX);
     }
+    // Honor a caller-supplied timeout (e.g. CLI --timeout) for the CDP requests in
+    // this call, restoring the default afterwards. Tool calls are serialized over
+    // the single Chrome connection, so the transient default change is safe.
+    const setTimeoutFn = this.cdp.setDefaultTimeout?.bind(this.cdp);
+    if (setTimeoutFn && typeof timeoutMs === 'number' && timeoutMs > 0) {
+      setTimeoutFn(timeoutMs);
+    }
+    try {
+      return await this.dispatchTool(name, args);
+    } finally {
+      if (setTimeoutFn && typeof timeoutMs === 'number' && timeoutMs > 0) {
+        setTimeoutFn(DEFAULT_CDP_TIMEOUT_MS);
+      }
+    }
+  }
+
+  private async dispatchTool(name: string, args: Record<string, unknown>): Promise<ToolResult> {
     const tool = normalizeToolName(name);
 
     switch (tool) {
@@ -416,7 +438,10 @@ export class ChromeUseConnection extends EventEmitter {
 
   // ── Tool implementations ───────────────────────────────────────────────────
 
-  private async waitForLoad(tab: TabSession, timeoutMs = 15_000): Promise<void> {
+  /** Poll readyState until 'complete'. Returns true if the page loaded within the
+   * window, false if it timed out (so the caller can flag a still-loading page
+   * rather than silently report success). */
+  private async waitForLoad(tab: TabSession, timeoutMs = 15_000): Promise<boolean> {
     const deadline = Date.now() + timeoutMs;
     await sleep(150);
     while (Date.now() < deadline) {
@@ -426,12 +451,13 @@ export class ChromeUseConnection extends EventEmitter {
           { expression: 'document.readyState', returnByValue: true },
           tab.sessionId,
         );
-        if (res?.result?.value === 'complete') return;
+        if (res?.result?.value === 'complete') return true;
       } catch {
         /* page may be mid-navigation; keep polling */
       }
       await sleep(150);
     }
+    return false;
   }
 
   private normalizeUrl(raw: string): string {
@@ -451,7 +477,7 @@ export class ChromeUseConnection extends EventEmitter {
     const url = this.normalizeUrl(raw);
     const tab = await this.session!.getActiveTab();
     await this.cdp!.send('Page.navigate', { url }, tab.sessionId);
-    await this.waitForLoad(tab);
+    const loaded = await this.waitForLoad(tab);
     try {
       const res = await this.cdp!.send<{ result?: { value?: unknown } }>(
         'Runtime.evaluate',
@@ -462,7 +488,11 @@ export class ChromeUseConnection extends EventEmitter {
     } catch {
       tab.url = url;
     }
-    return ok(`Opened ${tab.url}`);
+    return ok(
+      loaded
+        ? `Opened ${tab.url}`
+        : `Opened ${tab.url} (page did not reach readyState=complete within 15s; it may still be loading)`,
+    );
   }
 
   private async snapshot(args: Record<string, unknown>): Promise<ToolResult> {

--- a/src/chrome-use/proxy-client.ts
+++ b/src/chrome-use/proxy-client.ts
@@ -28,7 +28,7 @@ export class ProxyClient implements CdpClient {
   private readonly pending = new Map<number, Pending>();
   private readonly ready: Promise<void>;
   private isClosed = false;
-  private readonly defaultTimeout: number;
+  private defaultTimeout: number;
 
   private constructor(socket: net.Socket, defaultTimeout: number) {
     this.socket = socket;
@@ -62,6 +62,11 @@ export class ProxyClient implements CdpClient {
 
   get connected(): boolean {
     return !this.isClosed;
+  }
+
+  /** Set the per-request timeout used by subsequent send()s. */
+  setDefaultTimeout(ms: number): void {
+    if (Number.isFinite(ms) && ms > 0) this.defaultTimeout = ms;
   }
 
   /** The proxy relays request/response only; no CDP events are delivered. Nothing

--- a/src/chrome-use/session.ts
+++ b/src/chrome-use/session.ts
@@ -29,6 +29,9 @@ export class SessionManager {
   activeTargetId: string | null = null;
   /** Sessions attached this connection, detached on dispose() to keep Chrome clean. */
   private readonly attached = new Set<string>();
+  /** Monotonic counter for stable tab ids — a target keeps its id for the whole
+   * connection so a cached `tN` never silently points at a different tab. */
+  private tabSeq = 0;
 
   constructor(cdp: CdpClient) {
     this.cdp = cdp;
@@ -64,14 +67,13 @@ export class SessionManager {
   async syncTabs(): Promise<void> {
     const pages = await this.pages();
     const seen = new Set<string>();
-    let i = 0;
     for (const p of pages) {
-      i++;
       seen.add(p.targetId);
       const existing = this.tabs.get(p.targetId);
       if (existing) {
+        // Keep the existing tabId stable — only refresh the URL. Renumbering by
+        // enumeration order here would shift ids when Chrome reorders/closes tabs.
         existing.url = p.url;
-        existing.tabId = 't' + i;
         continue;
       }
       const sessionId = await this.attach(p.targetId);
@@ -79,7 +81,7 @@ export class SessionManager {
         targetId: p.targetId,
         sessionId,
         url: p.url,
-        tabId: 't' + i,
+        tabId: 't' + ++this.tabSeq,
         refRegistry: new Map(),
       });
     }
@@ -120,7 +122,7 @@ export class SessionManager {
       targetId,
       sessionId,
       url: url || 'about:blank',
-      tabId: 't' + (this.tabs.size + 1),
+      tabId: 't' + ++this.tabSeq,
       refRegistry: new Map(),
     };
     this.tabs.set(targetId, tab);

--- a/src/chrome-use/types.ts
+++ b/src/chrome-use/types.ts
@@ -21,6 +21,9 @@ export interface CdpClient {
   readonly connected: boolean;
   /** Close the socket. */
   close(): void;
+  /** Optional: set the per-request timeout (ms) used by subsequent send()s.
+   * Lets a caller honor a command-level timeout (e.g. the CLI `--timeout` flag). */
+  setDefaultTimeout?(ms: number): void;
 }
 
 /** Per-tab (per CDP target) session. */


### PR DESCRIPTION
Three follow-ups from the #75 gateway review, batched.

## #76 — stable tab ids
`SessionManager.syncTabs()` reassigned `tabId` by enumeration order on every sync, so a cached `tN` could silently point at a different tab after Chrome reordered or closed tabs; `newTab` used `size+1` which collides after deletions. Now each target gets a stable monotonic id for the connection, never renumbered.

## #77 — surface incomplete loads
`waitForLoad` returned void whether or not the page reached `readyState=complete`, so a never-loading page still reported a clean `Opened <url>`. It now returns a boolean and `navigate` appends `(page did not reach readyState=complete within 15s; it may still be loading)` when it times out.

## #78 — honor `--timeout`
`callTool` ignored its `timeoutMs` and `ProxyClient` hardcoded a 320s per-request timeout, so the CLI `--timeout` flag was a no-op in `--devtools` mode. Added optional `CdpClient.setDefaultTimeout`, implemented on `ProxyClient`, and `callTool` applies the caller timeout for the call then restores the default (tool calls are serialized over the one Chrome connection).

## Verification
- Build clean; hermetic `scripts/e2e-devtools-flag.mjs` green (exercises navigate/snapshot/evaluate through the refactored `dispatchTool` path).
- Real-Chrome path was end-to-end verified for the core gateway in #75; these are localized hardening changes.

Closes #76, closes #77, closes #78.