### PR TITLE
fix(devtools): per-profile gateway socket + actionable Chrome-approval errors (#79 #80)

### DIFF
--- a/src/chrome-use-connection.ts
+++ b/src/chrome-use-connection.ts
@@ -36,6 +36,20 @@ const UNAVAILABLE_PREFIX = 'chrome-use DevTools backend unavailable';
  * call via callTool(..., timeoutMs) (e.g. the CLI --timeout flag). */
 const DEFAULT_CDP_TIMEOUT_MS = 320_000;
 
+const APPROVAL_HINT =
+  'open chrome://inspect/#remote-debugging in Chrome and click Allow to grant remote-debugging access';
+
+/** Turn opaque CDP connect/timeout errors into an actionable approval message (#79). */
+function friendlyChromeError(message: string): string {
+  if (/DevToolsActivePort not found/i.test(message)) {
+    return `${message}. Make sure Chrome 144+ is running, then ${APPROVAL_HINT}.`;
+  }
+  if (/connect timed out|request timed out|Browser\.getVersion/i.test(message)) {
+    return `${message}. Chrome did not grant remote-debugging access in time — ${APPROVAL_HINT}, then retry.`;
+  }
+  return message;
+}
+
 /** How a CDP connection is established. Injectable so tests can supply a fake. */
 export interface CdpConnector {
   connect(): Promise<CdpClient>;
@@ -66,7 +80,8 @@ class AutoConnectCdpConnector implements CdpConnector {
   }
 
   async connect(): Promise<CdpClient> {
-    const socketPath = getSocketPath();
+    // Profile-specific socket so a proxy for one profile is never reused for another (#80).
+    const socketPath = getSocketPath(this.channel, this.userDataDir);
     const extraEnv: Record<string, string> = { VIBE_CHROME_CHANNEL: this.channel };
     if (this.userDataDir) extraEnv.VIBE_CHROME_USER_DATA_DIR = this.userDataDir;
     await ensureProxy(socketPath, undefined, extraEnv);
@@ -290,7 +305,7 @@ export class ChromeUseConnection extends EventEmitter {
       this.emit('tools_updated', this.getTools());
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      this.unavailableReason = `${UNAVAILABLE_PREFIX}: ${message}`;
+      this.unavailableReason = `${UNAVAILABLE_PREFIX}: ${friendlyChromeError(message)}`;
       this.available = false;
       // Close the client transport (proxy socket / WS) so it doesn't keep the
       // Node event loop alive and hang a one-shot CLI after it prints output.
@@ -323,7 +338,9 @@ export class ChromeUseConnection extends EventEmitter {
       const outcome = await Promise.race([probe.then(() => 'ok' as const), pending]);
       if (outcome === 'pending') {
         // Approval likely in progress: don't fail, don't await it here. Swallow the
-        // probe's eventual settling so it can't raise an unhandled rejection.
+        // probe's eventual settling so it can't raise an unhandled rejection. Surface
+        // a hint so the operator knows why the first command may pause (#79).
+        this.log(`Waiting for Chrome remote-debugging approval — ${APPROVAL_HINT}. Tools are exposed; the first command will wait for approval.`);
         probe.catch(() => {});
       }
     } finally {
@@ -386,6 +403,12 @@ export class ChromeUseConnection extends EventEmitter {
     }
     try {
       return await this.dispatchTool(name, args);
+    } catch (error) {
+      // Rewrite opaque CDP connect/timeout failures into an actionable approval
+      // message so the operator knows to allow remote debugging (#79).
+      const message = error instanceof Error ? error.message : String(error);
+      const friendly = friendlyChromeError(message);
+      throw friendly === message ? error : new Error(friendly);
     } finally {
       if (setTimeoutFn && typeof timeoutMs === 'number' && timeoutMs > 0) {
         setTimeoutFn(DEFAULT_CDP_TIMEOUT_MS);

--- a/src/chrome-use/proxy-launcher.ts
+++ b/src/chrome-use/proxy-launcher.ts
@@ -10,15 +10,29 @@
  * Adapted from the chrome-use skill (scripts/cli.ts ensureProxy/proxyAlive).
  */
 import os from 'node:os';
+import crypto from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 import { ProxyClient } from './proxy-client.js';
+import type { Channel } from './devtools-port.js';
 
-/** Unix socket the proxy listens on. Namespaced to vibe so it never collides with
- * the standalone chrome-use skill's own proxy. Overridable for tests. */
-export function getSocketPath(): string {
-  return process.env.VIBE_CHROME_USE_SOCKET ?? `/tmp/vibe-chrome-use-${os.userInfo().uid}.sock`;
+/**
+ * Unix socket the proxy listens on. Namespaced to vibe so it never collides with
+ * the standalone chrome-use skill's own proxy. Overridable for tests via
+ * VIBE_CHROME_USE_SOCKET.
+ *
+ * A non-default channel/profile gets its OWN socket (and therefore its own proxy)
+ * so a proxy already running for one profile is never silently reused to drive a
+ * different one. The default stable profile keeps the bare socket name for back
+ * compat. (#80)
+ */
+export function getSocketPath(channel: Channel = 'stable', userDataDir?: string): string {
+  if (process.env.VIBE_CHROME_USE_SOCKET) return process.env.VIBE_CHROME_USE_SOCKET;
+  const base = `/tmp/vibe-chrome-use-${os.userInfo().uid}`;
+  if (channel === 'stable' && !userDataDir) return `${base}.sock`;
+  const tag = crypto.createHash('sha1').update(`${channel}:${userDataDir ?? ''}`).digest('hex').slice(0, 10);
+  return `${base}-${tag}.sock`;
 }
 
 /** Absolute path to the compiled proxy entry (dist/chrome-use/proxy.js). */


### PR DESCRIPTION
Two gateway follow-ups from the #75 review.

## #80 — per-profile proxy socket
`getSocketPath()` now derives a profile-specific socket (sha1 of `channel` + `userDataDir`, 10-char tag) for non-default profiles. A proxy already running for one Chrome profile is no longer silently reused to drive a different profile/channel. The default stable profile keeps the bare `vibe-chrome-use-<uid>.sock` name for back-compat. Verified default/canary/custom-profile resolve to 3 distinct sockets.

## #79 — actionable approval errors
Opaque `CDP connect timed out after 300000ms` / `DevToolsActivePort not found` errors are rewritten to direct the operator to `chrome://inspect/#remote-debugging` → Allow. Applied to the unavailable reason (start failure) and tool-call failures. When `start()`'s probe defers (approval pending), the connection logs a 'Waiting for Chrome remote-debugging approval' hint so it's clear why the first command may pause.

## Verification
Build + `tsc --noEmit` clean; hermetic `e2e-devtools-flag` green; full `test:ci` green.

Closes #79, closes #80.