### PR TITLE
docs(kb): refresh agent knowledgebase for chrome-use gateway + recent work (#55)

### DIFF
--- a/.agents/knowledgebase/architecture.md
+++ b/.agents/knowledgebase/architecture.md
@@ -8,7 +8,7 @@
 
 - Package binaries from `package.json`: `mcp` (direct package-exec entry), `vibebrowser-mcp`, legacy alias `vibe-mcp`, and standalone `vibebrowser-cli`.
 - `src/cli.ts`: MCP server CLI. Default command is `start`; supports stdio and streamable HTTP transports, local relay mode, remote relay mode, `--devtools`, and `openclaw` config printing.
-- `src/server.ts`: MCP protocol server. Exposes tool listing/calling over stdio or HTTP and delegates to an extension/relay connection or Chrome DevTools fallback.
+- `src/server.ts`: MCP protocol server. Exposes tool listing/calling over stdio or HTTP and delegates to either an extension/relay connection or, with `--devtools`, the chrome-use CDP gateway (`src/chrome-use-connection.ts`).
 - `src/browser-main.ts` and `src/browser-cli.ts`: OpenClaw-compatible browser CLI surface for status, sessions, tabs, open/navigate, snapshots, clicks, typing, upload/drop, network, and evaluation helpers.
 - `src/relay-daemon.ts` starts the local relay daemon; `src/relay.ts` implements relay multiplexing.
 
@@ -62,8 +62,39 @@ Use this split from `docs/openclaw-local-browser.md`:
 - Tenant browser in cloud: use the tenant `/browser` stack.
 - User's real local browser: use Vibe extension + relay + `vibebrowser-mcp` HTTP bridge or `@vibebrowser/cli`.
 
-## Chrome DevTools Fallback
+## `--devtools` Mode: chrome-use CDP Gateway
 
-- `chrome-devtools-mcp` is an optional dependency.
-- `--devtools` bypasses extension/relay routing and uses only the Chrome DevTools backend.
-- In normal local relay mode, fallback tools are used only when the extension is unavailable/disconnected; extension tools are authoritative when connected.
+`--devtools` bypasses the extension/relay entirely and drives the user's **real
+running Chrome** directly over the Chrome DevTools Protocol. Source lives under
+`src/chrome-use/` plus `src/chrome-use-connection.ts` (a fixed catalog of tools:
+navigate, snapshot, click, fill, type, press_key, hover, scroll, screenshot, eval,
+get_text/url/title, list/new/select/close tab). It connects via Chrome 144+
+autoConnect (the `DevToolsActivePort` file), **not** `--remote-debugging-port`.
+
+Gateway model (the key design point):
+
+```text
+Chrome (real profile) <-CDP/WS- proxy daemon (holds the ONE approved connection)
+                                    ^ Unix socket /tmp/vibe-chrome-use-<uid>.sock
+            --devtools MCP server + every `browser --devtools` one-shot CLI
+```
+
+- A background proxy (`src/chrome-use/proxy.ts`, auto-started via
+  `proxy-launcher.ts`) holds a single approved CDP connection; `ProxyClient`
+  relays raw frames over the socket. Chrome's "Allow remote debugging?" dialog
+  therefore fires **once per proxy lifetime**, shared by the server and all CLI
+  one-shots — never once per request.
+- The socket is `0600` and per-profile (non-default channel/`VIBE_CHROME_USER_DATA_DIR`
+  get their own socket, so one profile's proxy is never reused for another).
+- `tools/list` never blocks past `STARTUP_TOOLS_LIST_BUDGET_MS` (3s); late tools
+  arrive via `notifications/tools/list_changed`.
+- This replaced the old buggy path that proxied the external `chrome-devtools-mcp`
+  for `--devtools` (issue #47 / PR #75).
+
+## Relay Internal Fallback (separate from `--devtools`)
+
+- `chrome-devtools-mcp` remains an optional dependency, used only by the **relay's**
+  shared `DevtoolsFallbackConnection` (`src/relay.ts`) — see "Local Relay Model".
+- In local relay mode, fallback tools are used only when the extension is
+  unavailable/disconnected; extension tools are authoritative when connected.
+- This is independent of the `--devtools` flag above.

--- a/.agents/knowledgebase/operations.md
+++ b/.agents/knowledgebase/operations.md
@@ -15,15 +15,17 @@
 ## Test And Eval Commands
 
 - Full local test script: `npm test`
+- CI gate (hermetic subset; excludes the pre-existing `browser-cli` failure): `npm run test:ci` — this is what `.github/workflows/ci.yml` runs after build + `tsc --noEmit`.
 - Relay race regression: `npm run test:e2e:relay-race`
 - Relay roundtrip: `npm run test:e2e:relay-roundtrip`
 - CLI relay: `npm run test:e2e:cli-relay`
 - Streamable HTTP MCP: `npm run test:e2e:http`
-- Browser CLI fake-extension harness: `npm run test:e2e:browser-cli`
-- Agent harness with real extension: `npm run test:e2e:agents`
+- `tools/list` startup-budget regression (#14): `npm run test:e2e:tools-list-budget`
+- Browser CLI fake-extension harness: `npm run test:e2e:browser-cli` (known pre-existing `navigate should include pageContent` failure; excluded from `test:ci`)
+- Agent harness with real extension (3 MiniWoB++ tasks via Codex + OpenCode): `npm run test:e2e:agents`
 - Debug agent harness: `E2E_DEBUG=1 npm run test:e2e:agents`
 - Live browser CLI regression: `npm run test:e2e:browser-cli-live`
-- DevTools flag harness: `npm run test:e2e:devtools-flag`
+- DevTools (chrome-use gateway) hermetic harness: `npm run test:e2e:devtools-flag`
 
 Pass signals from `docs/eval.md` and `AGENTS.md`:
 
@@ -47,6 +49,7 @@ Pass signals from `docs/eval.md` and `AGENTS.md`:
 - Current MCP package binaries are `mcp`, `vibebrowser-mcp`, `vibe-mcp`, and `vibebrowser-cli`; normal direct browser CLI docs use the separate `@vibebrowser/cli` package.
 - Package smoke check pattern: create a tarball with `npm pack --json --pack-destination <tmp>` and verify `vibebrowser-mcp --help` plus browser CLI help via the relevant package under test.
 - `docs/eval.md` records npm/publish verification history and should be updated when evaluation scope or pass criteria changes.
+- Publishing runs via `.github/workflows/publish.yml` (push to main on src/package.json paths, release, or `workflow_dispatch`): it upgrades npm to >= 11.5.1, then tries OIDC trusted publishing first and falls back to a token (`NODE_AUTH_TOKEN`/`NPM_TOKEN`). npm 404-on-PUT masks an auth failure — it means the token secret is expired, not a missing package. A monthly `npm-token-healthcheck.yml` runs `npm whoami` and opens/updates a `npm-token`-labelled issue when the fallback token dies, so expiry is caught before a release needs it.
 
 ## Docs And Skill Locations
 
@@ -62,4 +65,25 @@ Pass signals from `docs/eval.md` and `AGENTS.md`:
 - Use `E2E_DEBUG=1` to start relay daemon with debug logging in relevant harnesses.
 - Inspect relay logs around `call_tool` before changing agent prompts.
 - Fake extension harnesses should register message handlers before waiting on socket `open`, periodically announce `tools_list`, reconnect on socket close, and never treat stale `No connection` payloads as final success.
+
+## DevTools Gateway (`--devtools`)
+
+- Requires Chrome 144+ running with remote debugging allowed once at
+  `chrome://inspect/#remote-debugging` (native trust dialog — only the user can
+  click Allow; the approval persists for the Chrome session and the proxy lifetime).
+- Env: `VIBE_CHROME_CHANNEL` (`stable`/`canary`/`beta`/`dev`),
+  `VIBE_CHROME_USER_DATA_DIR` (target a specific profile),
+  `VIBE_CHROME_USE_SOCKET` (override the gateway socket path; tests use this to
+  isolate). Non-default channel/profile get their own per-profile socket.
+- The proxy is a detached daemon; it survives across CLI invocations. To force a
+  fresh approval, stop it: `node dist/cli.js` has no stop verb, so send `__stop`
+  to the socket or `pkill -f dist/chrome-use/proxy.js` and remove
+  `/tmp/vibe-chrome-use-*.sock`.
+- Symptoms: `CDP connect timed out after 300000ms` / `DevToolsActivePort not found`
+  mean Chrome isn't running or remote debugging wasn't approved — the error text
+  now points at `chrome://inspect/#remote-debugging`. Do NOT use
+  `--remote-debugging-port` or `curl http://localhost:<port>/json/version`;
+  autoConnect mode has no HTTP endpoint.
+- Hermetic coverage: `npm run test:e2e:devtools-flag` drives the browser-cli verb
+  -> tool dispatch and the connection against a fake CDP (no real Chrome).
 - If default `vibebrowser-cli snapshot` returns little content, retry with `snapshot --format aria --interactive`.


### PR DESCRIPTION
The `.agents/knowledgebase` already existed (README/architecture/operations); this refreshes it to match the current shipped state rather than leaving stale info.

- **architecture.md**: replace the stale 'Chrome DevTools Fallback' section (it described `--devtools` as proxying `chrome-devtools-mcp`) with the **chrome-use CDP gateway** model — single approved proxy connection over a per-profile `0600` Unix socket, approval once per proxy lifetime, `tools/list` budget. Clarify that the relay's internal `chrome-devtools-mcp` fallback is a *separate* mechanism (still accurate).
- **operations.md**: add `test:ci` (the CI gate), the #14 `tools-list-budget` regression, MiniWoB++ agent coverage, the `publish.yml` OIDC + token-healthcheck flow, and a **DevTools Gateway** section (env vars, approval, proxy lifecycle, symptoms).

Docs only. Closes #55.