### PR TITLE
fix(cli): snapshot + pageContent fallback used a non-existent take_snapshot tool

### DIFF
--- a/.agents/knowledgebase/operations.md
+++ b/.agents/knowledgebase/operations.md
@@ -15,13 +15,13 @@
 ## Test And Eval Commands
 
 - Full local test script: `npm test`
-- CI gate (hermetic subset; excludes the pre-existing `browser-cli` failure): `npm run test:ci` — this is what `.github/workflows/ci.yml` runs after build + `tsc --noEmit`.
+- CI gate (hermetic suite): `npm run test:ci` — this is what `.github/workflows/ci.yml` runs after build + `tsc --noEmit`.
 - Relay race regression: `npm run test:e2e:relay-race`
 - Relay roundtrip: `npm run test:e2e:relay-roundtrip`
 - CLI relay: `npm run test:e2e:cli-relay`
 - Streamable HTTP MCP: `npm run test:e2e:http`
 - `tools/list` startup-budget regression (#14): `npm run test:e2e:tools-list-budget`
-- Browser CLI fake-extension harness: `npm run test:e2e:browser-cli` (known pre-existing `navigate should include pageContent` failure; excluded from `test:ci`)
+- Browser CLI fake-extension harness: `npm run test:e2e:browser-cli` (in `test:ci`)
 - Agent harness with real extension (3 MiniWoB++ tasks via Codex + OpenCode): `npm run test:e2e:agents`
 - Debug agent harness: `E2E_DEBUG=1 npm run test:e2e:agents`
 - Live browser CLI regression: `npm run test:e2e:browser-cli-live`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         run: npx tsc --noEmit
 
       - name: E2E (hermetic)
-        # Reliable hermetic e2e gate. Excludes test:e2e:browser-cli, which has a
-        # pre-existing failure tracked separately. Includes the #14 tools/list
-        # startup-budget regression.
+        # Hermetic e2e gate: relay, http, CLI-relay, the #14 tools/list
+        # startup-budget regression, browser-cli, and the chrome-use devtools flag.
         run: npm run test:ci

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start": "node dist/cli.js",
     "prepublishOnly": "npm run build",
     "test": "npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:cli-relay && npm run test:e2e:http && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:devtools-flag",
-    "test:ci": "npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:cli-relay && npm run test:e2e:http && npm run test:e2e:tools-list-budget && npm run test:e2e:devtools-flag",
+    "test:ci": "npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:cli-relay && npm run test:e2e:http && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:devtools-flag",
     "test:e2e:tools-list-budget": "node scripts/e2e-tools-list-startup-budget.mjs",
     "test:e2e:browser-cli": "node scripts/e2e-browser-cli.mjs",
     "test:e2e:cli-relay": "node scripts/e2e-cli-relay.mjs",

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -776,7 +776,11 @@ export class BrowserCliContext {
       'snapshot',
       [
         {
-          names: ['take_snapshot', 'snapshot'],
+          // Extension/relay exposes take_md_snapshot (markdown) and
+          // take_a11y_snapshot (aria); the chrome-use --devtools backend exposes
+          // `snapshot`. Prefer the format-specific extension tool, then fall back
+          // to legacy take_snapshot / the chrome-use `snapshot`.
+          names: [wantsAria ? 'take_a11y_snapshot' : 'take_md_snapshot', 'take_snapshot', 'snapshot'],
           buildArgs: (tool: ToolDefinition) => withSnapshotArgs(tool, options),
         },
       ],
@@ -1246,7 +1250,7 @@ export class BrowserCliContext {
     return {
       ...output,
       pageContent: fallback.content,
-      pageContentSource: 'take_snapshot',
+      pageContentSource: 'take_md_snapshot',
       ...(fallback.pageId !== targetPageId ? { pageId: fallback.pageId } : {}),
     };
   }
@@ -1285,7 +1289,7 @@ export class BrowserCliContext {
       sessionId: this.currentSessionId(),
       requestedSessionId: this.requestedSessionId,
       ignoredCompatibilityOptions: this.ignoredCompatibilityOptions,
-      tool: 'take_snapshot',
+      tool: 'take_md_snapshot',
       recoveredFromTimeout: true,
       pageId: fallback.pageId,
       url,
@@ -1346,7 +1350,14 @@ export class BrowserCliContext {
 
   private async takeMarkdownSnapshotForPage(pageId: number, timeoutMs: number = this.timeoutMs): Promise<string | undefined> {
     await this.ensureToolsLoaded();
-    const snapshotTool = this.tools.find((tool) => normalizeName(tool.name) === 'take_snapshot');
+    // The markdown snapshot tool is `take_md_snapshot` (extension/relay) — there is
+    // no `take_snapshot` tool, so looking for that name silently disabled the
+    // post-navigate/open pageContent fallback. Match the real name, keeping the old
+    // name as a compatibility fallback.
+    const snapshotTool = this.tools.find((tool) => {
+      const normalized = normalizeName(tool.name);
+      return normalized === 'take_md_snapshot' || normalized === 'take_snapshot';
+    });
     if (!snapshotTool) {
       return undefined;
     }


### PR DESCRIPTION
## Bugs
The browser CLI referenced a tool named `take_snapshot` that **does not exist** — the extension/relay exposes `take_md_snapshot` (markdown) and `take_a11y_snapshot` (aria); the chrome-use `--devtools` backend exposes `snapshot`. Two user-facing consequences:

1. **`snapshot` command failed in extension/remote mode** with `No compatible browser tool found for "snapshot". Tried take_snapshot, snapshot`. The candidate list ignored the computed `wantsAria`. Fixed to select `take_a11y_snapshot` (aria) / `take_md_snapshot` (default), keeping `take_snapshot`/`snapshot` as fallbacks.
2. **`navigate`/`open` with an explicit `--page-id` silently dropped `pageContent`** — `takeMarkdownSnapshotForPage` looked up `take_snapshot`, never resolved, so the post-navigate page snapshot was never attached. Fixed to match `take_md_snapshot` (with `take_snapshot` fallback) and corrected the `pageContentSource`/`tool` labels.

## Why it wasn't caught
`scripts/e2e-browser-cli.mjs` asserts both behaviors, but the suite died at the earlier `navigate should include pageContent` assertion, masking the `snapshot` failure behind it. (The `take_snapshot` name predates #75; #75 only added `snapshot` alongside it.)

## Result
Both fixed → the full `e2e-browser-cli` harness passes. It **rejoins the CI gate** (`test:ci` now includes it), and the now-inaccurate "pre-existing failure" notes in `ci.yml` and the knowledgebase are corrected.

Verified: `npm run build`, `tsc --noEmit`, full `npm test` (7/7), and `npm run test:ci` (7/7) all green.