### PR TITLE
fix(readme,skill): correct OpenClaw skill-install flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ Copy-paste this into an OpenClaw or Hermes agent to install the **vibebrowser sk
 ```text
 You can control my real Chrome with Vibe Browser. Install the skill, install the CLI, remember my remote, then verify:
 
-1) Install the vibebrowser SKILL (persistent capability, auto-resolves the right agent):
-   npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -y
-   Confirm it registered:
-   - OpenClaw: `openclaw skills list` (or `node openclaw.mjs skills list`) — expect a `vibebrowser` entry.
-   - Hermes:   `npx -y skills list` (or `hermes skills list`) — expect a `vibebrowser` entry.
-   If your runner can't reach the registry, instead fetch the SKILL.md directly into your skills dir:
+1) Install the vibebrowser SKILL (persistent capability). Run the line for YOUR agent, then the matching confirm:
+   - OpenClaw:
+       npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -a openclaw -g -y --copy --dangerously-accept-openclaw-risks
+       openclaw skills list            # expect a "🌐 vibebrowser ... ✓ ready" row
+     (--copy is required: a symlinked install escapes the workspace root and OpenClaw skips it. --dangerously-accept-openclaw-risks is needed because this skill isn't ClawHub-verified yet.)
+   - Hermes:
+       npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -y
+       npx -y skills list              # expect a "vibebrowser" row
+   If your runner can't reach the registry, fetch the SKILL.md straight into your OpenClaw skills dir instead:
    mkdir -p ~/.openclaw/skills/vibebrowser && curl -fsSL https://raw.githubusercontent.com/VibeTechnologies/vibe-mcp/main/openclaw/vibebrowser/SKILL.md -o ~/.openclaw/skills/vibebrowser/SKILL.md
 
 2) The skill drives the CLI: the npm package @vibebrowser/cli, run on demand with `npx -y @vibebrowser/cli@latest` (no global install).

--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -33,11 +33,14 @@ metadata:
      ```
    - **Preferred: save it for the session** — see [## Remembering the remote connection](#remembering-the-remote-connection) below.
 
-3. **Install the skill** (one command, auto-resolves the agent format):
+3. **Install the skill** (run the line for your agent):
    ```bash
+   # OpenClaw (--copy is required, else the symlink escapes the workspace root and is skipped):
+   npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -a openclaw -g -y --copy --dangerously-accept-openclaw-risks
+   # Hermes:
    npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -y
    ```
-   Verify it registered with `openclaw skills list` (OpenClaw) or `npx -y skills list` (Hermes) — expect a `vibebrowser` entry. Offline/registry-blocked fallback: copy this file to `~/.openclaw/skills/vibebrowser/SKILL.md` (or your project's `openclaw/skills/` folder).
+   Verify it registered with `openclaw skills list` (expect a `🌐 vibebrowser … ✓ ready` row) or `npx -y skills list` (Hermes). Installs to `~/.openclaw/skills/vibebrowser/SKILL.md`. Offline/registry-blocked fallback: copy this file there directly.
 
 Use the `@vibebrowser/cli` command when the user wants OpenClaw to drive their real local browser through the Vibe extension.
 


### PR DESCRIPTION
## Why
PR #89 added a skill-install step but used the bare `npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -y`. Live eval on @OpenClawBoxBot proved that form **does not register on OpenClaw**:
- symlinked install resolves outside the workspace root → OpenClaw logs `symlink-escape` and skips it;
- the community skill is risk-gated.

## Fix (verified on the real agents)
Per-agent install commands in the README prompt + SKILL.md:
- **OpenClaw**: `npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -a openclaw -g -y --copy --dangerously-accept-openclaw-risks` → `openclaw skills list` shows `✓ ready 🌐 vibebrowser`.
- **Hermes**: `npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -y` (auto-detects) → `npx -y skills list` shows `vibebrowser`.

## Live verification
- **Hermes (@AflredAiBot)**: 3/3 — skill registered, extensionConnected=true, live ARIA snapshot.
- **OpenClaw (@OpenClawBoxBot)**: skill now registers (`✓ ready 🌐 vibebrowser`, source agents-skills-project at `~/.openclaw/skills/vibebrowser`), extensionConnected=true, live ARIA snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)