### PR TITLE
fix(skill): load saved remote before asking; persist to home-dir file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You are setting yourself up to control my real Chrome through Vibe Browser. Work
    - Hermes:    npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -y
                 then run `npx -y skills list` and confirm a "vibebrowser" row.
 
-2. Remember my remote so I only give it to you once. Save it under the key `vibebrowser_remote` (your memory tool) or in a file `vibebrowser-cli.md` as a line `remote: <value>`, and reuse it on every command without asking me again.
+2. Remember my remote so I only give it to you once. Save it in BOTH places: under the key `vibebrowser_remote` (your memory tool) AND in the file `~/.vibebrowser-cli.md` as a line `remote: <value>`. On every later command — including the first message of a new conversation — load it back from there and reuse it without asking me again.
 
 3. Confirm you can control my Chrome, retrying on "Extension reconnecting" (wait 3s, up to 5x):
    npx -y @vibebrowser/cli@latest --remote "<my remote>" --json status --wait-for-extension --wait-timeout 20000

--- a/README.md
+++ b/README.md
@@ -7,38 +7,26 @@ MCP server for [Vibe AI Browser](https://vibebrowser.app) - the **only browser a
 
 ## Install prompt for AI agents (OpenClaw / Hermes)
 
-Copy-paste this into an OpenClaw or Hermes agent to install the **vibebrowser skill**, install/configure the Vibe Browser **CLI**, and remember your remote so it can drive your real Chrome. Replace the last line with your remote value (a UUID or a `wss://relay.api.vibebrowser.app/<uuid>` URL from the Vibe extension's **Settings → AI Agent Control → Remote (internet) → Relay access**):
+Paste the block below into your **OpenClaw** or **Hermes** agent. Replace the last line with your remote value — a UUID or a `wss://relay.api.vibebrowser.app/<uuid>` URL from the Vibe extension's **Settings → AI Agent Control → Remote (internet) → Relay access**. That's the only edit you make.
 
 ```text
-You can control my real Chrome with Vibe Browser. Install the skill, install the CLI, remember my remote, then verify:
+You are setting yourself up to control my real Chrome through Vibe Browser. Work through the steps in order, and after each step confirm it worked before moving on. Do not claim a step is done until you have proven it.
 
-1) Install the vibebrowser SKILL (persistent capability). Run the line for YOUR agent, then the matching confirm:
-   - OpenClaw:
-       npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -a openclaw -g -y --copy --dangerously-accept-openclaw-risks
-       openclaw skills list            # expect a "🌐 vibebrowser ... ✓ ready" row
-     (--copy is required: a symlinked install escapes the workspace root and OpenClaw skips it. --dangerously-accept-openclaw-risks is needed because this skill isn't ClawHub-verified yet.)
-   - Hermes:
-       npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -y
-       npx -y skills list              # expect a "vibebrowser" row
-   If your runner can't reach the registry, fetch the SKILL.md straight into your OpenClaw skills dir instead:
-   mkdir -p ~/.openclaw/skills/vibebrowser && curl -fsSL https://raw.githubusercontent.com/VibeTechnologies/vibe-mcp/main/openclaw/vibebrowser/SKILL.md -o ~/.openclaw/skills/vibebrowser/SKILL.md
+1. Install the "vibebrowser" skill for your runtime, then confirm it is listed:
+   - OpenClaw:  npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -a openclaw -g -y --copy --dangerously-accept-openclaw-risks
+                then run `openclaw skills list` and confirm a "vibebrowser" row shows "ready".
+   - Hermes:    npx -y skills add VibeTechnologies/vibe-mcp -s vibebrowser -y
+                then run `npx -y skills list` and confirm a "vibebrowser" row.
 
-2) The skill drives the CLI: the npm package @vibebrowser/cli, run on demand with `npx -y @vibebrowser/cli@latest` (no global install).
+2. Remember my remote so I only give it to you once. Save it under the key `vibebrowser_remote` (your memory tool) or in a file `vibebrowser-cli.md` as a line `remote: <value>`, and reuse it on every command without asking me again.
 
-3) Remember my remote connection so I only give it to you once. Save the remote value and reuse it on every command without asking again:
-   - If you have a memory tool, store it under the key `vibebrowser_remote`.
-   - Otherwise write it to a file `vibebrowser-cli.md` as a line `remote: <value>` and read it back on later turns.
-   - OpenClaw: you may also set it in `~/.openclaw/openclaw.json` under `skills.entries."vibebrowser".env.VIBE_REMOTE_URL`, or export `VIBE_REMOTE_URL`.
-   - Hermes: you may also store it under `skills.config` key `vibebrowser.remote_url` (e.g. `hermes skills config vibebrowser`).
+3. Confirm you can control my Chrome, retrying on "Extension reconnecting" (wait 3s, up to 5x):
+   npx -y @vibebrowser/cli@latest --remote "<my remote>" --json status --wait-for-extension --wait-timeout 20000
+   npx -y @vibebrowser/cli@latest --remote "<my remote>" --json snapshot --format aria
 
-4) Verify and use it (retry on "Extension reconnecting": wait 3s, up to 5x):
-   npx -y @vibebrowser/cli@latest --remote "<remembered value>" --json status --wait-for-extension --wait-timeout 20000   # expect "extensionConnected": true
-   npx -y @vibebrowser/cli@latest --remote "<remembered value>" --json tabs
-   npx -y @vibebrowser/cli@latest --remote "<remembered value>" --json snapshot --format aria   # returns the live page content
+Then report: (1) is vibebrowser listed, (2) is extensionConnected true, (3) did the snapshot return my real page content?
 
-Report: (a) did `skills list` show a vibebrowser entry, (b) did status show extensionConnected=true, (c) did the snapshot return real page content?
-
-My remote value: <PASTE YOUR UUID OR wss:// URL HERE>
+My remote: <PASTE YOUR UUID OR wss:// URL HERE>
 ```
 
 ## Why Vibe MCP?

--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -16,6 +16,30 @@ metadata:
 
 # Vibe Local Browser
 
+## FIRST, EVERY TIME: load the saved remote before asking for it
+
+The user gives their remote value **once**. On **every** browser task — including the
+first message of a brand-new conversation — recover it yourself before doing anything
+else. Do **not** ask the user for the remote until you have checked **both** stores and
+found nothing.
+
+At the very start of any browser task, in this order:
+
+1. **Recall from memory.** If your runtime has a memory/recall tool, read the key
+   `vibebrowser_remote`. If it returns a value, use it as `--remote` and continue
+   silently — do not mention it.
+2. **Read the file fallback.** Check `~/.vibebrowser-cli.md` (and, for backward
+   compatibility, `./vibebrowser-cli.md` in the working dir) for a `remote:` line.
+   If present, use it.
+3. **Only if both are empty** may you ask the user for the remote. When they give it,
+   immediately save it to **both** stores (memory key `vibebrowser_remote` **and**
+   `~/.vibebrowser-cli.md`) so the next conversation never has to ask again.
+
+> If you find yourself about to say "I need your Vibe remote value first," STOP — you
+> almost certainly skipped step 1/2. A returning user has already provided it; recall it.
+
+Full details and examples: [## Remembering the remote connection](#remembering-the-remote-connection).
+
 ## Installation
 
 1. **Get the remote value**:
@@ -96,19 +120,25 @@ On later turns, recall it before running any browser command:
 recall("vibebrowser_remote")  # → use as --remote value
 ```
 
-**Option B — Local context file (fallback):** If no memory tool is available, write the value to a file named `vibebrowser-cli.md` in the agent's working directory. Use this exact format so it can be machine-read back:
+**Option B — Local context file (fallback / belt-and-suspenders):** Write the value to
+`~/.vibebrowser-cli.md` (home directory — **not** the working dir, which changes between
+conversations and would lose the value). Use this exact format so it can be machine-read back:
 
 ```markdown
 # VibeBrowser CLI context
 remote: <uuid-or-wss-url>
 ```
 
-At the start of any browser task, check whether `vibebrowser-cli.md` exists and read the `remote:` line to recover the value. Create or overwrite the file when the value is first provided or updated.
+Save to this file **even when a memory tool is available** — runtimes whose memory does
+not persist across conversations will still recover the remote from the file. At the start
+of any browser task, read `~/.vibebrowser-cli.md` (then `./vibebrowser-cli.md` for older
+saves) and use the `remote:` line. Create or overwrite the file when the value is first
+provided or updated.
 
 ### Rules for using the remembered value
 
-1. **On every browser command**, load the remembered remote (from memory or `vibebrowser-cli.md`) and pass it as `--remote "<remembered-value>"`.
-2. **Only ask the user** for the remote if none is remembered and the user did not provide one in the current message.
+1. **On every browser command**, load the remembered remote (recall memory key `vibebrowser_remote`, else read `~/.vibebrowser-cli.md`) and pass it as `--remote "<remembered-value>"`. Do this on the first message of every new conversation, not just within one session.
+2. **Only ask the user** for the remote if none is remembered in **either** store and the user did not provide one in the current message.
 3. **If the remembered remote stops working** — for example, `status` returns `extensionConnected: false`, or commands repeatedly fail — tell the user clearly and offer to update the saved value (then overwrite memory / `vibebrowser-cli.md` with the new one).
 
 ### Example: first use
@@ -116,7 +146,7 @@ At the start of any browser task, check whether `vibebrowser-cli.md` exists and 
 User: "Open google.com in my browser. My remote is `abc12345-...`."
 
 Agent actions:
-1. Save `abc12345-...` to memory under key `vibebrowser_remote` (or write to `vibebrowser-cli.md`).
+1. Save `abc12345-...` to memory under key `vibebrowser_remote` **and** write it to `~/.vibebrowser-cli.md`.
 2. Run:
    ```bash
    npx @vibebrowser/cli --remote "abc12345-..." --json status --wait-for-extension --wait-timeout 10000
@@ -128,7 +158,7 @@ Agent actions:
 User: "Now open github.com."
 
 Agent actions:
-1. Recall `vibebrowser_remote` from memory (or read `vibebrowser-cli.md` → `remote:` line).
+1. Recall `vibebrowser_remote` from memory (or read `~/.vibebrowser-cli.md` → `remote:` line).
 2. Run without asking the user:
    ```bash
    npx @vibebrowser/cli --remote "<remembered-value>" --json open https://github.com


### PR DESCRIPTION
## Problem
Hermes (`@AflredAiBot`) re-asked for the Vibe remote on a brand-new conversation even though it had been saved in a previous session — "I need your Vibe remote value first." The agent ignored the saved value.

## Root causes
1. **Recall rule buried.** SKILL.md's "load the remembered remote before asking" rule sat ~90 lines in, after the long Installation section. On a fresh turn the agent reads top-down, hits Installation, and asks for the remote instead of recalling.
2. **cwd-scoped file fallback.** The file fallback wrote `vibebrowser-cli.md` to the working directory, which differs between conversations → the value is unreachable next time.

## Fix
- Front-load a loud **"FIRST, EVERY TIME: load the saved remote before asking"** block directly under the H1. Explicit order: recall memory key `vibebrowser_remote` → read `~/.vibebrowser-cli.md` → only then ask. Includes a STOP guard against the "I need your remote first" failure line.
- Move file fallback to the stable **`~/.vibebrowser-cli.md`** (home dir, cwd-independent) and instruct saving to **both** memory and file (belt-and-suspenders for runtimes without durable cross-conversation memory).
- README agent-install prompt step 2 updated to match (save to both stores, reload on every command incl. first message of a new conversation).

## Validation
Re-tested live on `@AflredAiBot` (Hermes) and `@OpenClawBoxBot` (OpenClaw): fresh conversation, browser request WITHOUT supplying the remote → agent recovers the saved remote and runs without re-asking. (Results pasted in PR thread.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)