### PR TITLE
fix(skill): repair YAML frontmatter broken by #95

### DIFF
--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibebrowser
-description: Control the user's local browser through the Vibe Browser CLI bridge. Use for ANY task against the user's real Vibe-connected browser — tabs, cookies, sessions, extensions, opening pages, snapshots, clicks. ALWAYS load this skill before responding to a browser request: it tells you how to recover the user's saved connection (the "remote") from memory/workspace so you never re-ask for it.
+description: Control the user's real local browser through the Vibe Browser CLI bridge. Use for ANY task against the user's own Vibe-connected browser — their tabs, cookies, logged-in sessions, extensions, opening pages, snapshots, clicks. ALWAYS load this skill before responding to a browser request, so you can recover the user's saved connection (the remote) from memory or workspace and never re-ask for it.
 metadata:
   {
     "openclaw":


### PR DESCRIPTION
#95 made the SKILL.md `description` contain a colon-space and embedded quotes, breaking the YAML frontmatter (`mapping values are not allowed here`). `skills add` then found **no valid skill** and exited 1 — **fresh installs were broken on both runtimes**. Caught live during a reinstall test (existing installs still ran the old version). This rewrites the description to be YAML-safe with the same intent. Validated: frontmatter parses; name/description/metadata present; no colon-space in description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)