### PR TITLE
fix(skill): open->page-id read flow + frontmatter validator/CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Check types
         run: npx tsc --noEmit
 
+      - name: Validate skill frontmatter
+        run: npm run validate:skill
+
       - name: E2E (hermetic)
         # Hermetic e2e gate: relay, http, CLI-relay, the #14 tools/list
         # startup-budget regression, browser-cli, and the chrome-use devtools flag.

--- a/.github/workflows/publish-skill.yml
+++ b/.github/workflows/publish-skill.yml
@@ -27,12 +27,7 @@ jobs:
           echo "Skill file validated"
 
       - name: Validate SKILL.md frontmatter
-        run: |
-          head -1 openclaw/vibebrowser/SKILL.md | grep -q '^---' || {
-            echo "ERROR: SKILL.md missing frontmatter"
-            exit 1
-          }
-          echo "Frontmatter validated"
+        run: node scripts/validate-skill.mjs openclaw/vibebrowser/SKILL.md
 
       - name: Index skill on skills.sh
         run: |

--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -263,7 +263,7 @@ If `jq` is unavailable, parse `.pages` from `tabs --json` directly and still pas
   ```
 - Prefer `tabs` or `snapshot` before acting.
 - `snapshot` is tool-only and maps to the extension's `take_snapshot` tool (with `format` param for markdown vs aria).
-- Use `open <url>` to create a fresh page when possible.
+- Use `open <url>` to create a fresh page when possible. It opens a **background** tab and returns the new page id (`... (ID: <n>) ...`); pass that id as `--page-id` to any follow-up snapshot/evaluate/click — a bare follow-up reads the old active tab, not the page you just opened.
 - Use `evaluate --fn ...` only for simple compatibility-safe expressions such as:
   - `() => 21 + 21`
   - `() => document.title`
@@ -288,16 +288,27 @@ List pages:
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json tabs
 ```
 
-Open a new page:
+Open a new page **and then read it** — `open` creates a **background** tab and does NOT
+change the active tab, so a bare `snapshot`/`evaluate` afterwards would read the *old*
+active tab, not the page you just opened. Capture the new page id from the `open` output
+and pass it with `--page-id` to every follow-up command:
 
 ```bash
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json open https://example.com
+# open returns: raw.content[].text = "Successfully created new background page (ID: 12345) ..."
+OPEN_JSON="$(npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json open https://example.com)"
+PAGE_ID="$(printf '%s' "$OPEN_JSON" | grep -oE 'ID: [0-9]+' | grep -oE '[0-9]+' | head -n1)"
+# now read THAT page, not the active tab:
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json --page-id "$PAGE_ID" snapshot --format aria --interactive
 ```
 
-Take the default AI snapshot:
+If you instead want to read the tab the user is currently looking at, get its id from
+`tabs` (the `active: true` page) and pass that as `--page-id`. Never assume a bare
+`snapshot` after `open` shows the page you opened.
+
+Take the default AI snapshot (of a specific page — substitute the id you captured):
 
 ```bash
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json snapshot
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json --page-id "$PAGE_ID" snapshot
 ```
 
 Take the ARIA / interactive snapshot:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "tsc && node scripts/prepare-cli-package.mjs",
     "dev": "tsc --watch",
     "start": "node dist/cli.js",
+    "validate:skill": "node scripts/validate-skill.mjs openclaw/vibebrowser/SKILL.md",
     "prepublishOnly": "npm run build",
     "test": "npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:cli-relay && npm run test:e2e:http && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:devtools-flag",
     "test:ci": "npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:cli-relay && npm run test:e2e:http && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:devtools-flag",

--- a/scripts/validate-skill.mjs
+++ b/scripts/validate-skill.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Validate openclaw/vibebrowser/SKILL.md frontmatter the way the skills.sh CLI does:
+// it must be a parseable YAML block with `name` and `description`. A description (or any
+// scalar) containing an unquoted ": " breaks the YAML ("mapping values are not allowed
+// here") and makes `skills add` report "No valid skills found" — that shipped once (#95)
+// and the old grep-only check missed it. This guards that whole class.
+import { readFileSync } from 'node:fs';
+
+const path = process.argv[2] || 'openclaw/vibebrowser/SKILL.md';
+const fail = (msg) => { console.error(`SKILL VALIDATION FAILED (${path}): ${msg}`); process.exit(1); };
+
+let text;
+try { text = readFileSync(path, 'utf8'); } catch { fail('file not found'); }
+
+if (!text.startsWith('---')) fail('missing opening --- frontmatter fence');
+const end = text.indexOf('\n---', 3);
+if (end === -1) fail('missing closing --- frontmatter fence');
+const fm = text.slice(3, end);
+
+// Parse top-level `key: value` lines; tolerate nested/flow blocks (metadata) by tracking
+// indentation. We only need to validate the scalar top-level keys (name, description).
+const lines = fm.split('\n');
+const top = {};
+for (const raw of lines) {
+  if (!raw.trim() || raw.trimStart().startsWith('#')) continue;
+  if (/^\s/.test(raw)) continue;            // nested line — skip (e.g. metadata block)
+  const m = raw.match(/^([A-Za-z0-9_-]+):(.*)$/);
+  if (!m) continue;
+  const key = m[1];
+  const val = m[2].replace(/^\s+/, '');
+  top[key] = val;
+  // The exact hazard that broke #95: an unquoted scalar value containing ": ".
+  const quoted = (val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"));
+  if (val && !quoted && /:\s/.test(val)) {
+    fail(`key "${key}" has an unquoted ": " in its value — invalid YAML. Quote the value or remove the colon-space.\n  value: ${val}`);
+  }
+}
+
+if (!top.name) fail('frontmatter has no `name`');
+if (!top.description) fail('frontmatter has no `description`');
+if (top.name.trim() !== 'vibebrowser') fail(`name must be "vibebrowser", got "${top.name}"`);
+if (top.description.length < 40) fail('description suspiciously short');
+
+console.log(`SKILL.md OK: name="${top.name}", description ${top.description.length} chars, frontmatter parses.`);


### PR DESCRIPTION
Two follow-ups from live cold testing.

## 1. open → page-id read flow (real workflow bug)
Hermes cold test ("open HN, tell me the top story") used the skill correctly but ran `open` then a **bare** `snapshot`, which returned the previously-active GitHub tab — because `open` creates a **background** tab and doesn't change the active page. Hermes caught the mismatch and refused to fabricate (good), but the skill's simple examples invited the error. Now documents capturing the new page id from `open` output and passing `--page-id` to follow-up reads, in both the common-commands and safe-rules sections.

## 2. Frontmatter validator + CI guard (regression class)
#95 shipped a `description:` with an unquoted `": "`, which broke the YAML frontmatter (`mapping values are not allowed here`) and made `skills add` report **"No valid skills found"** — fresh installs were broken on both runtimes (hotfixed in #96). The old CI check only grepped for a leading `---`, so it missed it.

`scripts/validate-skill.mjs` parses the frontmatter and fails on: the unquoted `": "` hazard, missing `name`/`description`, wrong name. Wired into:
- `ci.yml` (runs on every PR — catches before merge)
- `publish-skill.yml` (replaces the grep-only check — catches before publish)
- `npm run validate:skill`

Verified: passes the current file, fails a colon-space description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)