### PR TITLE
chore: bump @vibebrowser/mcp to 0.2.13 (closes #102)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "MCP server for browser automation - the only solution supporting multiple AI agents (Claude, Cursor, VS Code) simultaneously controlling your Chrome browser",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version from 0.2.12 → 0.2.13
- Fixes oncall incident #102: 0.2.13 was expected on npm but never published

## Root cause
Version was not bumped before the publish workflow ran. Registry shows 0.2.12.

## On merge
Publish workflow auto-detects unpublished version and runs `npm publish`.