### PR TITLE
security(docs): sanitize relay UUID docs + add relay-URL secret warnings (Refs #105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 MCP server for [Vibe AI Browser](https://vibebrowser.app) - the **only browser automation tool that supports multiple AI agents simultaneously**.
 
+> ⚠️ **Security — treat your relay URL/UUID like a password.** A relay URL or extension UUID (`wss://relay.api.vibebrowser.app/<uuid>`) grants **live control of your browser session** (read your tabs, take screenshots, read page content). Never share it, paste it into a chat with untrusted parties, or commit it to a repo. Every example UUID in this documentation is a non-routable placeholder (`YOUR-EXTENSION-UUID` or `00000000-0000-0000-0000-000000000000`) — substitute your own secret value locally and keep it out of version control.
+
 ## Install prompt for AI agents (OpenClaw / Hermes)
 
 Paste the block below into your **OpenClaw** or **Hermes** agent. Replace the last line with your remote value — a UUID or a `wss://relay.api.vibebrowser.app/<uuid>` URL from the Vibe extension's **Settings → AI Agent Control → Remote (internet) → Relay access**. That's the only edit you make.
@@ -329,6 +331,8 @@ When multiple agents connect, Vibe MCP automatically spawns a relay daemon:
 - Each agent receives only its own responses
 
 ### Cloud OpenClaw -> Local Browser
+
+> ⚠️ **Security:** The `--remote` value below is a live credential — a relay URL/UUID grants full control of the target browser session. Keep it secret and never commit it. The placeholders shown here (`YOUR-EXTENSION-UUID`) are not routable.
 
 If your agent runs in the cloud but you want it to control the user's real local browser, run `vibebrowser-mcp` in HTTP mode and connect it to the Vibe extension in remote relay mode. Pass either the extension UUID or the full WebSocket relay URL to `--remote`.
 

--- a/docs/chrome-devtools-relay.md
+++ b/docs/chrome-devtools-relay.md
@@ -1,5 +1,7 @@
 # Chrome DevTools Relay — System Design
 
+> ⚠️ **Security:** A relay URL/UUID (`wss://relay.api.vibebrowser.app/<uuid>`) grants **live control of your browser session** (read tabs, screenshots, page content). Treat it like a password — never share it, paste it into a chat with untrusted parties, or commit it to a repo. Any example UUIDs are placeholders (`00000000-0000-0000-0000-000000000000`) and are not routable. The browser UUID must be paired with an access token; it is **not** a standalone credential.
+
 ## Problem
 
 Cloud AI agents (OpenClaw tenants, coding assistants, automation pipelines) need to

--- a/docs/openclaw-local-browser.md
+++ b/docs/openclaw-local-browser.md
@@ -8,6 +8,8 @@ published: true
 
 If you are running OpenClaw in the cloud, one of the most useful upgrades is giving it access to a real browser.
 
+> ⚠️ **Security:** A relay URL/UUID (`wss://relay.api.vibebrowser.app/<uuid>`) grants **live control of your browser session** (read tabs, screenshots, page content). Treat it like a password — never share it, paste it into a chat with untrusted parties, or commit it to a repo. Example UUIDs in this doc are placeholders (`YOUR-EXTENSION-UUID` / `00000000-0000-0000-0000-000000000000`) and are not routable.
+
 But there are actually two different browser problems hiding inside that sentence:
 
 - **tenant browser**: a browser that lives inside the hosted OpenClaw runtime

--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -16,6 +16,8 @@ metadata:
 
 # Vibe Local Browser
 
+> ⚠️ **Security:** The remote value (a relay URL/UUID, `wss://relay.api.vibebrowser.app/<uuid>`) grants **live control of the user's browser session** (read tabs, screenshots, page content). Treat it like a password — never echo it back in chat with untrusted parties, log it, or commit it to a repo. Store it only in the user's private workspace/memory as described below. Example UUIDs are non-routable placeholders.
+
 ## FIRST, EVERY TIME: load the saved remote before asking for it
 
 The user gives their remote value **once**. On **every** browser task — including the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "MCP server for browser automation - the only solution supporting multiple AI agents (Claude, Cursor, VS Code) simultaneously controlling your Chrome browser",
   "main": "dist/index.js",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,6 +2,8 @@
 
 Standalone CLI for controlling a Vibe-connected browser session.
 
+> ⚠️ **Security:** A relay URL/UUID (`wss://relay.api.vibebrowser.app/<uuid>`) grants **live control of your browser session** (read tabs, screenshots, page content). Treat it like a password — never share it, paste it into a chat with untrusted parties, or commit it to a repo. The `YOUR-EXTENSION-UUID` token below is a non-routable placeholder; substitute your own secret value locally.
+
 ```bash
 VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
 VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibebrowser/cli",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "Standalone Vibe Browser CLI for controlling a Vibe-connected browser session",
   "bin": {


### PR DESCRIPTION
## What leaked

The published npm packages `@vibebrowser/mcp` and `@vibebrowser/cli` (v0.2.12) previously exposed a **real relay session UUID** (redacted, see issue #105) in their README. A `wss://relay.api.vibebrowser.app/<uuid>` URL grants full live browser-session access with no auth beyond the UUID. This PR hardens the **documentation** shipped in both npm tarballs so a relay URL/UUID is clearly treated as a live secret, and bumps versions so a clean release can be published.

> Note: `main` already used placeholder tokens (`YOUR-EXTENSION-UUID`) rather than the real UUID, but the packaged docs had **no security warning** and the clean state of the full tarball had not been proven. This PR does both.

## Proof the package is now clean

Verified via `npm pack` (real tarballs extracted inside the repo, then deleted before commit) for **both** packages.

**`@vibebrowser/mcp` tarball** includes: `LICENSE`, `README.md`, `package.json`, `dist/**` (compiled JS + `.d.ts` + maps), `docs/chrome-devtools-relay.md`, `docs/openclaw-local-browser.md`, `openclaw/vibebrowser/SKILL.md`.

**`@vibebrowser/cli` tarball** includes: `README.md`, `package.json`, `dist/browser-cli.js`, `dist/browser-main.js`, `dist/connection.js`, `dist/devtools-fallback.js`, `dist/relay-daemon.js`, `dist/relay.js`, `dist/types.js`, `dist/version.js`.

Grep results against the extracted tarballs **and** the final tracked sources:

```
# literal leaked UUID (redacted; see issue #105) across both tarballs + sources
grep -rn "<leaked-uuid>"                 -> no matches (exit 1)

# any UUID-shaped string [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
# (excluding the all-zeros placeholder)
grep -rEn "<uuid-regex>"                 -> no matches (exit 1)
```

No real UUID is present in either published package. The docs use only non-routable placeholders: the `YOUR-EXTENSION-UUID` token and the all-zeros `00000000-0000-0000-0000-000000000000` example. No sanitization replacement was required (nothing real to replace); the change is the added warnings + version bump.

## Security warning added

Added a prominent "treat the relay URL/UUID like a password" warning to every packaged doc that describes `--remote` / `VIBE_REMOTE_URL` / relay URLs:

- **`README.md`** — top-of-file callout (right under the intro) + a targeted callout above the *Cloud OpenClaw -> Local Browser* remote section.
- **`docs/openclaw-local-browser.md`** — callout near the top.
- **`docs/chrome-devtools-relay.md`** — callout under the title (also notes the browser UUID must be paired with an access token, not used standalone).
- **`packages/cli/README.md`** — callout under the intro.
- **`openclaw/vibebrowser/SKILL.md`** — callout instructing agents never to echo/log/commit the remote value.

Excerpt:

> ⚠️ **Security:** A relay URL/UUID (`wss://relay.api.vibebrowser.app/<uuid>`) grants **live control of your browser session** (read tabs, screenshots, page content). Treat it like a password — never share it, paste it into a chat with untrusted parties, or commit it to a repo. Example UUIDs in this doc are placeholders (`00000000-0000-0000-0000-000000000000`) and are not routable.

## Version bump

| Package | Old | New |
|---|---|---|
| `@vibebrowser/mcp` | 0.2.12 | 0.2.13 |
| `@vibebrowser/cli` | 0.2.12 | 0.2.13 |

## Checklist for a human maintainer

- [ ] `npm publish` for `@vibebrowser/mcp` (this PR only bumps the version; publishing is NOT done)
- [ ] `npm publish` for `@vibebrowser/cli` (this PR only bumps the version; publishing is NOT done)
- [ ] Kill/revoke the leaked live relay session referenced in issue #105
- [ ] Fix relay auth model per VibeTechnologies/VibeWebAgent#1534 (UUID must not be the sole access credential)

---

Refs #105, VibeTechnologies/VibeWebAgent#1534
