### PR TITLE
chore: add server.json + fix npm metadata for MCP registry listings

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,118 @@
+name: Publish to MCP Registry
+
+# Publishes server.json to the official MCP registry
+# (https://registry.modelcontextprotocol.io).
+#
+# Why OIDC and not `mcp-publisher login github`:
+# the interactive GitHub device flow authenticates a *user*, and the registry
+# then derives the publishable namespace from that user's visible org
+# memberships. If the org restricts OAuth apps, the registry cannot see
+# `VibeTechnologies` and rejects `io.github.VibeTechnologies/*` with 403.
+# GitHub Actions OIDC instead proves *this repository's* identity directly, so
+# the namespace is granted from the repo owner with no org-level OAuth
+# approval needed.
+#
+# Ordering matters: the registry verifies ownership of the npm package by
+# reading the `mcpName` field from the *published* tarball, so npm must be
+# published first. This workflow therefore chains off "Publish to npm".
+
+on:
+  workflow_run:
+    workflows: ["Publish to npm"]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  publish-registry:
+    runs-on: ubuntu-latest
+    # Only run when the npm publish actually succeeded (or when dispatched by hand).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read versions from server.json
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          name=$(node -p "require('./server.json').name")
+          version=$(node -p "require('./server.json').version")
+          pkg=$(node -p "require('./server.json').packages[0].identifier")
+          pkg_version=$(node -p "require('./server.json').packages[0].version")
+          echo "name=$name"               >> "$GITHUB_OUTPUT"
+          echo "version=$version"         >> "$GITHUB_OUTPUT"
+          echo "pkg=$pkg"                 >> "$GITHUB_OUTPUT"
+          echo "pkg_version=$pkg_version" >> "$GITHUB_OUTPUT"
+          echo "Publishing $name@$version (npm $pkg@$pkg_version)"
+
+      - name: Wait for npm to serve the referenced version
+        shell: bash
+        run: |
+          set -euo pipefail
+          pkg='${{ steps.meta.outputs.pkg }}'
+          want='${{ steps.meta.outputs.pkg_version }}'
+          for i in $(seq 1 30); do
+            if npm view "$pkg@$want" version >/dev/null 2>&1; then
+              echo "$pkg@$want is live on npm."
+              exit 0
+            fi
+            echo "Attempt $i/30: $pkg@$want not on npm yet; sleeping 20s..."
+            sleep 20
+          done
+          echo "::error::$pkg@$want never appeared on npm; registry would reject the package ownership check." >&2
+          exit 1
+
+      - name: Verify the published tarball carries mcpName
+        shell: bash
+        run: |
+          set -euo pipefail
+          pkg='${{ steps.meta.outputs.pkg }}'
+          want='${{ steps.meta.outputs.pkg_version }}'
+          expect='${{ steps.meta.outputs.name }}'
+          got=$(npm view "$pkg@$want" mcpName 2>/dev/null || true)
+          if [ "$got" != "$expect" ]; then
+            echo "::error::Published $pkg@$want has mcpName='$got', expected '$expect'. The registry verifies npm ownership via this field and will reject the publish." >&2
+            exit 1
+          fi
+          echo "mcpName verified: $got"
+
+      - name: Install mcp-publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.0/mcp-publisher_linux_amd64.tar.gz" \
+            -o /tmp/mcp-publisher.tar.gz
+          tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp mcp-publisher
+          sudo install -m 0755 /tmp/mcp-publisher /usr/local/bin/mcp-publisher
+          mcp-publisher --version
+
+      - name: Validate server.json
+        run: mcp-publisher validate
+
+      - name: Authenticate via GitHub Actions OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Publish
+        run: mcp-publisher publish
+
+      - name: Confirm the server is listed
+        shell: bash
+        run: |
+          set -euo pipefail
+          name='${{ steps.meta.outputs.name }}'
+          for i in $(seq 1 10); do
+            if curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=vibebrowser" \
+                 | grep -q "$name"; then
+              echo "Confirmed: $name is live in the official registry."
+              exit 0
+            fi
+            echo "Attempt $i/10: not indexed yet; sleeping 15s..."
+            sleep 15
+          done
+          echo "::error::Publish reported success but $name is not searchable in the registry." >&2
+          exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibebrowser/mcp",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.3.1",
+  "mcpName": "io.github.VibeTechnologies/vibe-mcp",
+  "version": "0.3.2",
   "type": "module",
-  "description": "MCP server for browser automation - the only solution supporting multiple AI agents (Claude, Cursor, VS Code) simultaneously controlling your Chrome browser",
+  "description": "MCP server that drives your real, logged-in Chrome from any MCP client - including agents on a remote machine, with no inbound port open",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "workspaces": [
@@ -58,7 +59,15 @@
     "browser-mcp",
     "web-scraping",
     "vibe",
-    "vibebrowser"
+    "vibebrowser",
+    "remote-browser",
+    "logged-in-browser",
+    "chrome-extension",
+    "browser-control",
+    "claude",
+    "mcp-browser",
+    "real-browser",
+    "chrome-devtools-mcp-alternative"
   ],
   "author": "Vibe Technologies",
   "license": "Apache-2.0",
@@ -87,11 +96,12 @@
     "typescript": "^5.0.0"
   },
   "files": [
-    "dist",
-    "openclaw",
-    "docs/openclaw-local-browser.md",
-    "docs/chrome-devtools-relay.md",
+    "LICENSE",
     "README.md",
-    "LICENSE"
+    "dist",
+    "docs/chrome-devtools-relay.md",
+    "docs/openclaw-local-browser.md",
+    "openclaw",
+    "server.json"
   ]
 }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.VibeTechnologies/vibe-mcp",
+  "title": "Vibe MCP — Real Chrome, Remotely",
+  "description": "Drive your real, logged-in Chrome from any MCP client — even from a remote machine, no inbound port.",
+  "repository": {
+    "url": "https://github.com/VibeTechnologies/vibe-mcp",
+    "source": "github"
+  },
+  "version": "0.3.2",
+  "websiteUrl": "https://vibebrowser.app",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@vibebrowser/mcp",
+      "version": "0.3.2",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Why

vibe-mcp has near-zero discovery (2 stars, ~84 npm weekly downloads). Getting listed on the MCP registries/directories is permanent, high-intent, zero-recurring-cost traffic. This PR is the repo-side prerequisite for that.

## What

1. **`server.json`** — manifest for the official MCP registry (`registry.modelcontextprotocol.io`), namespace `io.github.VibeTechnologies`.
2. **`mcpName` in `package.json`** — the official registry reads this field from the published npm package to verify we own the server name. Without it, publish is rejected.
3. **Fixed the npm `description`.** The old one said we are *"the only solution supporting multiple AI agents"* — that is false (Playwright MCP `--extension` and Chrome DevTools MCP `--autoConnect` both drive a real browser). The README was already corrected in #114, but `package.json` was missed — and the npm description is exactly what Glama / mcp.so / PulseMCP index, so the false claim was the one actually propagating to directories.

   New description leads with the defensible wedge:
   > MCP server that drives your real, logged-in Chrome from any MCP client - including agents on a remote machine, with no inbound port open

4. **Discovery keywords** added (`remote-browser`, `logged-in-browser`, `browser-control`, `real-browser`, …) — these directories rank on npm keywords.
5. **Version bump to 0.3.2** so the corrected metadata and `mcpName` actually reach npm (directories crawl the published package, not the repo).
6. **New: `.github/workflows/publish-mcp-registry.yml`** — auto-publishes `server.json` to the official MCP registry. See below for why this is OIDC and not the interactive login.

## Why the registry publish had to become a workflow

I tried to publish manually with `mcp-publisher login github` + `publish`. It fails:

```
403 Forbidden — You do not have permission to publish this server.
You have permission to publish: io.github.dzianisv/*
Attempting to publish: io.github.VibeTechnologies/vibe-mcp
```

The device flow authenticates a **user** and the registry derives the namespace from that user's *visible* org memberships. I made the `VibeTechnologies` membership public (`https://api.github.com/users/dzianisv/orgs` now returns it) and re-authenticated with a fresh token — still 403. The remaining cause is the org's OAuth-app access restriction: the "MCP Registry Login (Prod)" OAuth app isn't approved for `VibeTechnologies`, so the registry can't see the org at all. Changing that setting needs GitHub sudo mode, and GitHub's verification mail isn't being delivered during the current partial outage.

GitHub Actions **OIDC** sidesteps this entirely: it proves *this repository's* identity, so the namespace is granted from the repo owner with no org-level OAuth approval. That is also the maintained path going forward — every future version publishes itself.

The workflow chains off **"Publish to npm"** because the registry verifies npm package ownership by reading `mcpName` from the *published* tarball, so npm must land first. It also:
- waits (up to 10 min) for the npm version referenced in `server.json` to be served,
- hard-fails if the published tarball's `mcpName` doesn't match `server.json`,
- validates `server.json` before publishing,
- re-queries the registry afterwards and fails if the server isn't actually searchable — so a green run means it's really listed, not just that the CLI exited 0.

## Claims audit

Every claim used here and in the registry submissions is one of the three verified-true ones:
- agent can run on another machine, no inbound port needed
- real logged-in profile **and** no per-connection approval dialog together
- works with any MCP client (not vendor-locked)

Deliberately **not** claimed anywhere: "only tool using your real browser", "only tool supporting multiple agents", "competitors fail with port conflicts". All verified false.

Related, done outside this PR (repo settings, not files): the **GitHub repo description** still carried the same "only solution supporting multiple AI agents" claim and has been corrected; `homepage` set to https://vibebrowser.app; topics expanded to 20 discovery terms. Those feed Glama and GitHub search directly.

## Verification

- `npm run build` passes locally.
- `npx -y @vibebrowser/mcp@latest` verified to complete an MCP `initialize` handshake and return `tools/list` (28 tools, serverInfo `vibebrowser-mcp`) before publishing the install command to any registry.
- `mcp-publisher validate` → `server.json is valid`.
- Workflow YAML parsed and the pinned `mcp-publisher_linux_amd64.tar.gz` v1.8.0 asset confirmed to return 200.

## Not merging yet

GitHub Actions is in a **major outage** right now, so CI cannot run on this branch (`no checks reported`). Per the rule of not merging without green CI, this stays open until Actions recovers.
