### PR TITLE
feat(dist): Claude Code plugin + .mcpb bundle, fix MCP registry verify step

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "vibe-browser",
+  "description": "Claude Code plugins from Vibe Technologies for driving your real Chrome.",
+  "owner": {
+    "name": "Vibe Technologies",
+    "url": "https://github.com/VibeTechnologies"
+  },
+  "plugins": [
+    {
+      "name": "vibe-browser",
+      "source": "./plugins/vibe-browser",
+      "description": "Drive your real, logged-in Chrome from Claude Code. Navigate, click, type, screenshot and read pages in the browser you already use - including a browser on a different machine, with no inbound port open.",
+      "version": "0.3.2",
+      "author": {
+        "name": "Vibe Technologies",
+        "url": "https://vibebrowser.app"
+      },
+      "homepage": "https://vibebrowser.app",
+      "repository": "https://github.com/VibeTechnologies/vibe-mcp",
+      "license": "Apache-2.0",
+      "category": "productivity",
+      "keywords": [
+        "browser",
+        "chrome",
+        "browser-automation",
+        "web-automation",
+        "mcp"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,13 @@ jobs:
         # packed @vibebrowser/cli install+help smoke, and the chrome-use
         # devtools flag.
         run: npm run test:ci
+
+      # Kept out of `test:ci` because it needs network: it installs the
+      # published npm package into the bundle, runs Anthropic's `mcpb` and
+      # `claude plugin validate` tools, and resolves the Chrome Web Store
+      # listing linked from the setup skill.
+      - name: Install claude CLI (runs the same validator as Anthropic's review pipeline)
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: E2E (distribution artifacts - plugin + .mcpb bundle)
+        run: npm run test:e2e:plugin-bundle

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -100,19 +100,43 @@ jobs:
       - name: Publish
         run: mcp-publisher publish
 
+      # Verify against the *server name*, not a hardcoded brand string. The
+      # previous version searched for "vibebrowser", which never matches: the
+      # registry's `search` filter matches the server `name`
+      # (io.github.VibeTechnologies/vibe-mcp), and "vibebrowser" appears only in
+      # the description and package identifier. That produced a red job on
+      # 2026-08-07 even though `mcp-publisher publish` had succeeded and the
+      # server was live. Also assert the published version and active status so a
+      # stale prior entry can't satisfy the check.
       - name: Confirm the server is listed
         shell: bash
         run: |
           set -euo pipefail
           name='${{ steps.meta.outputs.name }}'
+          want='${{ steps.meta.outputs.version }}'
           for i in $(seq 1 10); do
-            if curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=vibebrowser" \
-                 | grep -q "$name"; then
-              echo "Confirmed: $name is live in the official registry."
+            body=$(curl -fsS --get \
+              --data-urlencode "search=$name" \
+              "https://registry.modelcontextprotocol.io/v0/servers" || true)
+            if [ -n "$body" ] && printf '%s' "$body" | NAME="$name" WANT="$want" node -e '
+              const want = process.env.WANT, name = process.env.NAME;
+              let raw = "";
+              process.stdin.on("data", c => raw += c);
+              process.stdin.on("end", () => {
+                let d; try { d = JSON.parse(raw); } catch { process.exit(1); }
+                const hit = (d.servers || []).find(e => {
+                  const s = e.server || e;
+                  const meta = (e._meta || {})["io.modelcontextprotocol.registry/official"] || {};
+                  return s.name === name && s.version === want && meta.status === "active";
+                });
+                process.exit(hit ? 0 : 1);
+              });
+            '; then
+              echo "Confirmed: $name@$want is live and active in the official registry."
               exit 0
             fi
-            echo "Attempt $i/10: not indexed yet; sleeping 15s..."
+            echo "Attempt $i/10: $name@$want not indexed as active yet; sleeping 15s..."
             sleep 15
           done
-          echo "::error::Publish reported success but $name is not searchable in the registry." >&2
+          echo "::error::Publish reported success but $name@$want is not listed as active in the registry." >&2
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+build/
 *.log
 .DS_Store
 tmp/

--- a/mcpb/build.mjs
+++ b/mcpb/build.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Builds the `.mcpb` desktop-extension bundle for Claude Desktop.
+ *
+ * The bundle is self-contained: it ships @vibebrowser/mcp plus its runtime
+ * dependencies in node_modules/, so installing it never hits the network.
+ *
+ * Usage:
+ *   node mcpb/build.mjs            # build into build/mcpb and pack
+ *   node mcpb/build.mjs --no-pack  # stage only (used by the test harness)
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..');
+const stageDir = path.join(repoRoot, 'build', 'mcpb');
+
+const manifestPath = path.join(here, 'manifest.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const rootPkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+
+// Invariant: the bundle must advertise the same version as the package it ships.
+// A drift here would publish a bundle whose manifest lies about its contents.
+if (manifest.version !== rootPkg.version) {
+  throw new Error(
+    `Version drift: mcpb/manifest.json is ${manifest.version} but package.json is ${rootPkg.version}. ` +
+      'Bump both together.',
+  );
+}
+
+const serverSpec = `${rootPkg.name}@${rootPkg.version}`;
+
+function run(cmd, args, opts = {}) {
+  execFileSync(cmd, args, { stdio: 'inherit', ...opts });
+}
+
+fs.rmSync(stageDir, { recursive: true, force: true });
+fs.mkdirSync(path.join(stageDir, 'server'), { recursive: true });
+
+fs.copyFileSync(manifestPath, path.join(stageDir, 'manifest.json'));
+fs.copyFileSync(path.join(here, 'server-entry.mjs'), path.join(stageDir, 'server', 'index.js'));
+
+// A minimal package.json so Node treats server/index.js as ESM and npm has a
+// place to install the bundled dependency tree.
+fs.writeFileSync(
+  path.join(stageDir, 'package.json'),
+  `${JSON.stringify(
+    {
+      name: 'vibe-browser-mcpb',
+      version: manifest.version,
+      private: true,
+      type: 'module',
+      dependencies: { [rootPkg.name]: rootPkg.version },
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+console.log(`Installing ${serverSpec} into the bundle...`);
+// --omit=optional keeps chrome-devtools-mcp (a large optional fallback) out of
+// the bundle; the relay/extension path is the supported one for Claude Desktop.
+run('npm', ['install', '--omit=dev', '--omit=optional', '--no-audit', '--no-fund'], {
+  cwd: stageDir,
+});
+
+// npm writes a lockfile into the stage dir; harmless, but keep the bundle tidy.
+fs.rmSync(path.join(stageDir, 'package-lock.json'), { force: true });
+
+const entry = path.join(stageDir, manifest.server.entry_point);
+if (!fs.existsSync(entry)) {
+  throw new Error(`Bundle is missing its declared entry_point: ${manifest.server.entry_point}`);
+}
+
+if (process.argv.includes('--no-pack')) {
+  console.log(`Staged bundle at ${stageDir} (skipping pack).`);
+} else {
+  console.log('Packing .mcpb...');
+  run('npx', ['-y', '@anthropic-ai/mcpb@latest', 'pack', stageDir, path.join(repoRoot, 'build', 'vibe-browser.mcpb')]);
+  console.log(`Built ${path.join(repoRoot, 'build', 'vibe-browser.mcpb')}`);
+}

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,74 @@
+{
+  "manifest_version": "0.3",
+  "name": "vibe-browser",
+  "display_name": "Vibe Browser",
+  "version": "0.3.2",
+  "description": "Drive your real, logged-in Chrome from Claude Desktop.",
+  "long_description": "Vibe Browser lets Claude drive the Chrome you already use - with your tabs, your cookies, and your logged-in sessions - instead of a headless throwaway browser.\n\nThe browser can also run on a different machine from Claude, with no inbound port open on either side, by pairing them through a relay UUID.\n\nRequires the free Vibe Chrome extension. After installing this bundle, install the extension from the Chrome Web Store and enable 'MCP External Control' in its Settings.",
+  "author": {
+    "name": "Vibe Technologies",
+    "url": "https://vibebrowser.app"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VibeTechnologies/vibe-mcp.git"
+  },
+  "homepage": "https://vibebrowser.app",
+  "documentation": "https://github.com/VibeTechnologies/vibe-mcp#readme",
+  "support": "https://github.com/VibeTechnologies/vibe-mcp/issues",
+  "license": "Apache-2.0",
+  "keywords": [
+    "browser",
+    "chrome",
+    "browser-automation",
+    "web-automation",
+    "productivity"
+  ],
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server/index.js"],
+      "env": {
+        "VIBE_REMOTE_URL": "${user_config.remote_uuid}"
+      }
+    }
+  },
+  "user_config": {
+    "remote_uuid": {
+      "type": "string",
+      "title": "Remote browser UUID (optional)",
+      "description": "Leave empty when Chrome runs on this same machine. To control Chrome on a DIFFERENT machine, switch the Vibe extension to Remote mode and paste the UUID it shows here. Treat it like a password: it is the only credential guarding that browser.",
+      "sensitive": true,
+      "required": false,
+      "default": ""
+    }
+  },
+  "tools": [
+    { "name": "navigate_to_url", "description": "Navigate to any URL" },
+    { "name": "go_back", "description": "Go back in browser history" },
+    { "name": "go_forward", "description": "Go forward in browser history" },
+    { "name": "click", "description": "Click an element on the page" },
+    { "name": "type", "description": "Type text into an input" },
+    { "name": "fill", "description": "Fill an input with text" },
+    { "name": "scroll", "description": "Scroll the page" },
+    { "name": "take_screenshot", "description": "Capture a screenshot of the page" },
+    { "name": "get_page_content", "description": "Extract page text or HTML" },
+    { "name": "get_tabs", "description": "List open browser tabs" },
+    { "name": "create_new_tab", "description": "Open a new tab" },
+    { "name": "switch_to_tab", "description": "Switch to an existing tab" },
+    { "name": "close_tab", "description": "Close a tab" },
+    { "name": "keyboard_shortcut", "description": "Press a keyboard combination" },
+    { "name": "web_search", "description": "Search the web" }
+  ],
+  "tools_generated": true,
+  "privacy_policies": ["https://vibebrowser.app/privacy"],
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "node": ">=18.0.0"
+    }
+  }
+}

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -7,7 +7,7 @@
   "long_description": "Vibe Browser lets Claude drive the Chrome you already use - with your tabs, your cookies, and your logged-in sessions - instead of a headless throwaway browser.\n\nThe browser can also run on a different machine from Claude, with no inbound port open on either side, by pairing them through a relay UUID.\n\nRequires the free Vibe Chrome extension. After installing this bundle, install the extension from the Chrome Web Store and enable 'MCP External Control' in its Settings.",
   "author": {
     "name": "Vibe Technologies",
-    "url": "https://vibebrowser.app"
+    "url": "https://github.com/VibeTechnologies"
   },
   "repository": {
     "type": "git",

--- a/mcpb/server-entry.mjs
+++ b/mcpb/server-entry.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * MCPB bundle entry point.
+ *
+ * The bundle ships @vibebrowser/mcp and its dependencies in a sibling
+ * node_modules/, so this shim just resolves the package's real CLI and executes
+ * it in-process. It deliberately does NOT re-implement any server logic: the
+ * bundled server must behave identically to `npx @vibebrowser/mcp`.
+ *
+ * The CLI parses process.argv and defaults to the `start` command over stdio,
+ * which is exactly what an MCPB host expects.
+ */
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+function resolveServerEntry() {
+  // Resolve via package.json so we follow the package's own `bin` declaration
+  // rather than hardcoding a dist path that could move between releases.
+  const pkgJsonPath = require.resolve('@vibebrowser/mcp/package.json');
+  const pkg = require(pkgJsonPath);
+  const relative =
+    (pkg.bin && (pkg.bin.mcp || pkg.bin['vibebrowser-mcp'] || pkg.bin['vibe-mcp'])) || pkg.main;
+
+  if (!relative) {
+    throw new Error(
+      '@vibebrowser/mcp declares neither a usable `bin` entry nor `main`; the bundle is malformed.',
+    );
+  }
+
+  return path.resolve(path.dirname(pkgJsonPath), relative);
+}
+
+try {
+  await import(pathToFileURL(resolveServerEntry()).href);
+} catch (error) {
+  const message = error instanceof Error ? error.stack || error.message : String(error);
+  // stderr only: stdout is the MCP stdio transport and must stay protocol-clean.
+  process.stderr.write(`[vibe-browser] failed to start bundled MCP server:\n${message}\n`);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "test:e2e:browser-cli-live": "node scripts/e2e-browser-cli-live.mjs",
     "test:e2e:relay-race": "node scripts/e2e-relay-fake-extension-race.mjs",
     "test:e2e:relay-roundtrip": "node scripts/e2e-relay-roundtrip.mjs",
-    "test:e2e:agents": "node scripts/e2e-mcp-agents.mjs"
+    "test:e2e:agents": "node scripts/e2e-mcp-agents.mjs",
+    "build:mcpb": "node mcpb/build.mjs",
+    "test:e2e:plugin-bundle": "node scripts/e2e-plugin-bundle.mjs"
   },
   "keywords": [
     "mcp",

--- a/plugins/vibe-browser/.claude-plugin/plugin.json
+++ b/plugins/vibe-browser/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "vibe-browser",
+  "displayName": "Vibe Browser",
+  "version": "0.3.2",
+  "description": "Drive your real, logged-in Chrome from Claude Code. Navigate, click, type, screenshot and read pages in the browser you already use - including a browser on a different machine, with no inbound port open.",
+  "author": {
+    "name": "Vibe Technologies",
+    "url": "https://vibebrowser.app"
+  },
+  "homepage": "https://vibebrowser.app",
+  "repository": "https://github.com/VibeTechnologies/vibe-mcp",
+  "license": "Apache-2.0",
+  "keywords": [
+    "browser",
+    "chrome",
+    "browser-automation",
+    "web-automation",
+    "mcp",
+    "playwright-alternative",
+    "puppeteer-alternative"
+  ]
+}

--- a/plugins/vibe-browser/.mcp.json
+++ b/plugins/vibe-browser/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "vibe": {
+      "command": "npx",
+      "args": ["-y", "@vibebrowser/mcp@0.3.2"]
+    }
+  }
+}

--- a/plugins/vibe-browser/README.md
+++ b/plugins/vibe-browser/README.md
@@ -1,0 +1,46 @@
+# Vibe Browser - Claude Code plugin
+
+Drive your **real, logged-in Chrome** from Claude Code. Not a headless throwaway
+browser: the tabs, cookies, and sessions you already have.
+
+The browser can even be on a **different machine** from Claude Code, with no inbound
+port open on either side.
+
+## Install
+
+```shell
+/plugin marketplace add VibeTechnologies/vibe-mcp
+/plugin install vibe-browser@vibe-browser
+```
+
+## Setup
+
+This plugin needs the **Vibe Chrome extension** — the MCP server is a relay and has no
+browser of its own. Run the bundled setup skill and it will walk you through it:
+
+```shell
+/vibe-browser:setup
+```
+
+Short version:
+
+1. Install the extension: [Chrome Web Store](https://chromewebstore.google.com/detail/vibe-ai-browser-co-pilot/djodpgokbmobeclicaicnnidccoinado)
+2. Click the Vibe icon -> **Settings** -> enable **MCP External Control**
+3. Verify: `npx -y @vibebrowser/cli@latest tabs` should list your real open tabs
+
+## What you get
+
+`navigate_to_url`, `go_back` / `go_forward`, `click`, `type` / `fill`, `scroll`,
+`take_screenshot`, `get_page_content`, tab management (`get_tabs`, `create_new_tab`,
+`switch_to_tab`, `close_tab`), `keyboard_shortcut`, and `web_search`.
+
+Multiple agents can drive the same browser at once.
+
+## Links
+
+- Source: <https://github.com/VibeTechnologies/vibe-mcp>
+- npm: [`@vibebrowser/mcp`](https://www.npmjs.com/package/@vibebrowser/mcp)
+- MCP registry: `io.github.VibeTechnologies/vibe-mcp`
+- Issues: <https://github.com/VibeTechnologies/vibe-mcp/issues>
+
+Apache-2.0

--- a/plugins/vibe-browser/skills/setup/SKILL.md
+++ b/plugins/vibe-browser/skills/setup/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: setup
+description: Set up Vibe Browser so Claude Code can drive the user's real Chrome. Use when the vibe MCP tools are missing, return "No connection to Vibe extension", time out, or when the user asks how to install/connect/configure Vibe, the Vibe Chrome extension, or remote browser control.
+---
+
+# Set up Vibe Browser
+
+The `vibe` MCP server is only a **relay**. It has no browser of its own: it forwards
+tool calls to the **Vibe Chrome extension** running in the user's real Chrome. Until
+that extension is installed and connected, every browser tool will fail.
+
+Work through the steps below **in order**. Stop as soon as Step 4 verifies.
+
+## Step 1 — Install the Vibe extension
+
+Ask the user to install the extension in Chrome, Brave, or any Chromium browser:
+
+**Chrome Web Store (recommended)**
+<https://chromewebstore.google.com/detail/vibe-ai-browser-co-pilot/djodpgokbmobeclicaicnnidccoinado>
+
+Click **Add to Chrome**. The Vibe icon appears in the toolbar.
+
+**Developer version (if the store is blocked)**
+1. Download <https://github.com/VibeTechnologies/VibeWebAgent/releases/latest/download/vibe-ai-copilot-latest.zip>
+2. Extract it to a permanent folder (deleting it later uninstalls the extension).
+3. Open `chrome://extensions`, turn on **Developer mode**.
+4. Click **Load unpacked** and select the extracted folder.
+
+## Step 2 — Turn on external control
+
+The extension refuses external control until the user opts in:
+
+1. Click the **Vibe icon** in the Chrome toolbar.
+2. Open **Settings**.
+3. Enable **MCP External Control**.
+4. The status indicator should read **Connected**.
+
+Chrome must stay open. Closing the browser drops the connection.
+
+## Step 3 — Choose local or remote
+
+**Local (default).** Claude Code and Chrome are on the same machine. Nothing more to
+configure — the server auto-spawns a localhost relay daemon and the extension finds it.
+
+**Remote.** Chrome runs on a different machine from Claude Code (for example Claude Code
+on a dev box, Chrome on the user's laptop). This needs no inbound port:
+
+1. In the extension **Settings**, switch to **Remote** mode.
+2. Copy the **remote UUID** it shows.
+3. Pass it to the server, either as an argument (`--remote <uuid>`) or via the
+   `VIBE_REMOTE_URL` environment variable.
+
+> The remote UUID is the **only** bearer credential for that browser. Treat it like a
+> password. Never paste it into a file the user tracks in git, and never print it back
+> in full. If it leaks, regenerate it in extension Settings.
+
+## Step 4 — Verify (do not skip)
+
+Prove the whole chain works before telling the user setup is done. Call the `vibe`
+MCP server's tab-listing tool, or run:
+
+```bash
+npx -y @vibebrowser/cli@latest tabs
+```
+
+A list of the user's **actual open tabs** means the extension, relay, and server are all
+connected. Anything else means setup is not finished — go to Troubleshooting.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `No connection to Vibe extension` | Extension not installed, or **MCP External Control** is off | Redo Steps 1–2 |
+| Tools listed but every call times out | Chrome closed, or the machine went to sleep | Reopen Chrome, confirm the extension shows **Connected** |
+| Works locally, fails remotely | Wrong or regenerated UUID | Re-copy the UUID from extension Settings (Step 3) |
+| Connects, then drops after an update | Extension auto-updated and reset its toggle | Re-enable **MCP External Control** |
+
+Add `--debug` to the server args to get verbose logs when the table above doesn't resolve it.
+
+## Fallback: no extension at all
+
+If the user cannot install the extension, the server can drive their already-running
+Chrome directly over the Chrome DevTools Protocol instead:
+
+```bash
+npx -y @vibebrowser/cli@latest --devtools tabs
+```
+
+This requires **Chrome 144+** and triggers a one-time permission dialog per profile.
+It exposes a smaller tool set (`navigate`, `snapshot`, `click`, `fill`, `type`,
+`press_key`, `hover`, `scroll`, `screenshot`, `eval`, `get_text`, `get_url`,
+`get_title`, and tab management). Use `snapshot` to get `@eN` element refs, then pass
+those refs as selectors to `click`/`fill`/`type`.

--- a/scripts/e2e-plugin-bundle.mjs
+++ b/scripts/e2e-plugin-bundle.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * Real end-to-end check for the two distribution artifacts:
+ *
+ *   1. the Claude Code plugin under plugins/vibe-browser
+ *   2. the .mcpb desktop bundle built from mcpb/
+ *
+ * This deliberately avoids fixture-shaped assertions. Every check either runs a
+ * real external validator (`mcpb validate`, `claude plugin validate`) or boots
+ * the real server and speaks real MCP over stdio to it. If the artifact would
+ * not work for a user, this test fails.
+ *
+ * Run: node scripts/e2e-plugin-bundle.mjs
+ */
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const failures = [];
+let checks = 0;
+
+function check(name, fn) {
+  checks += 1;
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (error) {
+    failures.push(`${name}: ${error.message}`);
+    console.log(`  FAIL ${name}\n       ${error.message}`);
+  }
+}
+
+function assert(cond, message) {
+  if (!cond) throw new Error(message);
+}
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+// ---------------------------------------------------------------------------
+// 1. Plugin structure + manifest agreement with the rest of the repo
+// ---------------------------------------------------------------------------
+console.log('\n[1/4] Claude Code plugin');
+
+const pluginDir = path.join(repoRoot, 'plugins', 'vibe-browser');
+const pluginManifest = readJson(path.join(pluginDir, '.claude-plugin', 'plugin.json'));
+const marketplace = readJson(path.join(repoRoot, '.claude-plugin', 'marketplace.json'));
+const rootPkg = readJson(path.join(repoRoot, 'package.json'));
+
+check('plugin components sit at the plugin root, not inside .claude-plugin/', () => {
+  for (const dir of ['skills', 'commands', 'agents', 'hooks']) {
+    assert(
+      !fs.existsSync(path.join(pluginDir, '.claude-plugin', dir)),
+      `${dir}/ must not live inside .claude-plugin/ - Claude Code will not discover it`,
+    );
+  }
+});
+
+check('setup skill exists and declares a description', () => {
+  const skill = path.join(pluginDir, 'skills', 'setup', 'SKILL.md');
+  assert(fs.existsSync(skill), 'skills/setup/SKILL.md is missing');
+  const body = fs.readFileSync(skill, 'utf8');
+  const fm = /^---\n([\s\S]*?)\n---/.exec(body);
+  assert(fm, 'SKILL.md has no YAML frontmatter');
+  assert(/\bdescription:\s*\S/.test(fm[1]), 'SKILL.md frontmatter has no description');
+});
+
+check('setup skill points at a Chrome Web Store listing that resolves', () => {
+  const body = fs.readFileSync(path.join(pluginDir, 'skills', 'setup', 'SKILL.md'), 'utf8');
+  const m = /chromewebstore\.google\.com\/detail\/[a-z0-9-]+\/([a-z]{32})/.exec(body);
+  assert(m, 'no Chrome Web Store extension link found in the setup skill');
+  // Network check is opt-in so the suite stays runnable offline.
+  if (process.env.E2E_SKIP_NETWORK === '1') return;
+  const html = execFileSync(
+    'curl',
+    ['-sL', '-A', 'Mozilla/5.0', `https://chromewebstore.google.com/detail/${m[1]}`],
+    { encoding: 'utf8', timeout: 30_000 },
+  );
+  assert(
+    /<title>[^<]*Vibe[^<]*<\/title>/i.test(html),
+    `extension id ${m[1]} does not resolve to a Vibe listing (dead or unpublished link)`,
+  );
+});
+
+check('plugin .mcp.json pins the version this repo actually publishes', () => {
+  const mcp = readJson(path.join(pluginDir, '.mcp.json'));
+  const server = mcp.mcpServers && mcp.mcpServers.vibe;
+  assert(server, '.mcp.json has no "vibe" server');
+  const spec = (server.args || []).find((a) => a.startsWith(rootPkg.name));
+  assert(spec, `.mcp.json args do not reference ${rootPkg.name}`);
+  assert(
+    spec === `${rootPkg.name}@${rootPkg.version}`,
+    `.mcp.json pins ${spec} but package.json is at ${rootPkg.version}`,
+  );
+});
+
+check('marketplace entry resolves to the real plugin directory and version', () => {
+  const entry = (marketplace.plugins || []).find((p) => p.name === pluginManifest.name);
+  assert(entry, `marketplace.json has no entry named ${pluginManifest.name}`);
+  const resolved = path.resolve(repoRoot, entry.source);
+  assert(fs.existsSync(resolved), `marketplace source ${entry.source} does not exist`);
+  assert(
+    resolved === pluginDir,
+    `marketplace source resolves to ${resolved}, expected ${pluginDir}`,
+  );
+  assert(
+    entry.version === pluginManifest.version,
+    `marketplace pins ${entry.version} but plugin.json is ${pluginManifest.version}`,
+  );
+  assert(
+    pluginManifest.version === rootPkg.version,
+    `plugin.json is ${pluginManifest.version} but package.json is ${rootPkg.version}`,
+  );
+});
+
+// `claude` is not installed everywhere; when it is, defer to the real validator
+// that Anthropic's review pipeline runs.
+console.log('\n[2/4] claude plugin validate');
+let claudeAvailable = true;
+try {
+  execFileSync('claude', ['--version'], { stdio: 'ignore' });
+} catch {
+  claudeAvailable = false;
+}
+
+if (!claudeAvailable) {
+  console.log('  skip  claude CLI not installed (CI installs it; local runs may skip)');
+} else {
+  check('claude plugin validate --strict passes for the plugin', () => {
+    execFileSync('claude', ['plugin', 'validate', pluginDir, '--strict'], {
+      encoding: 'utf8',
+      timeout: 120_000,
+    });
+  });
+
+  check('claude plugin validate --strict passes for the marketplace', () => {
+    execFileSync('claude', ['plugin', 'validate', repoRoot, '--strict'], {
+      encoding: 'utf8',
+      timeout: 120_000,
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 3. Build the real bundle and validate it with Anthropic's own tool
+// ---------------------------------------------------------------------------
+console.log('\n[3/4] .mcpb bundle');
+
+const stageDir = path.join(repoRoot, 'build', 'mcpb');
+
+check('bundle builds from source', () => {
+  execFileSync('node', [path.join('mcpb', 'build.mjs'), '--no-pack'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    timeout: 300_000,
+  });
+  assert(fs.existsSync(stageDir), 'build/mcpb was not produced');
+});
+
+check('bundled manifest passes `mcpb validate`', () => {
+  execFileSync('npx', ['-y', '@anthropic-ai/mcpb@latest', 'validate', path.join(stageDir, 'manifest.json')], {
+    encoding: 'utf8',
+    timeout: 180_000,
+  });
+});
+
+check('bundle is self-contained (declared entry + dependency tree present)', () => {
+  const manifest = readJson(path.join(stageDir, 'manifest.json'));
+  const entry = path.join(stageDir, manifest.server.entry_point);
+  assert(fs.existsSync(entry), `entry_point ${manifest.server.entry_point} missing from bundle`);
+  assert(
+    fs.existsSync(path.join(stageDir, 'node_modules', rootPkg.name)),
+    `${rootPkg.name} was not vendored into the bundle - install would need the network`,
+  );
+  for (const dep of Object.keys(rootPkg.dependencies || {})) {
+    assert(
+      fs.existsSync(path.join(stageDir, 'node_modules', dep)),
+      `runtime dependency ${dep} is missing from the bundle`,
+    );
+  }
+});
+
+check('bundle packs into a loadable .mcpb archive', () => {
+  const out = path.join(repoRoot, 'build', 'vibe-browser.mcpb');
+  fs.rmSync(out, { force: true });
+  execFileSync('npx', ['-y', '@anthropic-ai/mcpb@latest', 'pack', stageDir, out], {
+    encoding: 'utf8',
+    timeout: 300_000,
+  });
+  assert(fs.existsSync(out), '.mcpb archive was not produced');
+  // Claude Desktop reads manifest.json from the archive root; prove it is there.
+  const listing = execFileSync('unzip', ['-Z1', out], { encoding: 'utf8' });
+  const names = listing.split('\n');
+  assert(names.includes('manifest.json'), '.mcpb archive has no manifest.json at its root');
+  assert(
+    names.some((n) => n === 'server/index.js'),
+    '.mcpb archive is missing server/index.js',
+  );
+  const bytes = fs.statSync(out).size;
+  assert(bytes > 10_000, `.mcpb archive is implausibly small (${bytes} bytes)`);
+  console.log(`       archive: ${(bytes / 1024).toFixed(0)} KiB, ${names.length - 1} entries`);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Boot the bundled server exactly as the manifest declares and speak MCP
+// ---------------------------------------------------------------------------
+console.log('\n[4/4] live MCP handshake against the bundled server');
+
+async function handshake() {
+  const manifest = readJson(path.join(stageDir, 'manifest.json'));
+  const args = manifest.server.mcp_config.args.map((a) => a.replace('${__dirname}', stageDir));
+
+  const child = spawn(manifest.server.mcp_config.command, args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    // Same env shape the host produces when the user leaves remote_uuid blank.
+    env: { ...process.env, VIBE_REMOTE_URL: '' },
+  });
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (c) => {
+    stdout += c;
+  });
+  child.stderr.on('data', (c) => {
+    stderr += c;
+  });
+
+  const send = (msg) => child.stdin.write(`${JSON.stringify(msg)}\n`);
+
+  send({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'mcpb-bundle-e2e', version: '1.0.0' },
+    },
+  });
+
+  const deadline = Date.now() + 60_000;
+  let result = null;
+  while (Date.now() < deadline && !result) {
+    for (const line of stdout.split('\n')) {
+      if (!line.trim()) continue;
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.id === 1) result = msg;
+    }
+    if (!result) await new Promise((r) => setTimeout(r, 200));
+  }
+
+  child.kill('SIGKILL');
+
+  if (!result) {
+    throw new Error(
+      `bundled server never answered initialize within 60s.\nstderr:\n${stderr.slice(0, 2000)}`,
+    );
+  }
+  if (result.error) {
+    throw new Error(`initialize returned an error: ${JSON.stringify(result.error)}`);
+  }
+  assert(
+    result.result && result.result.protocolVersion,
+    `initialize result missing protocolVersion: ${JSON.stringify(result.result)}`,
+  );
+  assert(
+    result.result.serverInfo && result.result.serverInfo.name,
+    'initialize result missing serverInfo.name',
+  );
+  return result.result;
+}
+
+let handshakeResult = null;
+try {
+  handshakeResult = await handshake();
+  checks += 1;
+  console.log(
+    `  ok   bundled server completed MCP initialize ` +
+      `(server: ${handshakeResult.serverInfo.name} ${handshakeResult.serverInfo.version || ''}, ` +
+      `protocol: ${handshakeResult.protocolVersion})`,
+  );
+} catch (error) {
+  checks += 1;
+  failures.push(`bundled server MCP initialize: ${error.message}`);
+  console.log(`  FAIL bundled server MCP initialize\n       ${error.message}`);
+}
+
+// ---------------------------------------------------------------------------
+console.log('');
+if (failures.length) {
+  console.error(`e2e FAILED - ${failures.length}/${checks} checks failed:`);
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log(`e2e ok - ${checks} checks passed`);

--- a/scripts/e2e-plugin-bundle.mjs
+++ b/scripts/e2e-plugin-bundle.mjs
@@ -183,6 +183,28 @@ check('bundle is self-contained (declared entry + dependency tree present)', () 
   }
 });
 
+// Hard requirements copied from Anthropic's MCPB Desktop Extensions submission
+// form. A drift here gets the submission rejected, so fail the build instead.
+check('bundle meets the MCPB directory submission requirements', () => {
+  const manifest = readJson(path.join(stageDir, 'manifest.json'));
+  assert(
+    manifest.server.type === 'node',
+    `directory expects a Node.js extension, manifest declares "${manifest.server.type}"`,
+  );
+  assert(
+    manifest.author && /^https:\/\/github\.com\/[^/]+\/?$/.test(manifest.author.url || ''),
+    `manifest author.url must point at a GitHub profile, got "${(manifest.author || {}).url}"`,
+  );
+  assert(
+    Array.isArray(manifest.privacy_policies) && manifest.privacy_policies.length > 0,
+    'manifest must declare privacy_policies: the server reaches an external relay',
+  );
+  assert(
+    manifest.repository && /^https:\/\/github\.com\//.test(manifest.repository.url || ''),
+    'manifest must declare a public GitHub repository',
+  );
+});
+
 check('bundle packs into a loadable .mcpb archive', () => {
   const out = path.join(repoRoot, 'build', 'vibe-browser.mcpb');
   fs.rmSync(out, { force: true });

--- a/worklog/mcp-distribution-channels.md
+++ b/worklog/mcp-distribution-channels.md
@@ -2,6 +2,86 @@
 
 Research date: 2026-08-07. Read-only investigation. No product code changed.
 
+Execution status last updated: 2026-08-07. See [Execution status](#execution-status) for what
+actually shipped — that section is the source of truth; the analysis below it is the original
+research and is left unedited except where it was factually wrong (noted inline).
+
+---
+
+## Execution status
+
+| Channel | Status | Date | Evidence / link |
+|---|---|---|---|
+| **Official MCP Registry** | **LIVE** | 2026-08-07 | `io.github.VibeTechnologies/vibe-mcp` v0.3.2, `status: active`, `isLatest: true`. Verify: `curl -s --get --data-urlencode "search=io.github.VibeTechnologies/vibe-mcp" https://registry.modelcontextprotocol.io/v0/servers` |
+| **Own Claude Code marketplace** | **LIVE** | 2026-08-07 | `/plugin marketplace add VibeTechnologies/vibe-mcp` then `/plugin install vibe-browser@vibe-browser`. Catalog: `.claude-plugin/marketplace.json` |
+| **Anthropic Plugin Directory** (`claude-community`) | **BUILT, NOT SUBMITTED — blocked** | 2026-08-07 | Plugin at `plugins/vibe-browser/`, passes `claude plugin validate --strict`. Blocker below. |
+| **Anthropic MCPB directory** | **BUILT, NOT SUBMITTED — blocked** | 2026-08-07 | Bundle builds via `npm run build:mcpb`, passes `mcpb validate`, installs and completes an MCP handshake. Blockers below. |
+| npm | LIVE | 2026-08-07 | `@vibebrowser/mcp@0.3.2` |
+
+### What shipped
+
+- **MCP registry.** `@vibebrowser/mcp@0.3.2` was published to npm (the registry verifies package
+  ownership by reading `mcpName` from the *published* tarball, so npm must go first), then
+  `mcp-publisher publish` ran under GitHub Actions OIDC. Live since `2026-08-07T13:13:04Z`.
+  The publish job nevertheless went red on its final step: the verifier grepped the API response
+  for the literal string `vibebrowser`, but the registry's `search` filter matches the server
+  *name* (`io.github.VibeTechnologies/vibe-mcp`) — `vibebrowser` appears only in the description
+  and package identifier. Fixed to assert name + version + `status: active`.
+- **Claude Code plugin** (`plugins/vibe-browser/`): `plugin.json`, `.mcp.json` wrapping the
+  published npm package, and a `skills/setup/SKILL.md` that walks the user through installing the
+  Chrome extension — our worst onboarding blocker, since the server is only a relay and cannot
+  install the extension itself.
+- **Repo-as-marketplace** (`.claude-plugin/marketplace.json`): users can install today without
+  waiting on Anthropic's review queue. This was not in the original plan and is the reason the
+  directory blocker below is not a hard dependency for distribution.
+- **`.mcpb` bundle** (`mcpb/`): manifest per MCPB spec 0.3 plus a build that vendors the server
+  and its dependencies, so installing needs no network. 3.4 MB, 2309 entries.
+- **Tests** (`scripts/e2e-plugin-bundle.mjs`, in CI): runs `claude plugin validate --strict` (the
+  same validator Anthropic's review pipeline runs) and `mcpb validate`, packs a real archive, and
+  boots the bundled server exactly as `manifest.json` declares to complete a real MCP `initialize`
+  handshake over stdio.
+
+### Blockers (exact)
+
+**1. Both Anthropic submissions need an authenticated Anthropic account, and we do not have the
+company one.** The only submission routes are two in-app forms —
+`platform.claude.com/plugins/submit` (Console) and
+`claude.ai/admin-settings/directory/submissions/plugins/new` (Team/Enterprise) — plus a Google
+Form for MCPB at `clau.de/desktop-extention-submission` that records the signed-in Google
+identity. `anthropics/claude-plugins-community` is explicitly a **read-only mirror**, so there is
+no pull-request path.
+
+The only identity signed into this machine's Chrome is the founder's **personal** Google/Anthropic
+account, which company policy forbids using for project signups. The company account
+(`vibeteaichnologies@gmail.com`) has its password in Bitwarden, and the Bitwarden CLI is
+**unauthenticated** — `~/Library/Application Support/Bitwarden CLI/data.json` contains only
+`stateVersion`, and `~/.env.d/bitwarden.env` holds a stale `BW_SESSION` with no API key or master
+password. `gcloud` *is* authenticated as `vibeteaichnologies@gmail.com`, but only with
+cloud-platform scope, which cannot read that mailbox or mint a browser session.
+
+*Unblock:* `bw login` the company Bitwarden account, then sign into Chrome as
+`vibeteaichnologies@gmail.com` and submit both forms. Everything else is ready.
+
+**2. MCPB directory states "MIT licensed"; this repo is Apache-2.0.** The form lists MIT under
+what Anthropic is "primarily considering" — soft-worded, not an explicit hard gate, but it is a
+stated preference we currently fail. Relicensing is a founder/legal decision (it affects existing
+contributors and the `vibe` fork), so it was deliberately **not** changed here. Either accept the
+lower odds and submit as Apache-2.0, or decide to relicense first.
+
+### Corrections to the original research below
+
+- §8 item 2 claimed submitting the plugin form "Lands us in `claude-plugins-official`, which every
+  Claude Code user already has." **That is wrong.** Per Anthropic's current docs the form feeds
+  `claude-community` (users must add it with `/plugin marketplace add anthropics/claude-plugins-community`).
+  `claude-plugins-official` is curated by Anthropic at its own discretion and has **no application
+  process** — "the submission form does not add plugins to the official marketplace." The
+  auto-available-everywhere reach attributed to this channel does not exist; treat it as a normal
+  reviewed directory.
+- §8 item 1's premise that a publish "would fail validation" because `server.json` claimed 0.3.2
+  while npm had 0.3.1 was correct, and was resolved by publishing 0.3.2 rather than downgrading.
+
+---
+
 ## One-sentence answer
 
 **No, there is no store you must publish to** — every client that matters (Claude Code, Claude


### PR DESCRIPTION
Executes actions 2 and 3 from `worklog/mcp-distribution-channels.md`, and fixes a bug found while executing action 1.

## Action 1 — Official MCP registry: DONE (already live)
`@vibebrowser/mcp@0.3.2` published to npm, then `mcp-publisher publish` ran via the existing OIDC workflow. The server is live:

```
$ curl -s --get --data-urlencode "search=io.github.VibeTechnologies/vibe-mcp" \
    https://registry.modelcontextprotocol.io/v0/servers
name:    io.github.VibeTechnologies/vibe-mcp
version: 0.3.2
status:  active     isLatest: true
published: 2026-08-07T13:13:04Z
```

The publish job still went red, because the **verify step had a false negative**: it grepped the response for the hardcoded string `vibebrowser`, but the registry's `search` filter matches the server *name* (`io.github.VibeTechnologies/vibe-mcp`) — `vibebrowser` only appears in the description and package identifier. This PR rewrites that step to assert name + version + `status: active`.

## Action 2 — Claude Code plugin
`plugins/vibe-browser/` with `plugin.json`, `.mcp.json`, and a `skills/setup/SKILL.md` that walks the user through installing the Chrome extension (the server is a relay and needs it, but can't install it).

Also adds `.claude-plugin/marketplace.json` so this repo is itself an installable marketplace — users can install today without waiting on directory review:

```
/plugin marketplace add VibeTechnologies/vibe-mcp
/plugin install vibe-browser@vibe-browser
```

> Correction to the research doc: the submission form feeds `claude-community`, **not** `claude-plugins-official`. Per Anthropic's current docs the official marketplace is curated at their discretion and has *no* application process. The doc is updated accordingly.

## Action 3 — `.mcpb` desktop bundle
`mcpb/manifest.json` (spec 0.3) + `mcpb/build.mjs`, which vendors the server and its runtime deps so installing needs no network. The build refuses to run on version drift between the manifest and `package.json`. Produces a 3.4 MB / 2309-entry archive.

## Testing
`scripts/e2e-plugin-bundle.mjs`, wired into CI as its own step (kept out of `test:ci` because it needs network):

- `claude plugin validate --strict` on the plugin **and** the marketplace — the same validator Anthropic's review pipeline runs
- `mcpb validate`, then packs a real archive and asserts its internal layout
- **boots the bundled server exactly as `manifest.json` declares and completes a real MCP `initialize` handshake over stdio**
- resolves the Chrome Web Store link in the setup skill, so a dead listing fails the build
- cross-checks version agreement across `package.json`, `plugin.json`, `.mcp.json`, `marketplace.json`, and the bundle manifest

Local run: `e2e ok - 12 checks passed`.

Per #1856, these are **not** synthetic-fixture tests. Each was mutation-tested — breaking the `.mcp.json` version pin and the bundle `entry_point` each produced the expected failures, and reverting restored green.