### PR TITLE
docs: Codex MCP config is TOML not JSON; cover ChatGPT desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,20 +237,29 @@ Add to `~/.gemini/settings.json`:
 </details>
 
 <details>
-<summary><strong>OpenAI Codex CLI</strong></summary>
+<summary><strong>OpenAI Codex CLI / ChatGPT desktop app / Codex IDE extension</strong></summary>
 
-Add to your Codex configuration:
+All three share one config file: `~/.codex/config.toml`. Configure once, use everywhere.
 
-```json
-{
-  "mcp": {
-    "vibe": {
-      "command": "npx",
-      "args": ["-y", "@vibebrowser/mcp"]
-    }
-  }
-}
+Easiest — let Codex write the entry:
+
+```bash
+codex mcp add vibe -- npx -y @vibebrowser/mcp
 ```
+
+Or add the table to `~/.codex/config.toml` by hand (Codex uses **TOML**, not JSON):
+
+```toml
+[mcp_servers.vibe]
+command = "npx"
+args = ["-y", "@vibebrowser/mcp"]
+```
+
+In the ChatGPT desktop app you can also use the UI: **Settings → MCP servers → Add server**, choose **STDIO**, command `npx`, args `-y @vibebrowser/mcp`, then **Restart**.
+
+Verify with `codex mcp list`, or type `/mcp` in the Codex TUI or the desktop composer.
+
+> ChatGPT on the web does not read local Codex config, so a local MCP server like Vibe is not available there.
 
 </details>
 


### PR DESCRIPTION
## The bug

The README's **OpenAI Codex CLI** section told users to add:

```json
{ "mcp": { "vibe": { "command": "npx", "args": ["-y", "@vibebrowser/mcp"] } } }
```

Codex has never accepted that shape. It reads `~/.codex/config.toml` and expects a `[mcp_servers.<name>]` **TOML** table. Anyone following our README got a server that silently never loaded — no error, just missing tools.

## Evidence

- https://developers.openai.com/codex/extend/mcp (fetched 2026-08-07):
  > "Codex stores MCP configuration in `config.toml` … By default this is `~/.codex/config.toml`"
  > "Configure each MCP server with a `[mcp_servers.<server-name>]` table in the configuration file."
- Cross-checked against a real working `~/.codex/config.toml`.

## Changes

- Correct snippet → `[mcp_servers.vibe]` TOML.
- Document `codex mcp add vibe -- npx -y @vibebrowser/mcp` as the easy path.
- Section retitled to **OpenAI Codex CLI / ChatGPT desktop app / Codex IDE extension** — the same doc confirms all three support MCP and share `~/.codex/config.toml`. We already work in all three; we just never said so.
- Add the desktop UI path (Settings → MCP servers → Add server → STDIO → Restart).
- Add verification steps (`codex mcp list`, `/mcp`).
- Note that ChatGPT **web** is out of scope, since it does not read local Codex config.

Paired with VibeBrowserProductPage#219, which fixes the same wrong snippet on the live `/integrations/openai-codex-cli` SEO page and adds `/integrations/chatgpt-desktop`.

Docs-only; no runtime code touched.