### PR TITLE
docs: add the remote-connector path for hosted assistants (Claude web/Cowork, ChatGPT web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,53 @@ npx -y -p @vibebrowser/mcp@latest vibebrowser-mcp --help
 npx -y -p @vibebrowser/mcp@latest vibe-mcp --help
 ```
 
+### Remote connector (hosted assistants — no install)
+
+Everything above assumes the client can spawn a local process. Hosted
+assistants cannot: Claude on the web / in Cowork / on mobile, and ChatGPT on
+the web, run in the vendor's cloud with no access to your machine. They accept
+a **remote MCP server URL** and nothing else — no command, no arguments, and
+no custom request headers.
+
+For those, skip `@vibebrowser/mcp` entirely. The extension alone is enough:
+
+```
+https://relay.api.vibebrowser.app/mcp/<your-extension-uuid>
+```
+
+Find `<your-extension-uuid>` in the extension: **Vibe icon → Settings → Agent
+connection URL**. It is the same UUID the CLI takes as
+`--remote wss://relay.api.vibebrowser.app/<uuid>`.
+
+Where to paste it:
+
+| Client | Where |
+|---|---|
+| Claude (web, Cowork, mobile, Desktop) | Settings → Connectors → Add custom connector |
+| ChatGPT (web) | Settings → Connectors → developer mode |
+
+Custom connectors are a paid-plan feature in both products.
+
+The relay also accepts the UUID as an `X-Remote-Session` or
+`Authorization: Bearer` header on a bare `POST /mcp`. Use the header form from
+anything that can send one (Codex CLI, scripts) — it keeps the credential out
+of URLs, logs, and browser history. The path form exists specifically for the
+UIs that cannot send a header.
+
+**Two things this path costs you, stated plainly:**
+
+1. **The URL is a credential.** Anyone who has that UUID can drive your
+   logged-in browser — read your mail, act as you on any site you are signed
+   into. Treat it exactly like a password: never commit it, never paste it into
+   a shared chat, an issue, a README, or a screenshot. If it leaks, revoke the
+   session in the extension and generate a new one. (This is not hypothetical:
+   a dev machine's UUID once shipped in these very docs.)
+2. **Page content leaves your machine.** On the local STDIO path, tool calls
+   and page content never leave `127.0.0.1`. On the remote-connector path they
+   traverse `relay.api.vibebrowser.app`, because the assistant is in the
+   vendor's cloud and has no other route to your browser. If you need
+   on-device-only, use a desktop client with the local server instead.
+
 ### 3. Connect the Extension
 
 1. Open Chrome with the Vibe extension installed


### PR DESCRIPTION
Closes #121 (the agent-doable half — the listings themselves are founder-gated, see below).

## Why

Every setup path in the README assumes the client can spawn a local process (`npx -y @vibebrowser/mcp`). Hosted assistants can't:

| Client | Can spawn a local process? | Can send a custom header? |
|---|---|---|
| Claude web / Cowork / mobile | No | No |
| ChatGPT web | No | No |
| Claude Desktop, Codex CLI, Cursor, VS Code | Yes | Yes |

So a user on any hosted surface read this README and found nothing applicable. The Notion backlog logged this as "publish vibebrowser-mcp as a connector" and assumed the blocker was that the relay wasn't publicly reachable. It has been — `https://relay.api.vibebrowser.app/mcp` is live. The blocker was that `/mcp` only read the UUID from a **header**, which those UIs cannot send. Fixed in VibeTechnologies/platform#64.

## What

A "Remote connector (hosted assistants — no install)" section: the bare URL, where to find the UUID (extension Settings → Agent connection URL, VibeWebAgent#1832), and a table of where each product wants it pasted.

It also keeps steering header-capable clients to the header form — that keeps the credential out of URLs, shell history, and logs. The path form is documented as existing *for the UIs that have no alternative*, not as the new default.

## The two warnings are deliberate and load-bearing

1. **The URL is a credential.** It grants live control of a logged-in browser. A dev machine's UUID already shipped in these docs once — that incident is what produced the relay audit-logging work. Saying "treat it like a password" once, in the section that hands people a pasteable URL, is the cheapest possible guard.
2. **Page content leaves the machine on this path.** The README advertises "Local by default" a few sections up. That claim is true for STDIO and false here, and letting it carry over silently would be a privacy misrepresentation, not a doc nit.

## Not in this PR (needs a human)

- Adding the connector inside Claude requires signing into claude.ai — standing founder directive says agents must not.
- Adding it in ChatGPT requires the founder's OpenAI account.
- Any public connector-directory submission is a brand/launch call.