### PR TITLE
docs: OpenAI verification pack + hosted-demo-browser recommendation

### DIFF
--- a/worklog/mcp-distribution-channels.md
+++ b/worklog/mcp-distribution-channels.md
@@ -250,3 +250,213 @@ Directory listings are discovery. Distribution already works.
 `<uuid>` comes from the extension: Settings → external agent control → Remote
 (internet) → Agent connection URL. It grants full control of that browser —
 never log, screenshot, or paste it anywhere else.
+
+---
+
+## 7. Update — 2026-08-08: what moved, and one correction
+
+Three things changed since §0–§6 were written, and one claim in them is now
+wrong. Read this section before acting on anything above.
+
+### 7.1 The OAuth gap in §4 is closed (shipped)
+
+§4 estimated ~4 engineering days for OAuth 2.1 + DCR. It landed in
+platform#67/#68. Measured against production today — all FACT:
+
+| Probe | Result |
+|---|---|
+| `POST /mcp` unauthenticated | `401` |
+| `WWW-Authenticate` on that `401` | `Bearer resource_metadata="https://relay.api.vibebrowser.app/.well-known/oauth-protected-resource", scope="browser:read browser:control"` |
+| `/.well-known/oauth-protected-resource` | `200` |
+| `/.well-known/oauth-authorization-server` | `200` |
+
+So we now have a **universal URL**: `https://relay.api.vibebrowser.app/mcp`.
+That removes the template-URL disqualifier §2 flagged for OpenAI, and the
+`custom_connection` special-casing §2 flagged for Anthropic. Treat §4 as a
+record of the design, not as outstanding work.
+
+### 7.2 Domain verification is now possible (shipped)
+
+`/.well-known/openai-apps-challenge` returned `404` in §1's probe table. It is
+now implemented and live (platform#69). Details, and the full business-
+verification pack, are in `openai-verification-pack.md`. Summary of the
+requirement, since §2 left it vague: it is a **`.well-known` HTTPS file only —
+there is no DNS TXT record**, and the file must return the bare token as
+`text/plain` with no JSON envelope.
+FACT — <https://developers.openai.com/plugins/deploy/submission#domain-verification>
+
+### 7.3 Correction: annotations are NOT done on the path that matters
+
+vibe-mcp#125 added a full annotation table (`src/tool-annotations.ts`) and the
+follow-up commit recorded the blocker as closed. **On the hosted endpoint it is
+not.** FACT, read from source today:
+
+- The relay does not own a tool list. `handleMcpToolsList` proxies whatever the
+  connected extension reports — `session.tools`, else a `list_tools` round-trip.
+  `platform/subscriptions/relay-service/server.js`
+- The extension's tool shape is `McpServerToolDefinition { name, description,
+  inputSchema }` — **no `title`, no annotations**.
+  `vibe/lib/mcp/server/types.ts:97`
+- `grep -c 'readOnlyHint|destructiveHint|annotations'` over the relay source and
+  over `vibe/lib/mcp/` both return **0**.
+
+`tool-annotations.ts` is applied by the **npm stdio package**. Both directories
+scan the **remote** endpoint, which is fed by the extension. So the endpoint
+OpenAI and Anthropic actually inspect still advertises zero annotations, and
+hard-fails both:
+
+- Anthropic: "Every tool must include a `title` and the applicable hint."
+- OpenAI: "Every tool has accurate `readOnlyHint`, `openWorldHint`, and
+  `destructiveHint` values."
+
+**Cheapest fix: enrich in the relay, not the extension.** The relay already
+mediates `tools/list`; it can join the extension's tool names against the same
+classification table and emit `title` + hints. That is a relay deploy (minutes)
+versus an extension change that must clear Chrome Web Store review (days, and
+users must update). Do this before anything in §8.
+
+---
+
+## 8. Hosted demo browser for reviewers — assessment and recommendation
+
+The question: reviewers install nothing, so our tools have no browser to drive.
+Do we have to host one?
+
+### 8.1 Does each directory actually require working tools?
+
+**Anthropic — NO, not to get listed.** FACT
+(<https://claude.com/docs/connectors/building/review-criteria>):
+
+> When you submit a server, it is automatically scanned for policy compliance
+> and, **by default, listed in the directory as a community connector**.
+> Anthropic may then escalate listings flagged as highly useful ... to verified
+> review, which is higher touch and slower; **reviewers run a functional test of
+> each tool**. This escalation is assessed automatically, and you do not need to
+> take any action.
+
+A human functional test happens only on an escalation we cannot request and do
+not control. "Test credentials ... must be a fully populated account" is a
+stated submission field, and "every tool must return a successful response when
+called with valid parameters" is a stated criterion — but the default path to a
+community listing is an automated policy scan, not a tool-by-tool exercise.
+
+**OpenAI — YES, hard, in three independent places.** FACT
+(<https://developers.openai.com/plugins/deploy/submission>):
+
+1. **`Scan Tools` cannot populate the draft.** Our relay answers `tools/list`
+   with JSON-RPC error `-32002` when no extension is connected. The portal
+   imports tool metadata by scanning the live endpoint, so with no browser
+   attached the submission cannot even be *built*, let alone reviewed.
+2. **Five positive and three negative test cases**, which reviewers run.
+3. Credentials must work "without MFA, email confirmation, SMS confirmation, or
+   **private-network access**", and the single most-cited rejection reason is
+   *"We're unable to connect to your MCP server using the MCP URL and/or test
+   credentials we were given."*
+
+Docs and a video do **not** substitute for either directory. Neither offers a
+documentation-only route.
+
+**Consequence:** a demo browser is required for OpenAI only. Building one to
+reach Anthropic's directory would be unjustified.
+
+### 8.2 Cheapest viable design (if we proceed for OpenAI)
+
+Our architecture already solves the hard part. The extension dials **outbound**
+to the relay; nothing needs an inbound port. So the demo browser can live
+anywhere with egress and does not need to be a hosted service at all.
+
+**Ephemeral CI session, on demand:**
+
+- Reuse `vibe/tests/cua/` — it already runs Xvfb + real Chrome with the
+  extension loaded, and four CUA workflows depend on it today. This is existing,
+  working, exercised code, not a new system.
+- Add a `workflow_dispatch` job that starts Chrome + extension, registers a
+  **pre-provisioned review session UUID**, and idles for the job's lifetime.
+- A GitHub-hosted job caps at 6 hours, which gives the time box for free — the
+  session cannot outlive the window even if we forget to tear it down.
+- Trigger it for an announced review window; revoke the session afterwards by
+  regenerating it (the relay already supports revocation, per §3).
+
+**Capacity, if we instead used the existing cluster** (measured today):
+3 nodes × 2 vCPU; memory at 35% / 51% / 72%, so roughly 2.5 GB free on the
+least-loaded node. Chrome plus the extension needs ~1–1.5 GB and bursts CPU.
+One concurrent session would fit. **We should still not do it — see 8.4.**
+
+### 8.3 Cost — honest number
+
+No new paid services and no new cloud spend under either option.
+
+| Option | Cash | Real cost |
+|---|---|---|
+| Ephemeral CI session | $0 new | GitHub Actions minutes. `VibeWebAgent` is **private**, so minutes are metered: ~360 per 6-hour window at the 1× Linux rate. A realistic review needs several windows — call it **1,000–2,000 minutes**, drawn from the existing plan allowance. |
+| Existing k8s cluster | $0 new | No minutes, spare capacity exists — but see 8.4. |
+
+So: it can be done with **no new spend**, but "free" overstates it for the CI
+option — it consumes an existing metered budget. If that allowance is exhausted,
+overage is billed per-minute; that is the only path to real money here.
+
+### 8.4 Security — the part that decides this
+
+An agent-drivable browser is a serious abuse surface. Enumerated:
+
+| # | Risk | Why it is real here |
+|---|---|---|
+| 1 | **SSRF into our own infrastructure** | Our toolset includes `evaluate_script` (arbitrary JS) and `web_fetch` (arbitrary URL). A browser inside our cluster can reach the cloud metadata endpoint (`169.254.169.254`) and cluster-internal services, escalating toward node credentials — in a cluster that holds `vibe-secrets`, LiteLLM, and the Stripe service. **This is the dominant risk and it is created purely by the "keep it free, put it on the existing cluster" choice.** |
+| 2 | Open proxy / anonymising egress | Anyone holding the token browses arbitrary sites from our IP: illegal content, abuse, fraud. Our IP and cloud account carry the consequences. |
+| 3 | Credential harvesting | Anthropic asks for a "fully populated account". Any real logged-in session in the demo profile is readable via `get_page_content` / `take_screenshot` by whoever holds the token. |
+| 4 | Token leakage | The session id is a bearer capability in a URL (§3). Review URLs get pasted into portals, tickets and screenshots. |
+| 5 | Noisy neighbour | Chrome on a 2-vCPU node beside the production relay can degrade the live product. |
+
+Required mitigations, all of them, not a subset:
+
+- Run **off** the production cluster; never in a namespace that can see
+  `vibe-secrets`.
+- **Egress allowlist** to the handful of benign domains the test cases need.
+  This is the single highest-value control: an allowlisted browser is not an
+  open proxy, which collapses risks 1 and 2.
+- Block link-local and RFC1918 (`169.254/16`, `10/8`, `172.16/12`, `192.168/16`).
+- **No real credentials** in the demo profile — use a throwaway account on a
+  property we control.
+- Live only during an announced review window; revoke the session afterwards.
+- Hard wall-clock cap and per-session rate limiting.
+
+### 8.5 Recommendation
+
+**Do not build a general hosted browser. Recommend AGAINST the persistent,
+open, cluster-hosted version outright.** It is free in cash and expensive in
+risk: a tool that executes arbitrary JavaScript, running inside the cluster that
+holds our production secrets, is a plausible metadata-service SSRF path to those
+secrets. No directory listing justifies that.
+
+**Do not build anything for Anthropic.** Community listing is automatic (8.1);
+the functional test only happens on an escalation we cannot request. There is no
+demo-browser-shaped blocker there to solve.
+
+**For OpenAI only, build the narrow version**: an ephemeral, allowlisted,
+credential-free CI session (8.2), live only during a review window. Scoped that
+way it is not a hosted browser product — it is a test fixture that happens to be
+reachable, and the abuse surface is small enough to accept.
+
+**Sequence it last.** §7.3 is the binding constraint: the hosted endpoint
+advertises no annotations, and both directories reject on that alone. A demo
+browser built today would let a reviewer connect to a server that still fails
+the checklist. Fix annotations in the relay first (hours), then reconsider the
+demo session. Do not open an OpenAI submission before both are done — only one
+version may be in review at a time, and the queue has no published SLA, so a
+predictable rejection is expensive.
+
+### 8.6 Revised order (supersedes §5)
+
+1. **Emit `title` + annotations from the relay's `tools/list`** (§7.3). Hours,
+   not days; unblocks every reviewed directory.
+2. Publish the privacy policy in the MCPB manifest + README, then submit
+   **MCPB** and **Plugin** directories — neither needs a demo browser.
+3. Submit **Anthropic Connectors**. Community listing is automatic; no demo
+   browser required.
+4. Complete OpenAI **business verification** and paste the domain token
+   (`openai-verification-pack.md` §4) — the endpoint is already live.
+5. Only then, build the narrow ephemeral demo session (8.2/8.4) and submit to
+   **OpenAI**.
+
+Steps 1–4 need no new infrastructure and carry no security risk. Step 5 is the
+only one that does, and it is last for that reason.

--- a/worklog/openai-verification-pack.md
+++ b/worklog/openai-verification-pack.md
@@ -1,0 +1,265 @@
+# OpenAI Plugins Directory — verification pack
+
+Everything an authorised founder needs to complete OpenAI domain verification
+and business verification for **vibe-mcp**, in one place, so the portal session
+is copy-paste rather than research.
+
+Assembled **2026-08-08**. Companion to `mcp-distribution-channels.md` (PR #124),
+which holds the channel-by-channel assessment; this file holds only the OpenAI
+submission inputs.
+
+Every row is marked **FACT** (from a cited official source, our own filed
+documents, or measured against production today) or **ASSUMPTION**. Do not
+paste an ASSUMPTION into a verification form without checking it.
+
+---
+
+## 0. Two different verifications — do not conflate them
+
+The portal gates a submission on two independent checks. They fail for
+different reasons and are fixed in different places.
+
+| | Domain verification | Business verification |
+|---|---|---|
+| Proves | We control the host serving the MCP endpoint | We are a real, named legal entity |
+| Mechanism | A token served over HTTPS at a well-known path | Identity documents reviewed by OpenAI |
+| Where it happens | Our infrastructure (**done — §2**) | OpenAI Platform org settings (**founder-only — §4**) |
+| Blocking on | Nothing; awaiting the portal-minted token | Founder account access |
+
+**There is no DNS TXT record involved in either.** This is worth stating
+explicitly because most directory verifications (Google, Microsoft, Brevo — all
+three of which appear in our apex TXT records today) use DNS. OpenAI does not:
+it is an HTTPS file fetch only.
+FACT — <https://developers.openai.com/plugins/deploy/submission#domain-verification>
+
+---
+
+## 1. What domain verification actually requires
+
+Quoting the current docs:
+
+> Plugins with MCP must verify control of the domain that hosts the server.
+> When the portal shows a domain verification challenge, place the exact
+> verification token at the generated well-known URL:
+> `https://<challenge-base-host>/.well-known/openai-apps-challenge`
+
+and:
+
+> The challenge endpoint must return only that plugin's verification token. Do
+> not return JSON, a list of tokens, or multiple tokens from the same URL.
+
+FACT — <https://developers.openai.com/plugins/deploy/submission#domain-verification>
+
+So the complete requirement is:
+
+1. A single HTTPS `GET` endpoint at `/.well-known/openai-apps-challenge`
+2. Body = the exact token, and **nothing else** — no JSON envelope, no list
+3. Hosted on the MCP host name **or a parent host name** (paths are ignored)
+
+### Which host we must serve it from
+
+Our MCP host is `relay.api.vibebrowser.app`. Candidate challenge bases:
+
+| Candidate | Valid per docs? | Serves cleanly? | Verdict |
+|---|---|---|---|
+| `relay.api.vibebrowser.app` | yes — the host itself, and the portal default | yes | **chosen** |
+| `api.vibebrowser.app` | yes — parent | no service listening | rejected |
+| `vibebrowser.app` | yes — parent | **307 → `www.vibebrowser.app`** (measured) | rejected |
+| `www.vibebrowser.app` | **no** — sibling of the MCP host, not a parent | yes | ineligible |
+
+The apex looks like the obvious home for a `.well-known` file, and it is the
+wrong answer: it redirects to `www`, and `www.vibebrowser.app` is **not** a
+parent of `relay.api.vibebrowser.app` — it is a sibling. Serving from the relay
+host itself is both redirect-free and what the portal checks by default.
+
+FACT — apex redirect measured 2026-08-08:
+`curl -sI https://vibebrowser.app/privacy` → `307` → `https://www.vibebrowser.app/privacy`
+
+---
+
+## 2. Domain verification — status: **infrastructure complete**
+
+Shipped in **VibeTechnologies/platform#69** (merged 2026-08-08).
+
+| Item | Value |
+|---|---|
+| Endpoint | `https://relay.api.vibebrowser.app/.well-known/openai-apps-challenge` |
+| Implementation | `subscriptions/relay-service/server.js`, routed before OAuth and `/mcp` |
+| Response when configured | `200`, `Content-Type: text/plain; charset=utf-8`, body = exact token, no trailing newline |
+| Response when unconfigured | `404` — deliberately **not** an empty `200` |
+| Token source | env `OPENAI_APPS_CHALLENGE_TOKEN` → k8s secret `vibe-secrets` (`optional: true`) |
+| Tests | `subscriptions/relay-service/tests/relay-openai-apps-challenge.test.mjs` — real server, real HTTP, 10 assertions |
+
+Why the token is injected rather than committed: the portal mints it **per
+plugin**, so a committed value would need a code change plus an image rebuild
+to rotate. Why unset returns `404` rather than an empty `200`: an empty body
+would present to the verifier as a valid-but-wrong token and could burn a
+verification attempt.
+
+### The one remaining action
+
+The token does not exist until the portal generates it, so this cannot be
+completed without the founder's OpenAI account. Exact remaining step:
+
+1. Open <https://platform.openai.com/plugins> → the vibe-mcp draft → **MCP** tab.
+2. Copy the value shown under the **Domain not verified** challenge.
+3. Set it as the repo secret `OPENAI_APPS_CHALLENGE_TOKEN` in
+   `VibeTechnologies/platform` (flows into `.env.secrets.prod` → `vibe-secrets`),
+   or hand the token over for an immediate `kubectl patch` of `vibe-secrets` in
+   the `vibe` namespace — the deployment already reads the key.
+4. Confirm the endpoint echoes it:
+   `curl -s https://relay.api.vibebrowser.app/.well-known/openai-apps-challenge`
+5. Press **Verify** in the portal.
+
+No code change is required at any point in that sequence.
+
+---
+
+## 3. Business-verification pack
+
+### 3.1 Legal entity
+
+Source: Washington Secretary of State Initial Report filed 2025-11-10 (Work
+Order #2025110600842248-1). FACT.
+
+| Field | Value |
+|---|---|
+| Legal name | VIBE TECHNOLOGIES, LLC |
+| Entity type | Washington domestic limited liability company |
+| Jurisdiction | State of Washington, United States |
+| Washington UBI | 606 003 933 |
+| Federal EIN | 41-2492929 |
+| D-U-N-S | 142059652 (Active, Single Location) |
+| Formation / effective date | 2025-11-10 |
+| Nature of business | Professional, Scientific & Technical Services |
+| Best-fit NAICS | 541511 — Custom Computer Programming Services (**ASSUMPTION**: not stated on the certificate) |
+
+### 3.2 Addresses and officers
+
+| Field | Value |
+|---|---|
+| Principal office | 519 S Henderson St, Seattle, WA 98108-4522, United States |
+| Mailing address | same as principal office |
+| Registered agent | Dzianis Vashchuk, 519 S Henderson St, Seattle, WA 98108-4522 (consent on file) |
+| Governor / officer | Dzianis Vashchuk, Governor, individual |
+| Company phone | 360-504-8967 |
+| Company email | `vibeteaichnologies@gmail.com` (note the intentional `eai` spelling — matches the WA SOS filing) |
+
+### 3.3 Public URLs required by the listing form
+
+All measured live 2026-08-08. FACT.
+
+| Form field | URL | Status |
+|---|---|---|
+| Website | `https://vibebrowser.app` | `200` (via `www`) |
+| Privacy policy | `https://www.vibebrowser.app/privacy` | `200` |
+| Terms of service | `https://www.vibebrowser.app/terms` | `200` |
+| Product / support page | `https://www.vibebrowser.app/mcp` | `200` |
+| Support contact | `info@vibebrowser.app` | published on the privacy page |
+| Source repository | `https://github.com/VibeTechnologies/vibe-mcp` | public |
+
+**Consistency requirement.** The docs state reviewers *"use this identity to
+confirm the submission matches the name, website, support contact, privacy
+policy, and terms in your public listing."* The publisher name entered in the
+portal must therefore read **VIBE TECHNOLOGIES, LLC** — matching the entity
+verified in org settings — and the same entity name should be discoverable on
+the privacy and terms pages. **ASSUMPTION, unverified:** the live privacy/terms
+pages may still name the product rather than the LLC. Worth one look before
+submitting, because a mismatch here is a stated rejection reason.
+FACT (the requirement) — <https://developers.openai.com/plugins/deploy/submission>
+
+### 3.4 Product description (paste-ready)
+
+**Name:** Vibe MCP — Real Chrome, Remotely
+
+**Short description (≤ ~120 chars):**
+> Let ChatGPT drive your own logged-in Chrome — read pages, fill forms, and take screenshots in your real browser session.
+
+**Long description:**
+> Vibe MCP connects ChatGPT to the Chrome browser you already use, with the
+> sessions you are already signed in to. Instead of a fresh, anonymous cloud
+> browser that hits a login wall on every useful site, the assistant works in
+> your real profile: it can open and switch tabs, read page content, take
+> screenshots and accessibility snapshots, click, type, fill forms, wait for
+> page state, and inspect network requests and console output.
+>
+> A browser extension holds the session and connects outbound to a hosted relay,
+> so nothing needs to be exposed on the user's machine and no inbound port is
+> opened. Every tool call is scoped to the browser session the user explicitly
+> connected, and the user can revoke access at any time by regenerating the
+> session in the extension.
+
+**Category:** Productivity / Developer tools (**ASSUMPTION** — pick from the
+portal's actual list at submission time).
+
+### 3.5 MCP server details
+
+| Field | Value | Note |
+|---|---|---|
+| URL type | **Universal** | `https://relay.api.vibebrowser.app/mcp` — a single fixed URL that works for all users |
+| Authentication | OAuth 2.1 + Dynamic Client Registration | live; see §3.6 |
+| Origin | `https://relay.api.vibebrowser.app` | **immutable after publication** — the docs state the origin cannot change between versions; changing it requires submitting a wholly new plugin |
+| Content security policy | not applicable | the server returns no UI; per the docs, do not attach screenshots for a no-UI plugin |
+
+Choosing **Universal** matters. The registry entry advertises a per-session
+template URL (`/mcp/{session_id}`), and template URLs are supported *"only for
+trusted developers with whom we have an established relationship"* — so
+submitting the template shape would be rejected on that ground alone. The OAuth
+work below is what makes a single universal URL viable.
+FACT — <https://developers.openai.com/plugins/deploy/app-review#template-mcp-server-urls>
+
+### 3.6 Auth posture — measured live 2026-08-08
+
+| Probe | Result |
+|---|---|
+| `POST /mcp` unauthenticated | `401` |
+| `WWW-Authenticate` on that `401` | `Bearer resource_metadata="https://relay.api.vibebrowser.app/.well-known/oauth-protected-resource", scope="browser:read browser:control"` |
+| `/.well-known/oauth-protected-resource` | `200` |
+| `/.well-known/oauth-authorization-server` | `200` |
+
+All FACT. Shipped in platform#67 / #68. This clears the universal-URL blocker
+recorded in `mcp-distribution-channels.md` §4, which was written before those
+merged — treat that section as superseded.
+
+---
+
+## 4. What only the founder can do
+
+Neither item below is a research gap; both are account-access gates.
+
+| # | Action | Where | Prepared for you |
+|---|---|---|---|
+| 1 | Complete **business verification** under the name VIBE TECHNOLOGIES, LLC | <https://platform.openai.com/settings/organization/general> → business verification | Entity data, §3.1–3.2 |
+| 2 | Grant the submitter **Apps Management = Write** | <https://platform.openai.com/settings/organization/people/roles> | — |
+| 3 | Copy the domain challenge token into `OPENAI_APPS_CHALLENGE_TOKEN` | portal → repo secret | Endpoint already live, §2 |
+
+Publish under a **business** identity, not an individual one: the listing
+should read VIBE TECHNOLOGIES, LLC to match the privacy policy and terms.
+Individual verification would create exactly the publisher/listing mismatch the
+docs call out as a rejection reason.
+
+Also note, before creating the draft: *"projects with EU data residency cannot
+submit plugins with MCP servers for review"* — use a global-data-residency
+project. FACT — <https://developers.openai.com/plugins/deploy/app-review>
+
+---
+
+## 5. Still blocking submission (not verification)
+
+Verification is necessary, not sufficient. Two items still fail the review
+checklist and are tracked in `mcp-distribution-channels.md`:
+
+1. **Tool annotations are absent on the hosted path.** `tool-annotations.ts`
+   (vibe-mcp#125) covers the npm **stdio** package only. The relay proxies
+   `tools/list` straight through from the browser extension, whose
+   `McpServerToolDefinition` carries no `title` and no hints — so the endpoint
+   OpenAI actually scans still advertises none. FACT — read from
+   `platform/subscriptions/relay-service/server.js:handleMcpToolsList` and
+   `vibe/lib/mcp/server/types.ts:97`.
+2. **A reviewer has no browser to drive**, so `Scan Tools` and all eight test
+   cases fail. See the demo-browser recommendation in
+   `mcp-distribution-channels.md`.
+
+Do not open a submission until both are resolved: a rejection consumes the
+review slot ("only one version may be in review at a time") and the queue has
+no published SLA.


### PR DESCRIPTION
Follow-up to #124. Two directory-submission prerequisites, assessed against **freshly fetched** official docs and **measured against production today**.

## TASK A — domain + business verification

**Domain verification is a `.well-known` HTTPS file only — there is no DNS TXT record.** Worth stating plainly: our apex already carries Google, Microsoft and Brevo TXT verifications, so "add a TXT record" is the natural but wrong assumption.

The DNS/hosting half is **done and live** — `VibeTechnologies/platform#69`:

```
$ curl -s https://relay.api.vibebrowser.app/.well-known/openai-apps-challenge
{"error":"Domain verification token not configured"}     # new handler, deployed

$ curl -s https://relay.api.vibebrowser.app/.well-known/nope
Not found                                                # generic 404 — proves the above is ours
```

Returns `200 text/plain` with the bare token once `OPENAI_APPS_CHALLENGE_TOKEN` is set; `404` while unset, deliberately never an empty `200` (an empty body reads as a valid-but-wrong token and could burn a verification attempt).

**Why the relay host, not the apex:** the apex `307`s to `www.vibebrowser.app`, and `www` is a *sibling* of the MCP host, not a parent — so it is ineligible as a challenge base. The relay host is redirect-free and is the portal's default.

`worklog/openai-verification-pack.md` (new) holds the business-verification pack: entity data (UBI, EIN, D-U-N-S, registered agent), public URLs all measured `200` today, support contact, a paste-ready product description, and the MCP server details — including why we must submit **Universal** rather than **Template**.

## §7 — corrections to #124

- **The OAuth gap is closed.** platform#67/#68 shipped; `/mcp` now returns `401` with a correct `WWW-Authenticate: Bearer resource_metadata=...` and both OAuth well-knowns return `200`. We have a universal URL, which removes the template-URL disqualifier. §4 is now a design record, not a TODO.
- **Correction — annotations are NOT done on the path that matters.** vibe-mcp#125 annotated the npm **stdio** package. The relay proxies `tools/list` straight from the extension, whose `McpServerToolDefinition` has no `title` and no hints, so the endpoint both directories actually scan still advertises **zero** annotations. Cheapest fix is to enrich in the **relay** (a deploy) rather than the extension (a Chrome Web Store release).

## TASK B — demo browser: recommendation

**Anthropic does not require working tools to be listed.** Submissions are auto-scanned and listed as community connectors *by default*; a functional per-tool test happens only on an escalation we cannot request. **Recommend building nothing for Anthropic.**

**OpenAI does require them**, in three independent places — most sharply, `Scan Tools` cannot even *populate* the draft, because our relay errors `-32002` on `tools/list` with no extension connected.

**Recommend AGAINST a persistent, cluster-hosted browser.** Our toolset includes `evaluate_script` (arbitrary JS) and `web_fetch` (arbitrary URL). A browser inside the cluster that holds `vibe-secrets` is a plausible metadata-service (`169.254.169.254`) SSRF path to production secrets. Free in cash, not worth the risk — and that risk is created purely by the "keep it free, reuse the existing cluster" choice.

**For OpenAI only, build the narrow version:** an ephemeral, allowlisted, credential-free session reusing the existing `vibe/tests/cua/` Xvfb+Chrome harness, exploiting the fact that the extension dials **outbound** so no inbound port is needed. A 6h job cap gives the time box for free.

**Cost, honestly:** no new paid services and no new cloud spend either way — but "free" overstates it. `VibeWebAgent` is private, so it consumes ~360 metered Actions minutes per 6h window (~1,000–2,000 for a realistic review) from the existing allowance.

**Sequenced last**, behind the annotations fix, so we never open a submission that is already guaranteed to be rejected — only one version may be in review at a time and the queue has no published SLA.

Docs-only; no code paths touched.