### PR TITLE
fix(relay): answer the extension heartbeat so the socket stops churning every 30s

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "vibe-browser",
       "source": "./plugins/vibe-browser",
       "description": "Drive your real, logged-in Chrome from Claude Code. Navigate, click, type, screenshot and read pages in the browser you already use - including a browser on a different machine, with no inbound port open.",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "author": {
         "name": "Vibe Technologies",
         "url": "https://vibebrowser.app"

--- a/mcpb/build.mjs
+++ b/mcpb/build.mjs
@@ -40,6 +40,30 @@ function run(cmd, args, opts = {}) {
 fs.rmSync(stageDir, { recursive: true, force: true });
 fs.mkdirSync(path.join(stageDir, 'server'), { recursive: true });
 
+// Bundle THIS checkout, not whatever the registry happens to hold.
+//
+// This used to depend on `${name}@${version}` and let npm resolve it from the
+// registry, which made the build — and the plugin-bundle e2e that runs it — fail
+// on every version bump, because the new version is by definition not published
+// yet. That is a release deadlock: you cannot publish without green CI and CI
+// cannot go green until you publish. Packing the local package also makes the
+// bundle byte-for-byte the code in this commit instead of a same-numbered
+// release that may have been built from something else.
+const packDir = path.join(repoRoot, 'build');
+fs.mkdirSync(packDir, { recursive: true });
+const tarballName = execFileSync('npm', ['pack', '--silent', '--pack-destination', packDir], {
+  cwd: repoRoot,
+  encoding: 'utf8',
+})
+  .trim()
+  .split('\n')
+  .pop()
+  .trim();
+const tarballPath = path.join(packDir, tarballName);
+if (!fs.existsSync(tarballPath)) {
+  throw new Error(`npm pack did not produce ${tarballPath}`);
+}
+
 fs.copyFileSync(manifestPath, path.join(stageDir, 'manifest.json'));
 fs.copyFileSync(path.join(here, 'server-entry.mjs'), path.join(stageDir, 'server', 'index.js'));
 
@@ -53,7 +77,7 @@ fs.writeFileSync(
       version: manifest.version,
       private: true,
       type: 'module',
-      dependencies: { [rootPkg.name]: rootPkg.version },
+      dependencies: { [rootPkg.name]: `file:${tarballPath}` },
     },
     null,
     2,
@@ -69,6 +93,14 @@ run('npm', ['install', '--omit=dev', '--omit=optional', '--no-audit', '--no-fund
 
 // npm writes a lockfile into the stage dir; harmless, but keep the bundle tidy.
 fs.rmSync(path.join(stageDir, 'package-lock.json'), { force: true });
+fs.rmSync(tarballPath, { force: true });
+
+// The staged package.json must not leak the absolute `file:` path of a build
+// host into the shipped bundle.
+const stagedPkgPath = path.join(stageDir, 'package.json');
+const stagedPkg = JSON.parse(fs.readFileSync(stagedPkgPath, 'utf8'));
+stagedPkg.dependencies = { [rootPkg.name]: rootPkg.version };
+fs.writeFileSync(stagedPkgPath, `${JSON.stringify(stagedPkg, null, 2)}\n`);
 
 const entry = path.join(stageDir, manifest.server.entry_point);
 if (!fs.existsSync(entry)) {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "vibe-browser",
   "display_name": "Vibe Browser",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Drive your real, logged-in Chrome from Claude Desktop.",
   "long_description": "Vibe Browser lets Claude drive the Chrome you already use - with your tabs, your cookies, and your logged-in sessions - instead of a headless throwaway browser.\n\nThe browser can also run on a different machine from Claude, with no inbound port open on either side, by pairing them through a relay UUID.\n\nRequires the free Vibe Chrome extension. After installing this bundle, install the extension from the Chrome Web Store and enable 'MCP External Control' in its Settings.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibebrowser/mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibebrowser/mcp",
   "mcpName": "io.github.VibeTechnologies/vibe-mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "description": "MCP server that drives your real, logged-in Chrome from any MCP client - including agents on a remote machine, with no inbound port open",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "start": "node dist/cli.js",
     "validate:skill": "node scripts/validate-skill.mjs openclaw/vibebrowser/SKILL.md",
     "prepublishOnly": "npm run build",
-    "test": "npm run test:e2e:docs-contract && npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:cli-relay && npm run test:e2e:cli-autospawn && npm run test:e2e:http && npm run test:e2e:uuid-only-auth && npm run test:e2e:tool-annotations && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:cli-package && npm run test:e2e:devtools-flag",
-    "test:ci": "npm run test:e2e:docs-contract && npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:cli-relay && npm run test:e2e:cli-autospawn && npm run test:e2e:http && npm run test:e2e:uuid-only-auth && npm run test:e2e:tool-annotations && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:cli-package && npm run test:e2e:devtools-flag",
+    "test": "npm run test:e2e:docs-contract && npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:relay-heartbeat-pong && npm run test:e2e:cli-relay && npm run test:e2e:cli-autospawn && npm run test:e2e:http && npm run test:e2e:uuid-only-auth && npm run test:e2e:tool-annotations && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:cli-package && npm run test:e2e:devtools-flag",
+    "test:ci": "npm run test:e2e:docs-contract && npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:relay-heartbeat-pong && npm run test:e2e:cli-relay && npm run test:e2e:cli-autospawn && npm run test:e2e:http && npm run test:e2e:uuid-only-auth && npm run test:e2e:tool-annotations && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:cli-package && npm run test:e2e:devtools-flag",
     "test:e2e:docs-contract": "node scripts/e2e-docs-contract.mjs",
     "test:e2e:tool-annotations": "node scripts/e2e-tool-annotations.mjs",
     "test:e2e:tools-list-budget": "node scripts/e2e-tools-list-startup-budget.mjs",
@@ -39,6 +39,7 @@
     "test:e2e:browser-cli-live": "node scripts/e2e-browser-cli-live.mjs",
     "test:e2e:relay-race": "node scripts/e2e-relay-fake-extension-race.mjs",
     "test:e2e:relay-roundtrip": "node scripts/e2e-relay-roundtrip.mjs",
+    "test:e2e:relay-heartbeat-pong": "node scripts/e2e-relay-heartbeat-pong.mjs",
     "test:e2e:agents": "node scripts/e2e-mcp-agents.mjs",
     "build:mcpb": "node mcpb/build.mjs",
     "test:e2e:plugin-bundle": "node scripts/e2e-plugin-bundle.mjs"

--- a/plugins/vibe-browser/.claude-plugin/plugin.json
+++ b/plugins/vibe-browser/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "vibe-browser",
   "displayName": "Vibe Browser",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Drive your real, logged-in Chrome from Claude Code. Navigate, click, type, screenshot and read pages in the browser you already use - including a browser on a different machine, with no inbound port open.",
   "author": {
     "name": "Vibe Technologies",

--- a/plugins/vibe-browser/.mcp.json
+++ b/plugins/vibe-browser/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "vibe": {
       "command": "npx",
-      "args": ["-y", "@vibebrowser/mcp@0.3.2"]
+      "args": ["-y", "@vibebrowser/mcp@0.3.3"]
     }
   }
 }

--- a/scripts/e2e-relay-heartbeat-pong.mjs
+++ b/scripts/e2e-relay-heartbeat-pong.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Regression test: the local relay daemon MUST answer the extension heartbeat.
+ *
+ * The Vibe extension (vibe `lib/mcp/external-client.ts`) sends
+ * `{ type: 'connected' }` every CLIENT_HEARTBEAT_INTERVAL_MS (15 s) and treats
+ * ANY inbound frame as the pong. After MAX_MISSED_PONGS (2) unanswered
+ * heartbeats it declares the socket dead and force-reconnects.
+ *
+ * The daemon used to `return` on `connected` without replying, so a perfectly
+ * healthy extension socket was torn down and rebuilt every ~30 s forever.
+ * Measured on a real machine: the extension's socket to 127.0.0.1:19889 lived
+ * 17-27 s, vanished for ~2 s, and came back on a new ephemeral port, in a loop.
+ * Any tool call that spanned a swap failed ("Extension reconnecting" on the
+ * hosted relay, dropped in-flight request locally).
+ *
+ * The hosted relay (platform/subscriptions/relay-service/server.js) already
+ * replies `{ type: 'pong' }`; this test pins the same behaviour for the daemon.
+ */
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+import { setTimeout as delay } from 'node:timers/promises';
+import WebSocket from 'ws';
+
+const HOST = '127.0.0.1';
+// The extension gives the relay PONG_TIMEOUT_MS (10 s) to answer; anything
+// slower than a second here already means the watchdog is at risk.
+const MAX_PONG_LATENCY_MS = 2_000;
+const HEARTBEATS = 3;
+const SESSION_ID = 'heartbeat-pong-session';
+const FAKE_TOOLS = [
+  { name: 'list_pages', inputSchema: { type: 'object', properties: {} } },
+];
+
+const RESERVED_PORTS = new Set();
+const AGENT_PORT = await findFreePort(RESERVED_PORTS);
+RESERVED_PORTS.add(AGENT_PORT);
+const EXTENSION_PORT = await findFreePort(RESERVED_PORTS);
+RESERVED_PORTS.add(EXTENSION_PORT);
+
+function findFreePort(exclude) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, HOST, () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close((error) => {
+        if (error) { reject(error); return; }
+        if (!port || exclude.has(port)) { findFreePort(exclude).then(resolve, reject); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+function probePort(port) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host: HOST, port });
+    socket.on('connect', () => { socket.destroy(); resolve(true); });
+    socket.on('error', () => { resolve(false); });
+  });
+}
+
+async function waitForPort(port, timeoutMs = 15_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await probePort(port)) return;
+    await delay(100);
+  }
+  throw new Error(`Timed out waiting for port ${port}`);
+}
+
+function connectWebSocket(url, timeoutMs = 10_000) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => { ws.terminate(); reject(new Error(`Timed out connecting to ${url}`)); }, timeoutMs);
+    ws.once('open', () => { clearTimeout(timer); resolve(ws); });
+    ws.once('error', (error) => { clearTimeout(timer); reject(error); });
+  });
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function main() {
+  let relay = null;
+  let extension = null;
+  const stateDir = mkdtempSync(join(tmpdir(), 'vibe-mcp-relay-hb-'));
+
+  try {
+    relay = spawn(process.execPath, ['dist/relay-daemon.js'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        VIBE_MCP_AGENT_PORT: String(AGENT_PORT),
+        VIBE_MCP_EXTENSION_PORT: String(EXTENSION_PORT),
+        VIBE_MCP_STATE_DIR: stateDir,
+      },
+    });
+    relay.stdout.on('data', () => {});
+    relay.stderr.on('data', () => {});
+
+    await Promise.all([waitForPort(AGENT_PORT), waitForPort(EXTENSION_PORT)]);
+
+    extension = await connectWebSocket(`ws://${HOST}:${EXTENSION_PORT}`);
+
+    // Every inbound frame counts as the pong for the extension's watchdog, so
+    // the test asserts on "any frame arrived", exactly like the real client.
+    let inbound = [];
+    extension.on('message', (raw) => {
+      let msg = null;
+      try { msg = JSON.parse(raw.toString()); } catch { msg = { type: 'unparsed' }; }
+      inbound.push({ at: Date.now(), msg });
+
+      // Behave like the real extension: answer the relay's tools probe. Without
+      // this the relay keeps re-probing and its own retries would masquerade as
+      // heartbeat replies, hiding the regression this test exists to catch.
+      if (msg && msg.type === 'list_tools' && msg.requestId) {
+        extension.send(JSON.stringify({
+          type: 'tools_list',
+          requestId: msg.requestId,
+          sessionId: SESSION_ID,
+          data: FAKE_TOOLS,
+        }));
+      }
+    });
+
+    // Handshake: the extension announces itself with `connected`.
+    extension.send(JSON.stringify({ type: 'connected', sessionId: SESSION_ID }));
+
+    // Let the relay finish its startup chatter (tools probe + broadcasts) and go
+    // quiet, so the only thing that can answer a heartbeat is the heartbeat
+    // handler itself.
+    await waitForQuiet(() => inbound, 'relay startup chatter');
+
+    // Now simulate the steady-state heartbeats and require a reply to each one.
+    for (let i = 1; i <= HEARTBEATS; i++) {
+      inbound.length = 0;
+
+      const sentAt = Date.now();
+      extension.send(JSON.stringify({ type: 'connected', sessionId: SESSION_ID }));
+      const reply = await waitForInbound(inbound, `heartbeat #${i}`);
+      const latency = reply.at - sentAt;
+      assert(
+        latency <= MAX_PONG_LATENCY_MS,
+        `Heartbeat #${i} answered after ${latency}ms (limit ${MAX_PONG_LATENCY_MS}ms)`,
+      );
+      console.log(`  heartbeat #${i}: answered with "${reply.msg.type}" in ${latency}ms`);
+      await delay(250);
+    }
+
+    console.log('PASS: local relay daemon answers extension heartbeats (no 30s reconnect churn)');
+  } finally {
+    if (extension) { try { extension.terminate(); } catch { /* ignore */ } }
+    if (relay) { try { relay.kill('SIGKILL'); } catch { /* ignore */ } }
+    try { rmSync(stateDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Wait until the relay stops sending unsolicited frames for `quietMs`, so a
+ * later assertion cannot be satisfied by leftover startup traffic.
+ */
+async function waitForQuiet(getQueue, label, quietMs = 1_500, timeoutMs = 15_000) {
+  const start = Date.now();
+  let lastLen = getQueue().length;
+  let lastChange = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    await delay(50);
+    const len = getQueue().length;
+    if (len !== lastLen) { lastLen = len; lastChange = Date.now(); continue; }
+    if (Date.now() - lastChange >= quietMs) return;
+  }
+  throw new Error(`Relay never went quiet while waiting out ${label}`);
+}
+
+async function waitForInbound(queue, label, timeoutMs = MAX_PONG_LATENCY_MS + 3_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (queue.length > 0) return queue[0];
+    await delay(10);
+  }
+  throw new Error(
+    `Relay never answered the extension ${label} — the extension's pong watchdog ` +
+    `would force-reconnect after 2 missed heartbeats (~30s churn loop).`,
+  );
+}
+
+main().catch((error) => {
+  console.error(`FAIL: ${error.message}`);
+  process.exit(1);
+});

--- a/server.json
+++ b/server.json
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@vibebrowser/mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -455,6 +455,23 @@ export class RelayServer extends EventEmitter {
     this.log(`Extension message (${session.sessionId}): ${message.type}`);
 
     if (message.type === 'connected') {
+      // Reply so the extension's pong watchdog does not fire.
+      //
+      // The extension (vibe lib/mcp/external-client.ts) sends `{type:'connected'}`
+      // every CLIENT_HEARTBEAT_INTERVAL_MS (15 s) and treats ANY inbound frame as
+      // the pong. After MAX_MISSED_PONGS (2) unanswered heartbeats it declares the
+      // socket dead and force-reconnects — so a relay that stays silent here churns
+      // the extension connection every ~30 s forever, and every in-flight tool call
+      // that spans a swap dies ("Extension reconnecting"). The hosted relay already
+      // answers this heartbeat (platform relay-service `handleExtensionMessage`);
+      // the local daemon must behave identically.
+      if (sourceWs.readyState === WebSocket.OPEN) {
+        try {
+          sourceWs.send(JSON.stringify({ type: 'pong' }));
+        } catch (error) {
+          this.log(`Failed to answer extension heartbeat: ${error}`);
+        }
+      }
       return;
     }
 


### PR DESCRIPTION
## Problem

Users driving their browser through a **local** `@vibebrowser/mcp` relay daemon see the extension connection flap forever, and agents (Claude Desktop/Cowork, OpenClaw, Cursor) get `Extension reconnecting` / dropped tool calls.

Root cause: the extension (`vibe` -> `lib/mcp/external-client.ts`) sends `{type:'connected'}` every `CLIENT_HEARTBEAT_INTERVAL_MS` (15s) and treats **any** inbound frame as the pong. After `MAX_MISSED_PONGS` (2) unanswered heartbeats it declares the socket dead and force-reconnects.

`RelayDaemon.handleExtensionMessage()` returned early on `connected` **without replying**, so a healthy socket was torn down and rebuilt every ~30s, forever.

### Measured on a real machine

1-second sampling of the extension's socket to `127.0.0.1:19889`:

```
up   port=58518 22:17:48 -> 22:18:09 (20s)
DOWN                22:18:10 -> 22:18:11 (2s)
up   port=58556 22:18:13 -> 22:18:41 (27s)
DOWN                22:18:42 -> 22:18:43 (2s)
up   port=58598 22:18:44 -> 22:19:02 (17s)
```

Every tool call that spans a swap dies. On the hosted relay the same swap path calls `notifyPendingRequests(existing, 'Extension reconnecting')` - the exact error users report.

## Fix

Reply `{type:'pong'}` to the extension heartbeat, matching the hosted relay, which already does this (`platform/subscriptions/relay-service/server.js`: *"Reply to extension heartbeat so the client's pong-timeout doesn't fire"*).

## Test

New `scripts/e2e-relay-heartbeat-pong.mjs`, wired into `test` and `test:ci`:

- spawns the **real** daemon,
- fake extension answers the relay's `list_tools` probe (so relay startup chatter cannot masquerade as a pong),
- waits for the relay to go quiet, then requires every heartbeat to be answered within 2s.

Verified as a true regression test:

```
unfixed daemon -> exit 1  ("Relay never answered the extension heartbeat #1 ...")
fixed daemon   -> exit 0  (heartbeats answered with "pong" in 1-3ms)
```

Sibling suites still green: `test:e2e:relay-race`, `test:e2e:relay-roundtrip`, `test:e2e:cli-relay`.

Investigated under Paperclip issue AGE-10 (Claude Co-Work + VibeBrowser).
