### PR TITLE
feat(relay): report the executing package's version on the extension handshake (AGE-91)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "vibe-browser",
       "source": "./plugins/vibe-browser",
       "description": "Drive your real, logged-in Chrome from Claude Code. Navigate, click, type, screenshot and read pages in the browser you already use - including a browser on a different machine, with no inbound port open.",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "author": {
         "name": "Vibe Technologies",
         "url": "https://vibebrowser.app"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 build/
+.artifacts/
 *.log
 .DS_Store
 tmp/

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "vibe-browser",
   "display_name": "Vibe Browser",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Drive your real, logged-in Chrome from Claude Desktop.",
   "long_description": "Vibe Browser lets Claude drive the Chrome you already use - with your tabs, your cookies, and your logged-in sessions - instead of a headless throwaway browser.\n\nThe browser can also run on a different machine from Claude, with no inbound port open on either side, by pairing them through a relay UUID.\n\nRequires the free Vibe Chrome extension. After installing this bundle, install the extension from the Chrome Web Store and enable 'MCP External Control' in its Settings.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibebrowser/mcp",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -1236,7 +1236,7 @@
     },
     "packages/cli": {
       "name": "@vibebrowser/cli",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibebrowser/mcp",
   "mcpName": "io.github.VibeTechnologies/vibe-mcp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "description": "MCP server that drives your real, logged-in Chrome from any MCP client - including agents on a remote machine, with no inbound port open",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "start": "node dist/cli.js",
     "validate:skill": "node scripts/validate-skill.mjs openclaw/vibebrowser/SKILL.md",
     "prepublishOnly": "npm run build",
-    "test": "npm run test:e2e:docs-contract && npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:relay-heartbeat-pong && npm run test:e2e:cli-relay && npm run test:e2e:cli-autospawn && npm run test:e2e:http && npm run test:e2e:uuid-only-auth && npm run test:e2e:remote-lifecycle && npm run test:e2e:tool-annotations && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:cli-package && npm run test:e2e:devtools-flag",
-    "test:ci": "npm run test:e2e:docs-contract && npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:relay-heartbeat-pong && npm run test:e2e:cli-relay && npm run test:e2e:cli-autospawn && npm run test:e2e:http && npm run test:e2e:uuid-only-auth && npm run test:e2e:remote-lifecycle && npm run test:e2e:tool-annotations && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:cli-package && npm run test:e2e:devtools-flag",
+    "test": "npm run test:e2e:docs-contract && npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:relay-heartbeat-pong && npm run test:e2e:relay-version-handshake && npm run test:e2e:cli-relay && npm run test:e2e:cli-autospawn && npm run test:e2e:http && npm run test:e2e:uuid-only-auth && npm run test:e2e:remote-lifecycle && npm run test:e2e:tool-annotations && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:cli-package && npm run test:e2e:devtools-flag",
+    "test:ci": "npm run test:e2e:docs-contract && npm run test:e2e:relay-race && npm run test:e2e:relay-roundtrip && npm run test:e2e:relay-heartbeat-pong && npm run test:e2e:relay-version-handshake && npm run test:e2e:cli-relay && npm run test:e2e:cli-autospawn && npm run test:e2e:http && npm run test:e2e:uuid-only-auth && npm run test:e2e:remote-lifecycle && npm run test:e2e:tool-annotations && npm run test:e2e:tools-list-budget && npm run test:e2e:browser-cli && npm run test:e2e:cli-package && npm run test:e2e:devtools-flag",
     "test:e2e:docs-contract": "node scripts/e2e-docs-contract.mjs",
     "test:e2e:tool-annotations": "node scripts/e2e-tool-annotations.mjs",
     "test:e2e:tools-list-budget": "node scripts/e2e-tools-list-startup-budget.mjs",
@@ -41,6 +41,7 @@
     "test:e2e:relay-race": "node scripts/e2e-relay-fake-extension-race.mjs",
     "test:e2e:relay-roundtrip": "node scripts/e2e-relay-roundtrip.mjs",
     "test:e2e:relay-heartbeat-pong": "node scripts/e2e-relay-heartbeat-pong.mjs",
+    "test:e2e:relay-version-handshake": "node scripts/e2e-relay-version-handshake.mjs",
     "test:e2e:agents": "node scripts/e2e-mcp-agents.mjs",
     "build:mcpb": "node mcpb/build.mjs",
     "test:e2e:plugin-bundle": "node scripts/e2e-plugin-bundle.mjs"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibebrowser/cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "description": "Standalone Vibe Browser CLI for controlling a Vibe-connected browser session",
   "bin": {

--- a/plugins/vibe-browser/.claude-plugin/plugin.json
+++ b/plugins/vibe-browser/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "vibe-browser",
   "displayName": "Vibe Browser",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Drive your real, logged-in Chrome from Claude Code. Navigate, click, type, screenshot and read pages in the browser you already use - including a browser on a different machine, with no inbound port open.",
   "author": {
     "name": "Vibe Technologies",

--- a/plugins/vibe-browser/.mcp.json
+++ b/plugins/vibe-browser/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "vibe": {
       "command": "npx",
-      "args": ["-y", "@vibebrowser/mcp@0.3.4"]
+      "args": ["-y", "@vibebrowser/mcp@0.3.5"]
     }
   }
 }

--- a/scripts/e2e-relay-version-handshake.mjs
+++ b/scripts/e2e-relay-version-handshake.mjs
@@ -7,8 +7,9 @@
  * ---
  * A published relay fix does not reach a user whose `@vibebrowser/mcp` install
  * is stale, and nothing used to say so. Measured on a real machine on
- * 2026-08-14: npm served 0.3.3, but the daemon actually bound to
- * 127.0.0.1:19889 came from a *global* install pinned at 0.2.12
+ * 2026-08-14: npm's latest was 0.3.3 (0.3.4 by the time this landed), but the
+ * daemon actually bound to 127.0.0.1:19889 came from a *global* install
+ * pinned at 0.2.12
  * (`grep -c pong dist/relay.js` -> 0), so the merged heartbeat fix was live on
  * the registry while the ~30 s reconnect churn still reproduced locally. The
  * only way to find that out was process/socket forensics.
@@ -24,7 +25,7 @@
  * test is the whole contract on the daemon side.
  */
 import { spawn } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import net from 'node:net';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -36,16 +37,27 @@ import WebSocket from 'ws';
 const HOST = '127.0.0.1';
 const SESSION_ID = 'version-handshake-session';
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const EXPECTED_VERSION = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8')).version;
+const CLI_PACKAGE_ROOT = join(REPO_ROOT, 'packages', 'cli');
 // The extension's pong watchdog gives the relay 10 s; the version rides the
 // same frame, so anything slower than this is already a bug.
 const HANDSHAKE_TIMEOUT_MS = 5_000;
 
+function packageVersion(packageRoot) {
+  return JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8')).version;
+}
+
+// Both published packages ship and execute this relay: `@vibebrowser/mcp`
+// runs `dist/relay-daemon.js`, and `@vibebrowser/cli` gets a full copy of the
+// same `dist/` (scripts/prepare-cli-package.mjs) which `src/connection.ts`
+// autospawns from its own directory. They are versioned independently, so each
+// one must report *its own* version — a root-only constant would make the
+// standalone CLI claim a version it was never published under.
+const DAEMONS = [
+  { label: '@vibebrowser/mcp', cwd: REPO_ROOT, expected: packageVersion(REPO_ROOT) },
+  { label: '@vibebrowser/cli', cwd: CLI_PACKAGE_ROOT, expected: packageVersion(CLI_PACKAGE_ROOT) },
+];
+
 const RESERVED_PORTS = new Set();
-const AGENT_PORT = await findFreePort(RESERVED_PORTS);
-RESERVED_PORTS.add(AGENT_PORT);
-const EXTENSION_PORT = await findFreePort(RESERVED_PORTS);
-RESERVED_PORTS.add(EXTENSION_PORT);
 
 function findFreePort(exclude) {
   return new Promise((resolve, reject) => {
@@ -94,14 +106,18 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-async function main() {
+async function checkDaemon({ label, cwd, expected }) {
   let relay = null;
   let extension = null;
   const stateDir = mkdtempSync(join(tmpdir(), 'vibe-mcp-relay-ver-'));
+  const AGENT_PORT = await findFreePort(RESERVED_PORTS);
+  RESERVED_PORTS.add(AGENT_PORT);
+  const EXTENSION_PORT = await findFreePort(RESERVED_PORTS);
+  RESERVED_PORTS.add(EXTENSION_PORT);
 
   try {
     relay = spawn(process.execPath, ['dist/relay-daemon.js'], {
-      cwd: REPO_ROOT,
+      cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
         ...process.env,
@@ -131,17 +147,18 @@ async function main() {
 
     assert(
       typeof pong.version === 'string' && pong.version.length > 0,
-      'Relay pong carried no `version` field — Settings cannot tell the user their daemon is stale ' +
+      `${label} relay pong carried no \`version\` field — Settings cannot tell the user their daemon is stale ` +
       `(got ${JSON.stringify(pong)}).`,
     );
     assert(
-      pong.version === EXPECTED_VERSION,
-      `Relay reported version "${pong.version}" but package.json says "${EXPECTED_VERSION}" — ` +
-      'the reported version must be the running package version or the outdated warning lies.',
+      pong.version === expected,
+      `${label} relay reported version "${pong.version}" but its package.json says "${expected}" — ` +
+      'the reported version must come from the package actually executing the relay, ' +
+      'or the outdated warning lies.',
     );
     assert(
       /^\d+\.\d+\.\d+/.test(pong.version),
-      `Relay reported a non-semver version "${pong.version}"; the extension compares it numerically.`,
+      `${label} relay reported a non-semver version "${pong.version}"; the extension compares it numerically.`,
     );
 
     // Steady-state heartbeats must keep carrying it, so a service worker that
@@ -150,11 +167,11 @@ async function main() {
     extension.send(JSON.stringify({ type: 'connected', sessionId: SESSION_ID }));
     const heartbeatPong = await waitFor(pongs, 'steady-state heartbeat pong');
     assert(
-      heartbeatPong.version === EXPECTED_VERSION,
+      heartbeatPong.version === expected,
       `Heartbeat pong lost the version field (got ${JSON.stringify(heartbeatPong)}).`,
     );
 
-    console.log(`PASS: local relay daemon reports version ${EXPECTED_VERSION} on the extension handshake`);
+    console.log(`PASS: ${label} relay daemon reports version ${expected} on the extension handshake`);
   } finally {
     if (extension) { try { extension.terminate(); } catch { /* ignore */ } }
     if (relay) { try { relay.kill('SIGKILL'); } catch { /* ignore */ } }
@@ -169,6 +186,41 @@ async function waitFor(queue, label, timeoutMs = HANDSHAKE_TIMEOUT_MS) {
     await delay(10);
   }
   throw new Error(`Relay never sent a ${label} within ${timeoutMs}ms`);
+}
+
+/**
+ * Stage a third, synthetic package around the *same* build output and give it a
+ * version that appears nowhere in the repo. If the relay still reports it, the
+ * lookup is genuinely relative to the executing package; if it reports the root
+ * version instead, someone replaced it with a root-only constant. This keeps
+ * the guarantee provable even if the real packages ever share a version number.
+ *
+ * Staged under the repo so `import 'ws'` still resolves via node_modules.
+ */
+function stageSyntheticPackage() {
+  const root = join(REPO_ROOT, '.artifacts', 'relay-version-handshake', 'synthetic-pkg');
+  rmSync(root, { recursive: true, force: true });
+  mkdirSync(root, { recursive: true });
+  cpSync(join(REPO_ROOT, 'dist'), join(root, 'dist'), { recursive: true });
+  const version = '99.98.97-e2e';
+  writeFileSync(
+    join(root, 'package.json'),
+    `${JSON.stringify({ name: '@vibebrowser/relay-version-probe', version, type: 'module', private: true }, null, 2)}\n`,
+  );
+  return { label: 'synthetic package (per-package lookup probe)', cwd: root, expected: version, root };
+}
+
+async function main() {
+  for (const daemon of DAEMONS) {
+    await checkDaemon(daemon);
+  }
+
+  const synthetic = stageSyntheticPackage();
+  try {
+    await checkDaemon(synthetic);
+  } finally {
+    rmSync(synthetic.root, { recursive: true, force: true });
+  }
 }
 
 main().catch((error) => {

--- a/scripts/e2e-relay-version-handshake.mjs
+++ b/scripts/e2e-relay-version-handshake.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * Regression test: the local relay daemon MUST report its package version on
+ * the extension handshake (AGE-91).
+ *
+ * WHY
+ * ---
+ * A published relay fix does not reach a user whose `@vibebrowser/mcp` install
+ * is stale, and nothing used to say so. Measured on a real machine on
+ * 2026-08-14: npm served 0.3.3, but the daemon actually bound to
+ * 127.0.0.1:19889 came from a *global* install pinned at 0.2.12
+ * (`grep -c pong dist/relay.js` -> 0), so the merged heartbeat fix was live on
+ * the registry while the ~30 s reconnect churn still reproduced locally. The
+ * only way to find that out was process/socket forensics.
+ *
+ * The extension (vibe `lib/mcp/external-client.ts`) sends `{type:'connected'}`
+ * on open and every 15 s after; the daemon answers `{type:'pong'}`. This test
+ * pins that the pong carries `version` and that it equals the daemon's own
+ * package.json version, which is what Settings renders as
+ * "Local relay <v> - outdated (expected <min>+)".
+ *
+ * A relay that answers WITHOUT a version field is, by construction, older than
+ * the build that added it — the extension treats that as outdated too, so this
+ * test is the whole contract on the daemon side.
+ */
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import process from 'node:process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import WebSocket from 'ws';
+
+const HOST = '127.0.0.1';
+const SESSION_ID = 'version-handshake-session';
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const EXPECTED_VERSION = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8')).version;
+// The extension's pong watchdog gives the relay 10 s; the version rides the
+// same frame, so anything slower than this is already a bug.
+const HANDSHAKE_TIMEOUT_MS = 5_000;
+
+const RESERVED_PORTS = new Set();
+const AGENT_PORT = await findFreePort(RESERVED_PORTS);
+RESERVED_PORTS.add(AGENT_PORT);
+const EXTENSION_PORT = await findFreePort(RESERVED_PORTS);
+RESERVED_PORTS.add(EXTENSION_PORT);
+
+function findFreePort(exclude) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, HOST, () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close((error) => {
+        if (error) { reject(error); return; }
+        if (!port || exclude.has(port)) { findFreePort(exclude).then(resolve, reject); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+function probePort(port) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host: HOST, port });
+    socket.on('connect', () => { socket.destroy(); resolve(true); });
+    socket.on('error', () => { resolve(false); });
+  });
+}
+
+async function waitForPort(port, timeoutMs = 15_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await probePort(port)) return;
+    await delay(100);
+  }
+  throw new Error(`Timed out waiting for port ${port}`);
+}
+
+function connectWebSocket(url, timeoutMs = 10_000) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => { ws.terminate(); reject(new Error(`Timed out connecting to ${url}`)); }, timeoutMs);
+    ws.once('open', () => { clearTimeout(timer); resolve(ws); });
+    ws.once('error', (error) => { clearTimeout(timer); reject(error); });
+  });
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function main() {
+  let relay = null;
+  let extension = null;
+  const stateDir = mkdtempSync(join(tmpdir(), 'vibe-mcp-relay-ver-'));
+
+  try {
+    relay = spawn(process.execPath, ['dist/relay-daemon.js'], {
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        VIBE_MCP_AGENT_PORT: String(AGENT_PORT),
+        VIBE_MCP_EXTENSION_PORT: String(EXTENSION_PORT),
+        VIBE_MCP_STATE_DIR: stateDir,
+      },
+    });
+    relay.stdout.on('data', () => {});
+    relay.stderr.on('data', () => {});
+
+    await Promise.all([waitForPort(AGENT_PORT), waitForPort(EXTENSION_PORT)]);
+
+    extension = await connectWebSocket(`ws://${HOST}:${EXTENSION_PORT}`);
+
+    const pongs = [];
+    extension.on('message', (raw) => {
+      let msg = null;
+      try { msg = JSON.parse(raw.toString()); } catch { return; }
+      if (msg && msg.type === 'pong') pongs.push(msg);
+    });
+
+    // Exactly what the extension does on open.
+    extension.send(JSON.stringify({ type: 'connected', sessionId: SESSION_ID }));
+
+    const pong = await waitFor(pongs, 'handshake pong');
+
+    assert(
+      typeof pong.version === 'string' && pong.version.length > 0,
+      'Relay pong carried no `version` field — Settings cannot tell the user their daemon is stale ' +
+      `(got ${JSON.stringify(pong)}).`,
+    );
+    assert(
+      pong.version === EXPECTED_VERSION,
+      `Relay reported version "${pong.version}" but package.json says "${EXPECTED_VERSION}" — ` +
+      'the reported version must be the running package version or the outdated warning lies.',
+    );
+    assert(
+      /^\d+\.\d+\.\d+/.test(pong.version),
+      `Relay reported a non-semver version "${pong.version}"; the extension compares it numerically.`,
+    );
+
+    // Steady-state heartbeats must keep carrying it, so a service worker that
+    // restarts mid-session re-learns the version without a reconnect.
+    pongs.length = 0;
+    extension.send(JSON.stringify({ type: 'connected', sessionId: SESSION_ID }));
+    const heartbeatPong = await waitFor(pongs, 'steady-state heartbeat pong');
+    assert(
+      heartbeatPong.version === EXPECTED_VERSION,
+      `Heartbeat pong lost the version field (got ${JSON.stringify(heartbeatPong)}).`,
+    );
+
+    console.log(`PASS: local relay daemon reports version ${EXPECTED_VERSION} on the extension handshake`);
+  } finally {
+    if (extension) { try { extension.terminate(); } catch { /* ignore */ } }
+    if (relay) { try { relay.kill('SIGKILL'); } catch { /* ignore */ } }
+    try { rmSync(stateDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+async function waitFor(queue, label, timeoutMs = HANDSHAKE_TIMEOUT_MS) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (queue.length > 0) return queue[0];
+    await delay(10);
+  }
+  throw new Error(`Relay never sent a ${label} within ${timeoutMs}ms`);
+}
+
+main().catch((error) => {
+  console.error(`FAIL: ${error.message}`);
+  process.exit(1);
+});

--- a/server.json
+++ b/server.json
@@ -7,14 +7,14 @@
     "url": "https://github.com/VibeTechnologies/vibe-mcp",
     "source": "github"
   },
-  "version": "0.3.4",
+  "version": "0.3.5",
   "websiteUrl": "https://vibebrowser.app",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@vibebrowser/mcp",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "transport": {
         "type": "stdio"
       }

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -15,7 +15,22 @@ import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { EventEmitter } from 'events';
 import { DevtoolsFallbackConnection } from './devtools-fallback.js';
+import { getPackageVersion } from './version.js';
 import type { ToolDefinition } from './types.js';
+
+/**
+ * The @vibebrowser/mcp version of the daemon that is actually serving this
+ * socket (AGE-91).
+ *
+ * A published relay fix does not reach a user whose install is stale, and
+ * nothing in the extension UI used to say so: on 2026-08-14 npm had 0.3.3
+ * while the daemon on 127.0.0.1:19889 was a *global* install pinned at
+ * 0.2.12, so the merged heartbeat fix was live on the registry and the ~30 s
+ * reconnect churn still reproduced locally. Reporting the version on the
+ * handshake lets Settings show "Local relay 0.2.12 - outdated" instead of
+ * making the user do process forensics.
+ */
+const RELAY_VERSION = getPackageVersion();
 
 function parseEnvPort(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -465,9 +480,15 @@ export class RelayServer extends EventEmitter {
       // that spans a swap dies ("Extension reconnecting"). The hosted relay already
       // answers this heartbeat (platform relay-service `handleExtensionMessage`);
       // the local daemon must behave identically.
+      //
+      // The reply also carries this daemon's package version (AGE-91). The
+      // extension sends `connected` immediately on open, so the version is
+      // known within one roundtrip of the handshake; a relay that answers
+      // without a `version` field is by definition older than the build that
+      // added it, and the extension surfaces that as "outdated".
       if (sourceWs.readyState === WebSocket.OPEN) {
         try {
-          sourceWs.send(JSON.stringify({ type: 'pong' }));
+          sourceWs.send(JSON.stringify({ type: 'pong', version: RELAY_VERSION }));
         } catch (error) {
           this.log(`Failed to answer extension heartbeat: ${error}`);
         }

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -19,16 +19,23 @@ import { getPackageVersion } from './version.js';
 import type { ToolDefinition } from './types.js';
 
 /**
- * The @vibebrowser/mcp version of the daemon that is actually serving this
- * socket (AGE-91).
+ * The version of the package that is actually serving this socket (AGE-91).
+ *
+ * Resolved from the executing package's own package.json, never hardcoded:
+ * this same build is published twice, as `@vibebrowser/mcp` and as
+ * `@vibebrowser/cli` (scripts/prepare-cli-package.mjs copies dist/ wholesale,
+ * and connection.ts autospawns relay-daemon.js from its own directory). The
+ * two are versioned independently, so a root-only constant would make the
+ * standalone CLI report a version it was never published under.
  *
  * A published relay fix does not reach a user whose install is stale, and
- * nothing in the extension UI used to say so: on 2026-08-14 npm had 0.3.3
- * while the daemon on 127.0.0.1:19889 was a *global* install pinned at
- * 0.2.12, so the merged heartbeat fix was live on the registry and the ~30 s
- * reconnect churn still reproduced locally. Reporting the version on the
- * handshake lets Settings show "Local relay 0.2.12 - outdated" instead of
- * making the user do process forensics.
+ * nothing in the extension UI used to say so: measured 2026-08-14, npm's
+ * latest was 0.3.3 (0.3.4 by the time this landed) while the daemon on
+ * 127.0.0.1:19889 was a *global* install pinned at 0.2.12, so the merged
+ * heartbeat fix was live on the registry and the ~30 s reconnect churn still
+ * reproduced locally. Reporting the version on the handshake lets Settings
+ * show "Local relay 0.2.12 - outdated" instead of making the user do process
+ * forensics.
  */
 const RELAY_VERSION = getPackageVersion();
 


### PR DESCRIPTION
## Why

A published relay fix does not reach a user whose install is stale, and nothing said so.

Measured on the issue owner's machine on 2026-08-14: npm's latest was `0.3.3`, but the daemon actually bound to `127.0.0.1:19889` came from a **global** install pinned at `0.2.12` (`grep -c pong dist/relay.js` → 0). The merged heartbeat fix (#143) was live on the registry while the ~30 s reconnect churn still reproduced locally. Finding that out took process and socket forensics.

## What

- `src/relay.ts`: the `pong` that answers the extension's `{type:'connected'}` handshake/heartbeat now carries `version` (the running package version). The extension sends `connected` on open, so the version is known within one roundtrip, and every steady-state heartbeat re-reports it. Purely additive — the only in-repo `pong` consumers match on `type`, never on the full payload.
- `scripts/e2e-relay-version-handshake.mjs`: regression test wired into `test` / `test:ci`.
- Version bumps (see below).

A relay that answers **without** a `version` field is by construction older than this build — which is exactly how the extension classifies the 0.2.12 case that physically cannot report itself.

## Versions

The original branch assumed root `0.3.4` was unpublished. It is not: npm now serves `@vibebrowser/mcp@0.3.4` and `@vibebrowser/cli@0.3.2`. This branch has been rebased onto `main` and moved to the next unpublished patches.

**Both packages are affected.** `scripts/prepare-cli-package.mjs` copies the entire root `dist/` into `packages/cli/dist/`, and `src/connection.ts` autospawns `relay-daemon.js` from its own directory — so `@vibebrowser/cli` ships **and executes** the changed relay code and must be republished too.

| Package / mirror | Was | Now |
|---|---|---|
| `@vibebrowser/mcp` (`package.json`, `package-lock.json`) | 0.3.4 | **0.3.5** |
| `@vibebrowser/cli` (`packages/cli/package.json`, lock workspace entry) | 0.3.2 | **0.3.3** |
| `server.json` (×2) | 0.3.4 | 0.3.5 |
| `mcpb/manifest.json` | 0.3.4 | 0.3.5 |
| `.claude-plugin/marketplace.json` | 0.3.4 | 0.3.5 |
| `plugins/vibe-browser/.claude-plugin/plugin.json` | 0.3.4 | 0.3.5 |
| `plugins/vibe-browser/.mcp.json` (`@vibebrowser/mcp@…`) | 0.3.4 | 0.3.5 |

`package-lock.json` diff is version fields only — no dependency churn.

### The reported version comes from the package that executes the relay

`getPackageVersion()` resolves `<moduleDir>/../package.json`, so the root daemon reports `0.3.5` and the packaged CLI reports `0.3.3` — each its own published version, not a root-only constant that would make the standalone CLI claim a version it was never published under. That behaviour existed but was untested; it is now pinned. The test runs the daemon three ways:

1. the root `@vibebrowser/mcp` package → must report `0.3.5`
2. the built `packages/cli` package → must report `0.3.3`
3. a synthetic package staged around the same `dist/` with version `99.98.97-e2e`, a string that appears nowhere in the repo → must report `99.98.97-e2e`

Verified meaningful by mutation: replacing `getPackageVersion()` with a hardcoded `'0.3.5'` fails the test (`@vibebrowser/cli relay reported version "0.3.5" but its package.json says "0.3.3"`).

## Rebase

Rebased onto `origin/main` (`406e591`). One conflict, in `package.json` `test` / `test:ci`: `main` added `test:e2e:remote-lifecycle`, this branch added `test:e2e:relay-version-handshake`. Resolved by keeping **both**. The follow-up mirror-bump commit was dropped as already upstream. `git diff origin/main -- src/` touches `src/relay.ts` only — all of main's hardened credential/lifecycle and `/mcp/<uuid>` connector work is intact.

## Verification

```
npm run build                              # PASS
npx tsc --noEmit                           # PASS
npm run test:e2e:relay-version-handshake   # PASS ×3 (mcp 0.3.5, cli 0.3.3, synthetic 99.98.97-e2e)
npm run test:e2e:relay-heartbeat-pong      # PASS (unchanged behaviour)
npm run build:mcpb                         # PASS (vibe-browser-0.3.5.mcpb)
npm run test:e2e:plugin-bundle             # PASS — 13 checks, live handshake: vibebrowser-mcp 0.3.5
npm test                                   # PASS — full suite, incl. cli-package gate (vibebrowser-cli-0.3.3.tgz)
```

Extension side: VibeTechnologies/VibeWebAgent `feat/age-91-relay-version`.
Paperclip: AGE-91.
