### PR TITLE
feat: accept the HTTPS /mcp/<uuid> connector URL in --remote (#145)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "vibe-browser",
       "source": "./plugins/vibe-browser",
       "description": "Drive your real, logged-in Chrome from Claude Code. Navigate, click, type, screenshot and read pages in the browser you already use - including a browser on a different machine, with no inbound port open.",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "author": {
         "name": "Vibe Technologies",
         "url": "https://vibebrowser.app"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MCP server for [Vibe AI Browser](https://vibebrowser.app) — drive your **real,
 
 ## Install prompt for AI agents (OpenClaw / Hermes)
 
-Paste the block below into your **OpenClaw** or **Hermes** agent. Replace the last line with your remote value — a UUID or a `wss://relay.api.vibebrowser.app/<uuid>` URL from the Vibe extension's **Settings → AI Agent Control → Remote (internet) → Relay access**. That's the only edit you make.
+Paste the block below into your **OpenClaw** or **Hermes** agent. Replace the last line with your remote value — the connector URL (`https://relay.api.vibebrowser.app/mcp/<uuid>`) shown in the Vibe extension's **Settings → AI Agent Control → Remote (internet) → Relay access** (a bare UUID or a `wss://` relay URL also still work). That's the only edit you make.
 
 ```text
 You are setting yourself up to control my real Chrome through Vibe Browser. Work through the steps in order, and after each step confirm it worked before moving on. Do not claim a step is done until you have proven it.
@@ -30,7 +30,7 @@ You are setting yourself up to control my real Chrome through Vibe Browser. Work
 
 Then report: (1) is extensionConnected true, (2) did the snapshot return my real page content?
 
-My remote: <PASTE YOUR UUID OR wss:// URL HERE>
+My remote: <PASTE YOUR CONNECTOR URL, UUID, OR wss:// URL HERE>
 ```
 
 ## Why Vibe MCP?
@@ -270,7 +270,7 @@ Use the shortest direct package invocation for the MCP server:
 ```bash
 npx -y @vibebrowser/mcp@latest --help
 npx -y @vibebrowser/mcp@latest start --transport http
-npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID"
+npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL"
 ```
 
 Backward-compatible aliases still work when you need explicit binaries:
@@ -295,8 +295,18 @@ https://relay.api.vibebrowser.app/mcp/<your-extension-uuid>
 ```
 
 Find `<your-extension-uuid>` in the extension: **Vibe icon → Settings → AI Agent
-Control → Remote (internet) → Relay access**. It is the same UUID the CLI takes
-as `--remote wss://relay.api.vibebrowser.app/<uuid>`.
+Control → Remote (internet) → Relay access**. That panel shows this exact
+connector URL, and the same string is now the **preferred** value for the
+CLI/server `--remote` flag — paste it in both places, no translation needed:
+
+```bash
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/00000000-0000-0000-0000-000000000000"
+npx -y @vibebrowser/mcp@latest start --remote "$VIBE_REMOTE_URL"
+```
+
+A bare extension UUID or a `wss://relay.api.vibebrowser.app/<uuid>` relay URL
+are still accepted as advanced/compatibility forms — see the accepted
+`--remote` values table in "Cloud OpenClaw -> Local Browser" below.
 
 This is a plain **Streamable HTTP** MCP endpoint. There is **no OAuth consent
 flow, no dynamic client registration, and no scope setup** on this path — the
@@ -465,14 +475,26 @@ When multiple agents connect, Vibe MCP automatically spawns a relay daemon:
 
 ### Cloud OpenClaw -> Local Browser
 
-> ⚠️ **Security:** The `--remote` value below is a live credential — a relay URL/UUID grants full control of the target browser session. It is the *sole* bearer credential (there is no second-factor token). Treat it like a password: keep it secret, never commit it or paste it into logs, and if it leaks, regenerate it in the Vibe extension Settings.
+> ⚠️ **Security:** The `--remote` value below is a live credential — a relay URL/UUID/connector URL grants full control of the target browser session. It is the *sole* bearer credential (there is no second-factor token). Treat it like a password: keep it secret, never commit it or paste it into logs, and if it leaks, regenerate it in the Vibe extension Settings.
 
-If your agent runs in the cloud but you want it to control the user's real local browser, run `vibebrowser-mcp` in HTTP mode and connect it to the Vibe extension in remote relay mode. Pass either the extension UUID or the full WebSocket relay URL to `--remote`.
+#### Accepted `--remote` values
+
+`--remote` (and the MCP `set_remote` tool) accept three forms, all normalized to the same relay connection:
+
+| Form | Example | Maps to | Status |
+|---|---|---|---|
+| Connector URL | `https://relay.api.vibebrowser.app/mcp/00000000-0000-0000-0000-000000000000` | relay `wss://relay.api.vibebrowser.app` + UUID | **Recommended** — same string shown in extension Settings and pasted into Claude/ChatGPT connectors |
+| Bare extension UUID | `00000000-0000-0000-0000-000000000000` | default public relay + UUID | Advanced / compatibility |
+| ws(s) relay URL | `wss://relay.api.vibebrowser.app/00000000-0000-0000-0000-000000000000` | explicit relay endpoint | Advanced / compatibility |
+
+Self-hosted or local relays derive the same way: `https://your-host/vibe/mcp/<uuid>` → relay `wss://your-host/vibe`; a loopback connector like `http://127.0.0.1:19889/mcp/<uuid>` → `ws://127.0.0.1:19889` (self-hosted/local relay only — non-loopback hosts must use `https://`/`wss://`).
+
+Rejected: an invalid UUID; a URL with embedded credentials, a query string, or a fragment; plaintext `http://`/`ws://` for a non-loopback host; and any HTTP(S) URL that doesn't end in the exact `/mcp/<uuid>` suffix.
+
+If your agent runs in the cloud but you want it to control the user's real local browser, run `vibebrowser-mcp` in HTTP mode and connect it to the Vibe extension in remote relay mode. Pass the connector URL (preferred), the extension UUID, or the full WebSocket relay URL to `--remote`.
 
 ```bash
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
-npx -y @vibebrowser/mcp@latest start --transport http --remote "$VIBE_REMOTE_UUID"
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/00000000-0000-0000-0000-000000000000"
 npx -y @vibebrowser/mcp@latest start --transport http --remote "$VIBE_REMOTE_URL"
 ```
 
@@ -481,34 +503,28 @@ This exposes a local MCP endpoint at `http://127.0.0.1:8788/mcp` by default.
 When OpenClaw runs on a different machine (for example cloud-hosted), provide a reachable URL:
 
 ```bash
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/00000000-0000-0000-0000-000000000000"
 PUBLIC_MCP_URL="https://browser-bridge.example.com/mcp"
-npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
 npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
 ```
 
 You can print the exact OpenClaw-friendly setup with:
 
 ```bash
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
-npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID"
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/00000000-0000-0000-0000-000000000000"
 npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL"
 ```
 
-Use `--remote <uuid>` with the default public relay, or `--remote <full-ws-url>` when you need an explicit relay endpoint. The UUID is the only credential — never share it, log it, or paste it into an untrusted chat.
+Use the connector URL (preferred) with the default public relay, a bare UUID (default public relay), or a `wss://` URL when you need an explicit relay endpoint. Whichever form you use is the only credential — never share it, log it, or paste it into an untrusted chat.
 
 For direct browser CLI checks, always use `npx -y @vibebrowser/cli@latest`:
 
 ```bash
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" --json status
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/00000000-0000-0000-0000-000000000000"
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json status
 ```
 
-`--remote <uuid>` uses the default public relay. `--remote <full-ws-url>` targets an explicit relay endpoint. No second-factor secret is needed or accepted — the UUID alone authorizes the session.
+The connector URL uses the default public relay. `--remote <uuid>` also uses the default public relay. `--remote <full-ws-url>` targets an explicit relay endpoint. No second-factor secret is needed or accepted — whichever form you pass is the sole credential that authorizes the session.
 
 For the full walkthrough, see `docs/openclaw-local-browser.md`.
 
@@ -518,13 +534,12 @@ For the full walkthrough, see `docs/openclaw-local-browser.md`.
 
 ```bash
 npx -y @vibebrowser/cli@latest sessions
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" status
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/00000000-0000-0000-0000-000000000000"
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" status
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" tabs
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" open https://example.com
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" open https://example.com
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" snapshot
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" click 12
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" click 12
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" type 23 "hello" --submit
 npx -y @vibebrowser/cli@latest --devtools status
 ```
@@ -541,7 +556,7 @@ Local-session selection:
 - `npx -y @vibebrowser/cli@latest sessions` lists connected local browser sessions.
 - `npx -y @vibebrowser/cli@latest --session <id> ...` targets a specific local session.
 - If `--session` is omitted in local mode, the CLI uses the first connected session.
-- In remote mode, pass either `--remote <uuid>` to use the default public relay or `--remote <full-ws-url>` to use an explicit relay endpoint.
+- In remote mode, pass the connector URL (preferred), a bare `--remote <uuid>` to use the default public relay, or `--remote <full-ws-url>` to use an explicit relay endpoint.
 
 Snapshot behavior is tool-only (no legacy snapshot RPC shortcut):
 
@@ -573,7 +588,7 @@ There are two ways to use Vibe with OpenClaw:
 If OpenClaw runs in the cloud but you want it to control your local browser:
 
 1. Install the Vibe extension and enable **Remote** mode (see [docs/openclaw-local-browser.md](docs/openclaw-local-browser.md))
-2. Start the local HTTP bridge: `vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_UUID" [--public-url "$PUBLIC_MCP_URL"]` or `vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL" [--public-url "$PUBLIC_MCP_URL"]`
+2. Start the local HTTP bridge: `vibebrowser-mcp openclaw --remote "$VIBE_REMOTE_URL" [--public-url "$PUBLIC_MCP_URL"]`
 3. Register the MCP URL in OpenClaw
 
 **Option B: OpenClaw skill for local agents**
@@ -581,7 +596,7 @@ If OpenClaw runs in the cloud but you want it to control your local browser:
 For OpenClaw agents that need your real browser context (logged-in sessions, existing tabs):
 
 1. Copy the Vibe skill from this package to your OpenClaw skills folder
-2. Use the extension UUID or full WebSocket relay URL with `--remote`
+2. Use the connector URL (preferred), the extension UUID, or full WebSocket relay URL with `--remote`
 3. Use `npx -y @vibebrowser/cli@latest` commands in your agent prompts
 
 The skill is located at [`openclaw/vibebrowser/SKILL.md`](openclaw/vibebrowser/SKILL.md) and provides:
@@ -652,29 +667,27 @@ npx -y @vibebrowser/mcp@latest [start] [options]
   --http-port <number> Port for streamable HTTP MCP transport (default: 8788)
   --http-path <path>   Path for streamable HTTP MCP transport (default: /mcp)
   --allow-host <host>  Allowed host header for HTTP transport (repeatable)
-  -r, --remote <uuid-or-url>  Extension UUID, or full ws(s) remote URL. This routing UUID is the sole bearer credential — treat it like a password.
+  -r, --remote <uuid-or-url>  Connect to a remote extension via relay. Accepts the connector URL from extension Settings (https://relay.api.vibebrowser.app/mcp/<uuid>), a bare extension UUID, or a ws(s) relay URL. This value is the sole bearer credential — treat it like a password; regenerate it in extension Settings if exposed.
   --devtools           Drive your real running Chrome directly over the DevTools Protocol (bypasses the extension relay)
 
 # MCP server tool
-set_remote { "url": "wss://relay.api.vibebrowser.app/<extension-uuid>" }
+set_remote { "url": "https://relay.api.vibebrowser.app/mcp/<extension-uuid>" }
 ```
 
-The `set_remote` MCP server tool hot-reconnects the running MCP server to a different remote relay URL. It is an MCP tool, not a browser CLI subcommand. The URL's UUID is the only credential — never place it in logs shared with untrusted parties; regenerate it in extension Settings if exposed.
+The `set_remote` MCP server tool hot-reconnects the running MCP server to a different remote relay. It is an MCP tool, not a browser CLI subcommand. It accepts the same three forms as `--remote` (connector URL preferred, bare UUID, or `wss://` URL). The value is the only credential — never place it in logs shared with untrusted parties; regenerate it in extension Settings if exposed.
 
 ```bash
 # OpenClaw helper
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/00000000-0000-0000-0000-000000000000"
 PUBLIC_MCP_URL="https://browser-bridge.example.com/mcp"
-npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
 npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
 
 # OpenClaw-compatible browser CLI
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" status
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" status
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" status --wait-for-extension --wait-timeout 10000
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" tabs
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" tabs
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" snapshot --json
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" click 12
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" click 12
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" type 23 "hello" --submit
 npx -y @vibebrowser/cli@latest --devtools tabs
 

--- a/docs/openclaw-local-browser.md
+++ b/docs/openclaw-local-browser.md
@@ -8,7 +8,7 @@ published: true
 
 If you are running OpenClaw in the cloud, one of the most useful upgrades is giving it access to a real browser.
 
-> ⚠️ **Security:** A relay URL/UUID (`wss://relay.api.vibebrowser.app/<uuid>`) grants **live control of your browser session** (read tabs, screenshots, page content). It is the *sole* bearer credential — there is no second-factor secret. Treat it like a password — never share it, paste it into a chat with untrusted parties, or commit it to a repo — and if it leaks, regenerate it in the Vibe extension Settings. Example UUIDs in this doc are placeholders (`YOUR-EXTENSION-UUID` / `00000000-0000-0000-0000-000000000000`) and are not routable.
+> ⚠️ **Security:** A relay URL/UUID/connector URL (`https://relay.api.vibebrowser.app/mcp/<uuid>`) grants **live control of your browser session** (read tabs, screenshots, page content). It is the *sole* bearer credential — there is no second-factor secret. Treat it like a password — never share it, paste it into a chat with untrusted parties, or commit it to a repo — and if it leaks, regenerate it in the Vibe extension Settings. Example UUIDs in this doc are placeholders (`YOUR-EXTENSION-UUID` / `00000000-0000-0000-0000-000000000000`) and are not routable.
 
 But there are actually two different browser problems hiding inside that sentence:
 
@@ -84,9 +84,21 @@ The user needs three pieces:
 3. Go to **Settings** (gear icon)
 4. Find **MCP External** (or "MCP External Control")
 5. Enable it and select **Remote** mode
-6. Copy either the extension UUID or the full WebSocket relay URL shown, for example `wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID`
+6. Copy the **connector URL** shown, for example `https://relay.api.vibebrowser.app/mcp/YOUR-EXTENSION-UUID` — this is the **preferred** value for `--remote`. The bare extension UUID or the full `wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID` relay URL also still work, as advanced/compatibility forms.
 
-> **Note**: `--remote <uuid>` uses the default public relay. `--remote <full-ws-url>` targets an explicit relay endpoint.
+Accepted `--remote` values:
+
+| Form | Example | Status |
+|---|---|---|
+| Connector URL | `https://relay.api.vibebrowser.app/mcp/YOUR-EXTENSION-UUID` | **Recommended** |
+| Bare extension UUID | `YOUR-EXTENSION-UUID` | Advanced / compatibility (default public relay) |
+| ws(s) relay URL | `wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID` | Advanced / compatibility (explicit relay endpoint) |
+
+Self-hosted/local relay: a connector URL like `http://127.0.0.1:19889/mcp/YOUR-EXTENSION-UUID` maps to `ws://127.0.0.1:19889` (loopback only — non-loopback relays must use `https://`/`wss://`).
+
+Rejected: an invalid UUID; a URL with embedded credentials, a query string, or a fragment; plaintext `http://`/`ws://` for a non-loopback host; and any HTTP(S) URL that doesn't end in the exact `/mcp/<uuid>` suffix.
+
+> **Note**: The connector URL (preferred) and `--remote <uuid>` both use the default public relay. `--remote <full-ws-url>` targets an explicit relay endpoint.
 
 ## Step 2: Start the local HTTP bridge
 
@@ -95,10 +107,8 @@ On the same machine where the browser extension is installed, run one of these r
 **Option A: Using the helper command (recommended)**
 
 ```bash
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/YOUR-EXTENSION-UUID"
 
-npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID"
 npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL"
 ```
 
@@ -107,21 +117,17 @@ This prints the exact commands and MCP URL you need.
 If OpenClaw is running on another machine (for example in the cloud), provide a reachable URL:
 
 ```bash
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/YOUR-EXTENSION-UUID"
 PUBLIC_MCP_URL="https://browser-bridge.example.com/mcp"
 
-npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_UUID" --public-url "$PUBLIC_MCP_URL"
 npx -y @vibebrowser/mcp@latest openclaw --remote "$VIBE_REMOTE_URL" --public-url "$PUBLIC_MCP_URL"
 ```
 
 **Option B: Manual command**
 
 ```bash
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/YOUR-EXTENSION-UUID"
 
-npx -y @vibebrowser/mcp@latest start --transport http --remote "$VIBE_REMOTE_UUID"
 npx -y @vibebrowser/mcp@latest start --transport http --remote "$VIBE_REMOTE_URL"
 ```
 
@@ -139,24 +145,21 @@ For operator workflows and OpenClaw skills, you can also use the OpenClaw-compat
 
 ```bash
 npx -y @vibebrowser/cli@latest sessions
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" status
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/YOUR-EXTENSION-UUID"
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" status
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" tabs
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" snapshot --json
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" snapshot --json
 ```
 
-The CLI accepts only these remote forms:
+The CLI accepts these remote forms — connector URL (preferred), bare UUID, or `wss://` relay URL:
 
 ```bash
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/YOUR-EXTENSION-UUID"
 
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" --json status
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json status
 ```
 
-`--remote <uuid>` uses the default public relay. `--remote <full-ws-url>` targets an explicit relay endpoint. No second-factor secret is needed or accepted — the UUID alone authorizes the session.
+The connector URL (preferred) and `--remote <uuid>` both use the default public relay. `--remote <full-ws-url>` targets an explicit relay endpoint. No second-factor secret is needed or accepted — whichever form you pass is the sole credential that authorizes the session.
 
 `snapshot` is tool-only and maps to the specific snapshot tool for the requested format:
 
@@ -193,13 +196,13 @@ Use that loopback URL only for same-machine setups. For cloud OpenClaw, set `"ur
 
 Once that is configured, the cloud OpenClaw agent can use the Vibe browser tools through the local bridge.
 
-If the browser relay URL changes (for example after regenerating the routing UUID in extension Settings) while the MCP server is already running, call the MCP server tool `set_remote` with the new full URL to hot-reconnect without restarting the server:
+If the browser relay URL changes (for example after regenerating the routing UUID in extension Settings) while the MCP server is already running, call the MCP server tool `set_remote` with the new connector URL (preferred) or a `wss://` URL to hot-reconnect without restarting the server:
 
 ```json
-{ "url": "wss://relay.api.vibebrowser.app/<extension-uuid>" }
+{ "url": "https://relay.api.vibebrowser.app/mcp/<extension-uuid>" }
 ```
 
-`set_remote` is an MCP tool exposed by the server, not a `vibebrowser-cli` subcommand.
+`set_remote` is an MCP tool exposed by the server, not a `vibebrowser-cli` subcommand. It accepts the same three `--remote` forms (connector URL, bare UUID, or `wss://` URL).
 
 ## Optional: Use the OpenClaw skill for local agents
 
@@ -211,13 +214,11 @@ Copy `openclaw/vibebrowser/SKILL.md` from this package to your OpenClaw skills d
 
 ### Configure environment
 
-Use either remote form in commands:
+Use the connector URL (preferred) or another remote form in commands:
 
 ```bash
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/YOUR-EXTENSION-UUID"
 
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" --json status
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json status
 ```
 
@@ -225,21 +226,20 @@ npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json status
 
 ```bash
 # Check status
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" --json status
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/YOUR-EXTENSION-UUID"
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json status
 
 # List tabs
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json tabs
 
 # Open a page
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" --json open https://example.com
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json open https://example.com
 
 # Click element by index
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json click 12
 
 # Type into element
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" --json type 23 "hello"
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json type 23 "hello"
 ```
 
 See [`openclaw/vibebrowser/SKILL.md`](../openclaw/vibebrowser/SKILL.md) for the full command reference.
@@ -293,7 +293,7 @@ The end result is simple:
 
 ### "Remote relay URL not found"
 
-Make sure you've enabled **Remote** mode in the Vibe extension settings. Use `--remote <uuid>` for the default public relay or `--remote <full-ws-url>` for an explicit relay endpoint.
+Make sure you've enabled **Remote** mode in the Vibe extension settings. Use the connector URL (preferred) or `--remote <uuid>` for the default public relay, or `--remote <full-ws-url>` for an explicit relay endpoint.
 
 ### "Connection refused" errors
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "vibe-browser",
   "display_name": "Vibe Browser",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Drive your real, logged-in Chrome from Claude Desktop.",
   "long_description": "Vibe Browser lets Claude drive the Chrome you already use - with your tabs, your cookies, and your logged-in sessions - instead of a headless throwaway browser.\n\nThe browser can also run on a different machine from Claude, with no inbound port open on either side, by pairing them through a relay UUID.\n\nRequires the free Vibe Chrome extension. After installing this bundle, install the extension from the Chrome Web Store and enable 'MCP External Control' in its Settings.",
   "author": {

--- a/openclaw/vibebrowser/SKILL.md
+++ b/openclaw/vibebrowser/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 # Vibe Local Browser
 
-> ⚠️ **Security:** The remote value (a relay URL/UUID, `wss://relay.api.vibebrowser.app/<uuid>`) grants **live control of the user's browser session** (read tabs, screenshots, page content). It is the *sole* bearer credential — there is no second-factor secret. Treat it like a password — never echo it back in chat with untrusted parties, log it, or commit it to a repo — and if it leaks, tell the user to regenerate it in the Vibe extension Settings. Store it only in private workspace/memory as described below. Example UUIDs are non-routable placeholders.
+> ⚠️ **Security:** The remote value (a connector URL, bare UUID, or relay URL — e.g. `https://relay.api.vibebrowser.app/mcp/<uuid>`) grants **live control of the user's browser session** (read tabs, screenshots, page content). It is the *sole* bearer credential — there is no second-factor secret. Treat it like a password — never echo it back in chat with untrusted parties, log it, or commit it to a repo — and if it leaks, tell the user to regenerate it in the Vibe extension Settings. Store it only in private workspace/memory as described below. Example UUIDs are non-routable placeholders.
 
 ## FIRST, EVERY TIME: load the saved remote before asking for it
 
@@ -76,13 +76,13 @@ remote). For those requests:
    - Open extension Settings → **AI Agent Control**
    - Toggle **Enable external AI agent control** to ON
    - Set **Connection mode** to **Remote (internet)**
-   - Copy the relay URL from the **Relay access** section
+   - Copy the **connector URL** from the **Relay access** section (`https://relay.api.vibebrowser.app/mcp/<uuid>`) — this is the preferred value; the bare UUID or `wss://` relay URL shown there also still work
 
 2. **Provide the remote value** (one of):
-   - Pass it directly on every command with `--remote <uuid-or-url>` — no environment variable needed.
+   - Pass it directly on every command with `--remote <connector-url-uuid-or-ws-url>` — no environment variable needed.
    - Or set it once as an environment variable so `--remote` can be omitted (the CLI picks it up automatically):
      ```bash
-     export VIBE_REMOTE_URL="<uuid-or-full-ws-url>"
+     export VIBE_REMOTE_URL="<connector-url-uuid-or-full-ws-url>"
      ```
    - **Preferred: save it for the session** — see [## Remembering the remote connection](#remembering-the-remote-connection) below.
 
@@ -108,14 +108,18 @@ Do not use this skill for OpenClaw tenant cloud browsing.
 
 ## Remote value
 
-Every command needs a remote value: the extension UUID (uses the default public relay) or a full `ws(s)` relay URL (explicit relay endpoint).
+Every command needs a remote value. Three forms are accepted, all normalized to the same relay connection:
 
-Pass it with `--remote <uuid-or-url>`. No environment variable is required when `--remote` is set.
+- **Connector URL (preferred):** `https://relay.api.vibebrowser.app/mcp/<uuid>` — the exact string shown in the extension's Settings → AI Agent Control → Relay access, the same one pasted into Claude/ChatGPT connectors.
+- Bare extension UUID — uses the default public relay (advanced/compatibility).
+- Full `ws(s)` relay URL — targets an explicit relay endpoint (advanced/compatibility).
+
+Pass it with `--remote <connector-url-uuid-or-ws-url>`. No environment variable is required when `--remote` is set.
 
 Optionally, set it once via environment instead — the CLI uses it as the default when `--remote` is omitted (checked in this order):
 
 ```bash
-export VIBE_REMOTE_URL="<uuid-or-full-ws-url>"
+export VIBE_REMOTE_URL="<connector-url-uuid-or-full-ws-url>"
 # Also honored: VIBE_EXTENSION_UUID, VIBE_RELAY_UUID
 
 # Optional compatibility label. Vibe always targets the real local browser path.
@@ -130,8 +134,9 @@ The user should only have to provide their remote value once. After receiving it
 
 ### What counts as a "remote value"
 
-Either of these forms is valid for `--remote`:
+Any of these forms is valid for `--remote`:
 
+- **Connector URL (preferred):** `https://relay.api.vibebrowser.app/mcp/<uuid>`
 - A bare UUID: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 - A full relay URL: `wss://relay.api.vibebrowser.app/<uuid>`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vibebrowser/mcp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibebrowser/mcp",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -1236,7 +1236,7 @@
     },
     "packages/cli": {
       "name": "@vibebrowser/cli",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibebrowser/mcp",
   "mcpName": "io.github.VibeTechnologies/vibe-mcp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "description": "MCP server that drives your real, logged-in Chrome from any MCP client - including agents on a remote machine, with no inbound port open",
   "main": "dist/index.js",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,14 +2,21 @@
 
 Standalone CLI for controlling a Vibe-connected browser session.
 
-> ⚠️ **Security:** A relay URL/UUID (`wss://relay.api.vibebrowser.app/<uuid>`) grants **live control of your browser session** (read tabs, screenshots, page content). It is the *sole* bearer credential — there is no second-factor secret. Treat it like a password — never share it, paste it into a chat with untrusted parties, or commit it to a repo — and if it leaks, regenerate it in the Vibe extension Settings. The `YOUR-EXTENSION-UUID` value below is a non-routable placeholder.
+> ⚠️ **Security:** A relay URL/UUID/connector URL (`https://relay.api.vibebrowser.app/mcp/<uuid>`) grants **live control of your browser session** (read tabs, screenshots, page content). It is the *sole* bearer credential — there is no second-factor secret. Treat it like a password — never share it, paste it into a chat with untrusted parties, or commit it to a repo — and if it leaks, regenerate it in the Vibe extension Settings. The `YOUR-EXTENSION-UUID` value below is a non-routable placeholder.
+
+`--remote` accepts three forms, all normalized to the same relay connection:
+
+| Form | Example | Status |
+|---|---|---|
+| Connector URL | `https://relay.api.vibebrowser.app/mcp/00000000-0000-0000-0000-000000000000` | **Recommended** — the same string shown in the extension's Settings and pasted into Claude/ChatGPT connectors |
+| Bare extension UUID | `00000000-0000-0000-0000-000000000000` | Advanced / compatibility — uses the default public relay |
+| ws(s) relay URL | `wss://relay.api.vibebrowser.app/00000000-0000-0000-0000-000000000000` | Advanced / compatibility — targets an explicit relay endpoint |
 
 ```bash
-VIBE_REMOTE_UUID="YOUR-EXTENSION-UUID"
-VIBE_REMOTE_URL="wss://relay.api.vibebrowser.app/YOUR-EXTENSION-UUID"
+VIBE_REMOTE_URL="https://relay.api.vibebrowser.app/mcp/00000000-0000-0000-0000-000000000000"
 
-npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_UUID" --json status
+npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json status
 npx -y @vibebrowser/cli@latest --remote "$VIBE_REMOTE_URL" --json tabs
 ```
 
-`--remote <uuid>` uses the default public Vibe relay. `--remote <full-ws-url>` targets an explicit relay endpoint. No second-factor secret is needed or accepted — the UUID alone authorizes the session.
+`--remote <connector-url>` (preferred) and `--remote <uuid>` both use the default public Vibe relay. `--remote <full-ws-url>` targets an explicit relay endpoint. No second-factor secret is needed or accepted — whichever form you pass is the sole credential that authorizes the session. Rejected: an invalid UUID; a URL with embedded credentials, a query string, or a fragment; plaintext `http://`/`ws://` for a non-loopback host; and any HTTP(S) URL that doesn't end in the exact `/mcp/<uuid>` suffix.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibebrowser/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "Standalone Vibe Browser CLI for controlling a Vibe-connected browser session",
   "bin": {

--- a/plugins/vibe-browser/.claude-plugin/plugin.json
+++ b/plugins/vibe-browser/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "vibe-browser",
   "displayName": "Vibe Browser",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Drive your real, logged-in Chrome from Claude Code. Navigate, click, type, screenshot and read pages in the browser you already use - including a browser on a different machine, with no inbound port open.",
   "author": {
     "name": "Vibe Technologies",

--- a/plugins/vibe-browser/.mcp.json
+++ b/plugins/vibe-browser/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "vibe": {
       "command": "npx",
-      "args": ["-y", "@vibebrowser/mcp@0.3.3"]
+      "args": ["-y", "@vibebrowser/mcp@0.3.4"]
     }
   }
 }

--- a/scripts/e2e-browser-cli.mjs
+++ b/scripts/e2e-browser-cli.mjs
@@ -166,7 +166,7 @@ try {
     });
   });
 
-  const { parseRemoteRelayUrl } = await import(DIST_CONNECTION);
+  const { parseRemoteRelayUrl, parseRemoteTarget } = await import(DIST_CONNECTION);
   const parsedWssRemote = parseRemoteRelayUrl(`wss://relay.example.test/nested/${REMOTE_UUID}`);
   assert(parsedWssRemote.relayUrl === 'wss://relay.example.test/nested', `wss remote relay base parsed incorrectly: ${JSON.stringify(parsedWssRemote)}`);
   assert(parsedWssRemote.uuid === REMOTE_UUID, `wss remote UUID parsed incorrectly: ${JSON.stringify(parsedWssRemote)}`);
@@ -179,12 +179,25 @@ try {
   }
   assert(queryRejected, 'remote relay URL with query params should be rejected (token must be separate)');
 
+  const parsedHttpConnector = parseRemoteTarget(`https://relay.example.test/nested/mcp/${REMOTE_UUID}`);
+  assert(parsedHttpConnector.relayUrl === 'wss://relay.example.test/nested', `https connector relay base parsed incorrectly: ${JSON.stringify(parsedHttpConnector)}`);
+  assert(parsedHttpConnector.uuid === REMOTE_UUID, `https connector UUID parsed incorrectly: ${JSON.stringify(parsedHttpConnector)}`);
+
   const status = await runCli(['status']);
   assert(status.ok === true, `status failed: ${JSON.stringify(status)}`);
   assert(status.extensionConnected === true, `expected extension connected: ${JSON.stringify(status)}`);
   assert(Number(status.toolCount) >= 10, `expected toolCount >= 10: ${JSON.stringify(status)}`);
   assert(status.sessionId === REDACTED_REMOTE_ID, `expected redacted remote session: ${JSON.stringify(status)}`);
   assert(!JSON.stringify(status).includes(REMOTE_UUID), `status leaked remote UUID: ${JSON.stringify(status)}`);
+
+  const connectorStatus = await runCli(['status'], { remoteValue: `http://${HOST}:${RELAY_PORT}/mcp/${REMOTE_UUID}` });
+  assert(connectorStatus.ok === true, `connector-url status failed: ${JSON.stringify(connectorStatus)}`);
+  assert(connectorStatus.mode === 'remote', `connector-url status should be remote mode: ${JSON.stringify(connectorStatus)}`);
+  assert(connectorStatus.extensionConnected === true, `connector-url status should connect extension: ${JSON.stringify(connectorStatus)}`);
+  assert(connectorStatus.sessionId === REDACTED_REMOTE_ID, `connector-url status should redact sessionId: ${JSON.stringify(connectorStatus)}`);
+  assert(!JSON.stringify(connectorStatus).includes(REMOTE_UUID), `connector-url status leaked remote UUID: ${JSON.stringify(connectorStatus)}`);
+  assert(connectorStatus.toolCount === status.toolCount, `connector-url status toolCount mismatch: ${JSON.stringify(connectorStatus)} vs ${JSON.stringify(status)}`);
+  assert(Array.isArray(connectorStatus.sessions) && connectorStatus.sessions.length === status.sessions.length, `connector-url status sessions mismatch: ${JSON.stringify(connectorStatus)} vs ${JSON.stringify(status)}`);
 
   const uuidStatus = await runCli(['status'], { remoteValue: REMOTE_UUID });
   if (E2E_BROWSER_CLI_SOURCE === 'local') {

--- a/scripts/e2e-cli-package-smoke.mjs
+++ b/scripts/e2e-cli-package-smoke.mjs
@@ -79,6 +79,13 @@ function main() {
     throw new Error(`CLI help output missing usage marker\nstdout=${helpResult.stdout}\nstderr=${helpResult.stderr}`);
   }
   console.log('CLI_PACK_GATE:HELP_OK');
+
+  const remoteHelpIndex = helpOutput.indexOf('--remote');
+  const remoteHelpText = remoteHelpIndex >= 0 ? helpOutput.slice(remoteHelpIndex, remoteHelpIndex + 600) : '';
+  if (!remoteHelpText.includes('/mcp/<uuid>')) {
+    throw new Error(`CLI --remote help does not advertise the /mcp/<uuid> connector URL form\nhelp=${helpOutput}`);
+  }
+  console.log('CLI_PACK_GATE:REMOTE_HELP_OK');
   console.log('CLI_PACK_GATE:PASS');
 }
 

--- a/scripts/e2e-remote-lifecycle.mjs
+++ b/scripts/e2e-remote-lifecycle.mjs
@@ -7,7 +7,9 @@ import {
   ExtensionConnection,
   isPermanentRelayCloseCode,
   isPermanentRelayHttpStatus,
+  parseHttpMcpConnectorUrl,
   parseRemoteRelayUrl,
+  parseRemoteTarget,
   redactRemoteTarget,
   REDACTED_REMOTE_ID,
 } from '../dist/connection.js';
@@ -287,6 +289,125 @@ async function testUrlValidation() {
     /must use wss/,
     'private/development non-loopback plaintext relay',
   );
+}
+
+// Fabricated, non-routable stand-ins for a leaked secret. Never real values.
+const FAKE_URL_USER = 'connector-user';
+const FAKE_URL_SECRET = 'connector-secret';
+const FAKE_QUERY_TOKEN = 'connector-query-token';
+const AT = String.fromCharCode(64);
+
+function assertNoLeak(message, label) {
+  const lower = message.toLowerCase();
+  assert(!lower.includes(UUID_A.toLowerCase()), `${label}: message leaked UUID_A: ${message}`);
+  assert(!lower.includes(UUID_B.toLowerCase()), `${label}: message leaked UUID_B: ${message}`);
+  assert(!lower.includes(FAKE_URL_USER), `${label}: message leaked URL username: ${message}`);
+  assert(!lower.includes(FAKE_URL_SECRET), `${label}: message leaked URL password: ${message}`);
+  assert(!lower.includes(FAKE_QUERY_TOKEN), `${label}: message leaked query token value: ${message}`);
+  assert(!lower.includes('relay.example.test'), `${label}: message leaked target host: ${message}`);
+}
+
+async function testConnectorUrlNormalization() {
+  // Canonical form: https://host/mcp/<uuid> -> wss://host
+  const basic = parseRemoteTarget(`https://relay.example.test/mcp/${UUID_A}`);
+  assert(basic.relayUrl === 'wss://relay.example.test', `basic connector relayUrl wrong: ${JSON.stringify(basic)}`);
+  assert(basic.uuid === UUID_A, `basic connector uuid wrong: ${JSON.stringify(basic)}`);
+
+  // Self-hosted single-segment prefix
+  const prefixed = parseRemoteTarget(`https://relay.example.test/vibe/mcp/${UUID_A}`);
+  assert(prefixed.relayUrl === 'wss://relay.example.test/vibe', `prefixed connector relayUrl wrong: ${JSON.stringify(prefixed)}`);
+  assert(prefixed.uuid === UUID_A, `prefixed connector uuid wrong: ${JSON.stringify(prefixed)}`);
+
+  // Deeper prefix
+  const deepPrefixed = parseRemoteTarget(`https://relay.example.test/a/b/mcp/${UUID_A}`);
+  assert(deepPrefixed.relayUrl === 'wss://relay.example.test/a/b', `deep prefixed connector relayUrl wrong: ${JSON.stringify(deepPrefixed)}`);
+  assert(deepPrefixed.uuid === UUID_A, `deep prefixed connector uuid wrong: ${JSON.stringify(deepPrefixed)}`);
+
+  // Non-default port preserved
+  const portPreserved = parseRemoteTarget(`https://relay.example.test:8443/mcp/${UUID_A}`);
+  assert(portPreserved.relayUrl === 'wss://relay.example.test:8443', `port-preserved connector relayUrl wrong: ${JSON.stringify(portPreserved)}`);
+  assert(portPreserved.uuid === UUID_A, `port-preserved connector uuid wrong: ${JSON.stringify(portPreserved)}`);
+
+  // Loopback plaintext maps to ws
+  const loopback1 = parseRemoteTarget(`http://127.0.0.1:19889/mcp/${UUID_A}`);
+  assert(loopback1.relayUrl === 'ws://127.0.0.1:19889', `loopback IPv4 connector relayUrl wrong: ${JSON.stringify(loopback1)}`);
+  const loopback2 = parseRemoteTarget(`http://localhost:19889/mcp/${UUID_A}`);
+  assert(loopback2.relayUrl === 'ws://localhost:19889', `loopback hostname connector relayUrl wrong: ${JSON.stringify(loopback2)}`);
+  const loopback3 = parseRemoteTarget(`http://[::1]:19889/mcp/${UUID_A}`);
+  assert(loopback3.relayUrl === 'ws://[::1]:19889', `loopback IPv6 connector relayUrl wrong: ${JSON.stringify(loopback3)}`);
+
+  // Bare UUID and ws(s) relay URL still normalize as before
+  const bareUuid = parseRemoteTarget(UUID_A, 'wss://relay.example.test');
+  assert(bareUuid.uuid === UUID_A && bareUuid.relayUrl === 'wss://relay.example.test', `bare uuid regression: ${JSON.stringify(bareUuid)}`);
+  const wssForm = parseRemoteTarget(`wss://relay.example.test/${UUID_B}`);
+  assert(wssForm.uuid === UUID_B && wssForm.relayUrl === 'wss://relay.example.test', `wss form regression: ${JSON.stringify(wssForm)}`);
+
+  // parseHttpMcpConnectorUrl direct export matches parseRemoteTarget for the connector form
+  const direct = parseHttpMcpConnectorUrl(`https://relay.example.test/mcp/${UUID_A}`);
+  assert(direct.relayUrl === basic.relayUrl && direct.uuid === basic.uuid, 'parseHttpMcpConnectorUrl and parseRemoteTarget disagree');
+
+  // Rejections
+  const rejections = [
+    [`https://relay.example.test/${UUID_A}`, /expected an MCP connector path/, 'no /mcp/ segment'],
+    [`https://relay.example.test/mcp`, /expected an MCP connector path/, 'missing uuid'],
+    [`https://relay.example.test/mcp/not-a-uuid`, /UUID path segment is not valid/, 'invalid uuid'],
+    [`https://relay.example.test/MCP/${UUID_A}`, /expected an MCP connector path/, 'wrong-case mcp segment'],
+    [`https://relay.example.test/mcp/${UUID_A}/extra`, /expected an MCP connector path/, 'trailing extra segment'],
+    [`http://relay.example.test/mcp/${UUID_A}`, /non-loopback|must use wss/i, 'non-loopback plaintext connector'],
+    [
+      `https://${FAKE_URL_USER}:${FAKE_URL_SECRET}${AT}relay.example.test/mcp/${UUID_A}`,
+      /credentials/,
+      'credentials in connector URL',
+    ],
+    [`https://relay.example.test/mcp/${UUID_A}?token=${FAKE_QUERY_TOKEN}`, /query|fragment/, 'query in connector URL'],
+    [`https://relay.example.test/mcp/${UUID_A}#frag`, /query|fragment/, 'fragment in connector URL'],
+    [`https://relay.example.test/`, /expected an MCP connector path/, 'generic http URL (root)'],
+    [`https://relay.example.test/api/tools`, /expected an MCP connector path/, 'generic http URL (path)'],
+  ];
+
+  for (const [input, pattern, label] of rejections) {
+    const message = await expectReject(
+      () => Promise.resolve(parseRemoteTarget(input)),
+      pattern,
+      label,
+    );
+    assertNoLeak(message, label);
+  }
+
+  const finalRedacted = redactRemoteTarget(
+    `boom https://relay.example.test/mcp/${UUID_A} ${UUID_A.toUpperCase()}`,
+    `https://relay.example.test/mcp/${UUID_A}`,
+  );
+  assert(
+    !finalRedacted.toLowerCase().includes(UUID_A.toLowerCase()),
+    `redactRemoteTarget leaked connector UUID: ${finalRedacted}`,
+  );
+}
+
+async function testSetRemoteAcceptsConnectorUrl() {
+  const port = await findFreePort();
+  const relay = startRelay(port, UUID_A);
+  const connection = new ExtensionConnection(0, false, undefined, undefined, 2_000, RECONNECT_DELAY_MS);
+  try {
+    const parsed = await withTimeout(
+      connection.setRemoteUrl(`http://${HOST}:${port}/mcp/${UUID_A}`),
+      'set_remote with http connector URL',
+    );
+    assert(parsed.uuid === UUID_A, `set_remote connector uuid wrong: ${JSON.stringify(parsed)}`);
+    assert(parsed.relayUrl === `ws://${HOST}:${port}`, `set_remote connector relayUrl wrong: ${JSON.stringify(parsed)}`);
+    await withTimeout(relay.connected, 'connector-url relay upgrade');
+    assert(connection.getStatus() === 'connected', `set_remote connector did not connect: ${connection.getStatus()}`);
+    assert(connection.getRemoteConfig()?.uuid === UUID_A, 'set_remote connector did not store uuid');
+
+    await expectReject(
+      () => connection.setRemoteUrl(`https://relay.example.test/api/tools`),
+      /expected an MCP connector path/,
+      'set_remote rejects generic http URL',
+    );
+  } finally {
+    await connection.stop();
+    await relay.close();
+  }
 }
 
 function testRetryPolicyMatrix() {
@@ -625,6 +746,8 @@ async function testHttpHandshakeRejectionMatrix() {
 }
 
 await testUrlValidation();
+await testConnectorUrlNormalization();
+await testSetRemoteAcceptsConnectorUrl();
 testRetryPolicyMatrix();
 testCaseInsensitiveRedaction();
 await testHandshakeTimeout();

--- a/server.json
+++ b/server.json
@@ -7,14 +7,14 @@
     "url": "https://github.com/VibeTechnologies/vibe-mcp",
     "source": "github"
   },
-  "version": "0.3.3",
+  "version": "0.3.4",
   "websiteUrl": "https://vibebrowser.app",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@vibebrowser/mcp",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "transport": {
         "type": "stdio"
       }

--- a/src/browser-cli.ts
+++ b/src/browser-cli.ts
@@ -120,7 +120,7 @@ function buildBrowserCommand(command: Command): Command {
     .option('-p, --port <number>', 'WebSocket port for local relay (agent) connection', String(DEFAULT_WS_PORT))
     .option('-d, --debug', 'Enable debug logging', false)
     .option('--devtools', 'Drive your real running Chrome directly over the DevTools Protocol (bypasses the extension relay)', false)
-    .option('-r, --remote <uuid-or-url>', 'Connect to a remote extension via relay (provide extension UUID or full ws(s) relay URL). This routing UUID is the sole bearer credential — treat it like a password; regenerate it in extension Settings if exposed.', DEFAULT_REMOTE)
+    .option('-r, --remote <uuid-or-url>', 'Connect to a remote extension via relay. Accepts the connector URL from extension Settings (https://relay.api.vibebrowser.app/mcp/<uuid>), a bare extension UUID, or a ws(s) relay URL. This value is the sole bearer credential — treat it like a password; regenerate it in extension Settings if exposed.', DEFAULT_REMOTE)
     .option('-s, --session <id>', 'Target a specific local browser session ID; defaults to the first connected session')
     .option('--json', 'Emit machine-readable JSON output', false)
     .option('--timeout <ms>', 'Command timeout in milliseconds', String(DEFAULT_TIMEOUT_MS))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,9 @@
  *
  * Modes:
  *   Local (default): connects to local relay daemon on localhost
- *   Remote (--remote <uuid-or-url>): connects to public relay at relay.api.vibebrowser.app
+ *   Remote (--remote <uuid-or-url>): connects to a Vibe relay using the MCP
+ *     connector URL from extension Settings (https://relay.api.vibebrowser.app/mcp/<uuid>),
+ *     a bare extension UUID, or a ws(s) relay URL.
  */
 
 import { program } from 'commander';
@@ -35,7 +37,7 @@ program
   .option('-p, --port <number>', 'WebSocket port for local relay (agent) connection', String(DEFAULT_WS_PORT))
   .option('-d, --debug', 'Enable debug logging', false)
   .option('--devtools', 'Drive your real running Chrome directly over the DevTools Protocol (bypasses the extension relay)', false)
-  .option('-r, --remote <uuid-or-url>', 'Connect to a remote extension via relay (provide extension UUID or full ws(s) relay URL). This routing UUID is the sole bearer credential — treat it like a password; regenerate it in extension Settings if exposed.')
+  .option('-r, --remote <uuid-or-url>', 'Connect to a remote extension via relay. Accepts the connector URL from extension Settings (https://relay.api.vibebrowser.app/mcp/<uuid>), a bare extension UUID, or a ws(s) relay URL. This value is the sole bearer credential — treat it like a password; regenerate it in extension Settings if exposed.')
   .option('-s, --session <id>', 'Target a specific local browser session ID; defaults to the first connected session')
   .option('--transport <mode>', 'MCP transport to expose: stdio or http', 'stdio')
   .option('--host <host>', 'Host to bind the HTTP server to', '127.0.0.1')
@@ -77,7 +79,7 @@ program
 program
   .command('openclaw')
   .description('Print OpenClaw-friendly configuration for cloud agent -> local browser relay')
-  .requiredOption('-r, --remote <uuid-or-url>', 'Extension UUID or full ws(s) relay URL from Vibe extension Settings > MCP External > Remote. Treat this routing UUID like a password; regenerate it in Settings if exposed.')
+  .requiredOption('-r, --remote <uuid-or-url>', 'MCP connector URL (https://relay.api.vibebrowser.app/mcp/<uuid>), extension UUID, or ws(s) relay URL from Vibe extension Settings > MCP External > Remote. Treat this value like a password; regenerate it in Settings if exposed.')
   .option('--host <host>', 'Host to bind the HTTP server to', '127.0.0.1')
   .option('--http-port <number>', 'Port for streamable HTTP MCP transport', String(DEFAULT_HTTP_PORT))
   .option('--http-path <path>', 'Path for streamable HTTP MCP transport', DEFAULT_HTTP_PATH)
@@ -123,7 +125,7 @@ program
       };
 
       console.log('Start a local bridge on the machine running the Vibe extension:');
-      console.log('Set VIBE_REMOTE_URL securely to the UUID or full relay URL, then run:');
+      console.log('Set VIBE_REMOTE_URL securely to the connector URL (https://relay.api.vibebrowser.app/mcp/<uuid>), a bare UUID, or a full ws(s) relay URL, then run:');
       console.log(`npx ${cliArgs.join(' ')}`);
       console.log('');
       console.log('Local bridge MCP URL:');

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -39,6 +39,7 @@ export const REDACTED_REMOTE_ID = '[redacted]';
 
 const DEFAULT_RELAY_URL = 'wss://relay.api.vibebrowser.app';
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MCP_CONNECTOR_SEGMENT = 'mcp';
 const PERMANENT_RELAY_CLOSE_CODES = new Set([
   1002, 1003, 1007, 1008,
   4001, 4003, 4004, 4009,
@@ -101,6 +102,14 @@ export function redactRemoteTarget(message: string, target?: string): string {
 
 function isRemoteRelayUrl(value: string): boolean {
   return /^wss?:\/\//i.test(value);
+}
+
+function isHttpConnectorUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function isRemoteTargetUrl(value: string): boolean {
+  return isRemoteRelayUrl(value) || isHttpConnectorUrl(value);
 }
 
 function isLoopbackHostname(hostname: string): boolean {
@@ -173,13 +182,65 @@ export function parseRemoteRelayUrl(value: string): ParsedRemoteRelayUrl {
   };
 }
 
-function parseRemoteTarget(value: string, currentRelayUrl?: string): ParsedRemoteRelayUrl {
+/**
+ * Parse the canonical HTTPS MCP connector URL exposed in the extension UI:
+ *   https://host[/prefix]/mcp/<uuid>  -> relayUrl wss://host[/prefix]
+ *   http://<loopback>[/prefix]/mcp/<uuid> -> relayUrl ws://<loopback>[/prefix]
+ *
+ * Error messages intentionally never echo the input value or the UUID, since
+ * this value is a bearer credential.
+ */
+export function parseHttpMcpConnectorUrl(value: string): ParsedRemoteRelayUrl {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error('Invalid MCP connector URL');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Invalid MCP connector URL: protocol must be http:// or https://');
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('Invalid MCP connector URL: credentials in URL are not allowed');
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error('Invalid MCP connector URL: query/fragments are not allowed');
+  }
+
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  const uuid = segments.pop();
+  const mcpSegment = segments.pop();
+  if (!uuid || mcpSegment !== MCP_CONNECTOR_SEGMENT) {
+    throw new Error('Invalid MCP connector URL: expected an MCP connector path ending in /mcp/<uuid>');
+  }
+  if (!UUID_PATTERN.test(uuid)) {
+    throw new Error('Invalid MCP connector URL: UUID path segment is not valid');
+  }
+
+  const relayProtocol = parsed.protocol === 'https:' ? 'wss:' : 'ws:';
+  parsed.pathname = segments.length > 0 ? `/${segments.join('/')}` : '';
+  parsed.search = '';
+  parsed.hash = '';
+  parsed.protocol = relayProtocol;
+
+  return {
+    relayUrl: normalizeRelayBaseUrl(parsed.toString()),
+    uuid,
+  };
+}
+
+export function parseRemoteTarget(value: string, currentRelayUrl?: string): ParsedRemoteRelayUrl {
   if (isRemoteRelayUrl(value)) {
     return parseRemoteRelayUrl(value);
   }
 
+  if (isHttpConnectorUrl(value)) {
+    return parseHttpMcpConnectorUrl(value);
+  }
+
   if (!UUID_PATTERN.test(value)) {
-    throw new Error('Invalid remote target: expected a UUID or ws(s) relay URL');
+    throw new Error('Invalid remote target: expected a UUID, an https://host/mcp/<uuid> connector URL, or a ws(s) relay URL');
   }
 
   return {
@@ -195,7 +256,7 @@ export function normalizeRemoteConfig(remote?: RemoteConfig): RemoteConfig | und
 
   const relayUrl = remote.relayUrl ? normalizeRelayBaseUrl(remote.relayUrl) : undefined;
   const parsed = parseRemoteTarget(remote.uuid, relayUrl);
-  if (relayUrl && isRemoteRelayUrl(remote.uuid) && relayUrl !== parsed.relayUrl) {
+  if (relayUrl && isRemoteTargetUrl(remote.uuid) && relayUrl !== parsed.relayUrl) {
     throw new Error('Remote relay URL mismatch');
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,13 +50,13 @@ const STARTUP_TOOLS_LIST_BUDGET_MS = 3_000;
 const CALL_TOOL_TIMEOUT_MS = 120_000;
 export const SET_REMOTE_TOOL: ToolDefinition = {
   name: 'set_remote',
-  description: 'Set the remote relay target for this MCP server. If browser tools are missing, call set_remote first to connect to a Vibe relay. The routing UUID in the URL is the sole bearer credential for the relay session.',
+  description: 'Set the remote relay target for this MCP server. If browser tools are missing, call set_remote first to connect to a Vibe relay using the MCP connector URL from extension Settings, a bare extension UUID, or a ws(s) relay URL. The UUID is the sole bearer credential for the relay session.',
   inputSchema: {
     type: 'object',
     properties: {
       url: {
         type: 'string',
-        description: 'Remote target as either an extension UUID or a full websocket relay URL (for example wss://relay.api.vibebrowser.app/<extension-uuid>). Call set_remote first when browser tools are unavailable.',
+        description: 'Remote target: the MCP connector URL from the Vibe extension (https://relay.api.vibebrowser.app/mcp/<extension-uuid>), a bare extension UUID, or a ws(s) relay URL. Call set_remote first when browser tools are unavailable.',
       },
     },
     required: ['url'],


### PR DESCRIPTION
Stacked on #136 (`fix/135-relay-lifecycle`) — review that first; this PR's diff is only the last commit.

Closes #145. Parent: #130.

## Problem

The extension shows one canonical connector credential:

```text
https://relay.api.vibebrowser.app/mcp/<uuid>
```

Claude/ChatGPT accept it directly, but the CLI required either a bare UUID or a separate `wss://relay.api.vibebrowser.app/<uuid>` value — two transport URLs for the same bearer capability.

## Change

`--remote` (`start`, `openclaw`, browser CLI) and the MCP `set_remote` tool now accept the connector URL, normalized through the one shared entry point `parseRemoteTarget` in `src/connection.ts`:

| `--remote` input | Derived relay | Status |
|---|---|---|
| `https://host[/prefix]/mcp/<uuid>` | `wss://host[/prefix]` + `<uuid>` | **New, recommended** |
| `http://<loopback>[/prefix]/mcp/<uuid>` | `ws://<loopback>[/prefix]` + `<uuid>` | New, self-hosted/local only |
| `<uuid>` | default public relay + `<uuid>` | Unchanged |
| `ws(s)://host[/prefix]/<uuid>` | `ws(s)://host[/prefix]` + `<uuid>` | Unchanged (advanced) |

## Security

All hardening from #136 is preserved and re-asserted by tests:

- valid UUID only
- embedded credentials, query strings, and fragments rejected
- non-loopback plaintext (`http://` / `ws://`) relay transport rejected
- generic HTTP(S) URLs without the exact `/mcp/<uuid>` suffix rejected
- the bearer value never appears in error messages, logs, help text, or CLI output; `redactRemoteTarget` still redacts both the full input and the UUID

Verified against bypass vectors: `%2F`-encoded separators rejected; `..` and `//` normalized by WHATWG `URL`; uppercase `/MCP/` rejected; default ports normalized; `[::1]` treated as loopback.

Only the documented non-routable placeholder `00000000-0000-0000-0000-000000000000` and the repo's pre-existing fabricated test constants appear in the diff. No real credential.

## Tests

- `scripts/e2e-remote-lifecycle.mjs`: connector normalization matrix (self-hosted path prefixes, non-default ports, all loopback forms), 11 malformed/hostile URL rejections each asserting no UUID/credential/host leak in the message, a live `set_remote` connect over the connector form against a fake relay, and a `set_remote` rejection of a generic HTTP URL
- `scripts/e2e-browser-cli.mjs`: browser CLI `status` driven through an `http://.../mcp/<uuid>` connector URL, asserting identical structured output to the ws form with the session id redacted
- `scripts/e2e-cli-package-smoke.mjs`: new `CLI_PACK_GATE:REMOTE_HELP_OK` gate proving the packaged CLI's `--help` advertises the connector form

`npm run build` and full `npm test` (12 gates) pass.

## Docs

README, `packages/cli/README.md`, `docs/openclaw-local-browser.md`, and `openclaw/vibebrowser/SKILL.md` now lead with the connector URL, list UUID and `ws(s)://` as advanced/compatibility forms, document the self-hosted prefix and loopback derivations, and state the rejection rules. Duplicated two-variable example blocks were collapsed to a single `VIBE_REMOTE_URL` form.

## Release readiness (commit `b731023`)

npm already serves `@vibebrowser/mcp@0.3.3` and `@vibebrowser/cli@0.3.1`, so this branch was code-complete but unpublishable. Both packages are now bumped:

| Package | Was | Now |
| --- | --- | --- |
| `@vibebrowser/mcp` (root) | 0.3.3 | **0.3.4** |
| `@vibebrowser/cli` (`packages/cli`) | 0.3.1 | **0.3.2** |

- `package-lock.json` regenerated with `npm version --no-git-tag-version` (root + `-w @vibebrowser/cli`). Diff is version fields only: **no dependency changes** (3 lines).
- Mirrored version references synced so the `test:e2e:plugin-bundle` version-consistency contract stays green: `server.json` (`version` + `packages[0].version`), `mcpb/manifest.json`, `plugins/vibe-browser/.claude-plugin/plugin.json`, the `@vibebrowser/mcp@<version>` pin in `plugins/vibe-browser/.mcp.json`, and `.claude-plugin/marketplace.json`.
- `.github/workflows/publish.yml` needs no edit: its `check_package` step compares each `package.json` version against the live npm version and publishes only on a change. Both packages now differ from npm, so **both will publish after merge through the existing publish workflow**.
- The one-shot `Deprecate broken @vibebrowser/cli@0.3.0` step is gated on `cli_current == '0.3.1'` and will now skip. That is correct: `@vibebrowser/cli@0.3.0` is already deprecated on npm with the exact expected message (`npm view @vibebrowser/cli@0.3.0 deprecated` -> `Broken package: missing runtime file. Use 0.3.1 or later.`).

### Release verification results

| Command | Result |
| --- | --- |
| `npm run build` | PASS (exit 0, `tsc` + `prepare-cli-package.mjs`) |
| `npm run test:e2e:cli-package` | PASS - `CLI_PACK_GATE:PACK_OK:vibebrowser-cli-0.3.2.tgz`, `INSTALL_OK`, `HELP_OK`, `REMOTE_HELP_OK`, `PASS` |
| `npm run test:e2e:plugin-bundle` (version/publish contract) | PASS - `e2e ok - 13 checks passed`, incl. "plugin .mcp.json pins the version this repo actually publishes", "marketplace entry resolves to the real plugin directory and version", and a live MCP handshake reporting `vibebrowser-mcp 0.3.4` |
| `npm test` (full suite, 14 gates) | PASS (exit 0) |

Not merged. Nothing published from this branch - publishing happens only via the `publish.yml` workflow on push to `main`.

Not merged, not published.

